### PR TITLE
Initializing the background pressure Penv inside src/owiwind.F

### DIFF
--- a/src/owiwind.F
+++ b/src/owiwind.F
@@ -355,6 +355,10 @@ C
 #endif
       RHOWATG=RHOWAT0*G
 
+! Set a value for Penv
+
+      Penv=1013d0         !mb
+
 ! Read basin data  ---------------------------------------------------------
 
       ! Increment counter (cntSnaps initialized to zero in nws12init)


### PR DESCRIPTION
This should be a quick change, I think.  I added one line to the subroutine NWS12GET inside src/owiwind.F to initialize the background pressure.  This initialization line is included in wind/owi22.F, but it was not carried over to the src code.