### PR TITLE
Setting CMake to look for NETCDFHOME and XDMFHOME

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,6 +23,7 @@ CMake is available to use on Windows, Linux, Macintosh, and Cygwin. It provides 
 ### Windows Requirements
 If you are building on Windows, you will need to install the MinGW64 suite of tools to provide the compilers and make command, A form of Windows Perl, and the CMake interface itself. The following links can provide the packages you need:
 
+
 | Package                |   Link                          |
 |------------------------|---------------------------------|
 | CMake                  | https://cmake.org/download/     |
@@ -108,6 +109,8 @@ make
 ```
 
 This process is valid for both Windows and Linux based systems. CMake is also able to build both the serial SWAN and parallel unstructured SWAN using the same build process. There is no need to use SWAN's build system.
+
+Note that CMake will attempt to locate the environment variables "NETCDFHOME" and "XDMFHOME". If these are set in your environment, the netCDF and XDMF package paths will be automatically set, meaning there is no need to set -DXDMFHOME and -DNETCDFHOME.
 
 ## Building with GNU make
 

--- a/cmake/options_select.cmake
+++ b/cmake/options_select.cmake
@@ -47,13 +47,21 @@ MARK_AS_ADVANCED(CLEAR CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG CMAKE_Fortran_F
 ###########################################################################
 #...Library paths
 IF(ENABLE_OUTPUT_NETCDF)
-    SET(NETCDFHOME "NETCDF-NOTFOUND" CACHE STRING "netCDF home path containing lib and include")
+    IF(NOT "$ENV{NETCDFHOME}" STREQUAL "") 
+        SET(NETCDFHOME "$ENV{NETCDFHOME}" CACHE STRING "netCDF home path containing lib and include")
+    ELSE(NOT "$ENV{NETCDFHOME}" STREQUAL "")
+        SET(NETCDFHOME "NETCDF-NOTFOUND" CACHE STRING "netCDF home path containing lib and include")
+    ENDIF(NOT "$ENV{NETCDFHOME}" STREQUAL "")
 ELSE(ENABLE_OUTPUT_NETCDF)
     UNSET(NETCDFHOME CACHE)
 ENDIF(ENABLE_OUTPUT_NETCDF)
 
 IF(ENABLE_OUTPUT_XDMF)
-    SET(XDMFHOME "XDMF-NOTFOUND" CACHE STRING "XDMF home path containing lib and include")
+    IF(NOT "$ENV{XDMFHOME}" STREQUAL "") 
+        SET(XDMFHOME "$ENV{XDMFHOME}" CACHE STRING "XDMF home path containing lib and include")
+    ELSE(NOT "$ENV{XDMFHOME}" STREQUAL "")
+        SET(XDMFHOME "XDMF-NOTFOUND" CACHE STRING "XDMF home path containing lib and include")
+    ENDIF(NOT "$ENV{XDMFHOME}" STREQUAL "")
 ELSE(ENABLE_OUTPUT_XDMF)
     UNSET(XDMFHOME CACHE)
 ENDIF(ENABLE_OUTPUT_XDMF)


### PR DESCRIPTION
At configure time, CMake will look for these two environment variables and test the code against what it finds. If valid, the code will use what is found here or the user can set a different path. If these variables
are not set, the user will need to set these manually if they want to enable these options.