### PR TITLE
Fixes issue #31: Harmonic analysis netCDF segfault

### DIFF
--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -92,7 +92,7 @@ C  46.44 vjp added code for prep13-only command
 C----------------------------------------------------------------------------
 
       MODULE PRESIZES
-#ifdef ADCSWAN
+#if defined CSWAN || defined ADCSWAN
       USE GLOBAL, ONLY :
      &                   SWAN_OutputHS,SWAN_OutputDIR,SWAN_OutputTM01,
      &                   SWAN_OutputTPS,SWAN_OutputWIND,SWAN_OutputTM02,

--- a/src/global.F
+++ b/src/global.F
@@ -142,7 +142,7 @@ C     for writing fulldomain hotstart files.
       REAL(SZ),ALLOCATABLE, TARGET :: RSNMax_Time(:) 
       REAL(SZ),ALLOCATABLE, TARGET :: RSNMax_Time_G(:) 
      
-#ifdef CSWAN
+#if defined CSWAN || defined ADCSWAN
       !...Global SWAN Arrays
       REAL(SZ), ALLOCATABLE, TARGET      :: SWAN_HSOut_g(:)
       REAL(SZ), ALLOCATABLE, TARGET      :: SWAN_DIROut_g(:)
@@ -221,7 +221,7 @@ c.
       REAL(SZ),ALLOCATABLE, TARGET ::  PrMin(:) ! v46.50 sb 11/11/2006
       REAL(SZ),ALLOCATABLE, TARGET ::  WVNOutMax(:) ! v46.50 sb 11/11/2006
       
-#ifdef CSWAN      
+#if defined CSWAN || defined ADCSWAN     
       !...Local SWAN Arrays
       REAL(SZ), ALLOCATABLE, TARGET      :: SWAN_HSOut(:)
       REAL(SZ), ALLOCATABLE, TARGET      :: SWAN_DIROut(:)

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -3543,7 +3543,7 @@ C
             CALL writeNodalData(tau0nc, lun, descript1, timesec)
          CASE(164)
             CALL writeNodalData(rads, lun, descript1, timesec)
-#ifdef CSWAN
+#if defined CSWAN || defined ADCSWAN
          CASE(301)
             CALL writeNodalData(sw_hs, lun, descript1, timesec)
          CASE(302)
@@ -3569,7 +3569,7 @@ C
             CALL writeNodalData(WVMax, lun, descript1, timesec)
          CASE(315)
             CALL writeNodalData(RSMax, lun, descript1, timesec)
-#ifdef CSWAN
+#if defined CSWAN || defined ADCSWAN
          CASE(316)
             CALL writeNodalData(sw_hs_max, lun, descript1, timesec)
          CASE(317)
@@ -8017,9 +8017,13 @@ C     STAELV - station elevation
      &          STAELV, start, kount)
             CALL check_err(iret)
          ELSE
-            call mapFullDomainToSubdomainMByNP(hs%ncid,
-     &         2*MNHARF, hs%staelv%num_stations,
-     &         hs%staelv%station_data_id, subdomain_reals=STAELV)
+         ! jgf52.30.12: Fix segfault by checking number of stations 
+         ! (provided by Damrongsak Wirasaet)
+            IF ( NSTAE > 0 ) THEN
+               call mapFullDomainToSubdomainMByNP(hs%ncid,
+     &            2*MNHARF, hs%staelv%num_stations,
+     &            hs%staelv%station_data_id, subdomain_reals=STAELV)
+            ENDIF
          ENDIF
       ENDIF
 C     STAULV/STAVLV - station u and v velocity
@@ -8042,12 +8046,16 @@ C     STAULV/STAVLV - station u and v velocity
      &          STAVLV, start, kount)
             CALL check_err(iret)
          ELSE
-            call mapFullDomainToSubdomainMByNP(hs%ncid,
-     &         2*MNHARF, hs%stavellv%num_stations,
-     &         hs%stavellv%u_station_data_id, subdomain_reals=STAULV)
-            call mapFullDomainToSubdomainMByNP(hs%ncid,
-     &         2*MNHARF, hs%stavellv%num_stations,
-     &         hs%stavellv%v_station_data_id, subdomain_reals=STAVLV)
+            ! jgf52.30.12: Fix segfault by checking number of stations 
+            ! (provided by Damrongsak Wirasaet)
+            IF ( NSTAV > 0 ) THEN
+               call mapFullDomainToSubdomainMByNP(hs%ncid,
+     &            2*MNHARF, hs%stavellv%num_stations,
+     &            hs%stavellv%u_station_data_id, subdomain_reals=STAULV)
+               call mapFullDomainToSubdomainMByNP(hs%ncid,
+     &            2*MNHARF, hs%stavellv%num_stations,
+     &            hs%stavellv%v_station_data_id, subdomain_reals=STAVLV)
+            ENDIF
          ENDIF
       ENDIF
 C


### PR DESCRIPTION
This fixes when using a netcdf hotstart file containing harmonc analysis data in parallel, a segmentation fault would occur if there were zero stations.
