### PR TITLE
Updating linking for Xdmf on the build server which was causing issues

### DIFF
--- a/circleci/installXdmf.sh
+++ b/circleci/installXdmf.sh
@@ -30,4 +30,6 @@ fi
 #   the directory that is cached
 sudo ln -sf $installDirectory/xdmf_build/include/* /usr/include/.
 sudo ln -sf $installDirectory/xdmf_build/lib/*.so /usr/lib/.
+sudo ln -sf $installDirectory/xdmf_build/lib/*.so.* /usr/lib/.
 sudo ln -sf $installDirectory/xdmf_build/lib/x86_64-linux-gnu/*.so /usr/lib/.
+sudo ln -sf $installDirectory/xdmf_build/lib/x86_64-linux-gnu/*.so.* /usr/lib/.


### PR DESCRIPTION
Xdmf libraries were being named differently and causing builds to fail. This fix adds some additional linking required for the build server to correctly find and use libraries