### PR TITLE
Fixing logic when checking for an eta_max type boundary change

### DIFF
--- a/src/weir_boundary.F
+++ b/src/weir_boundary.F
@@ -739,30 +739,24 @@ C...............SET DEFAULT RETURN VALUE
 
 C...............CHECK IF THE ETA_MAX HAS BEEN EXCEEDED ALREADY
                 IF(BAR_FAILURE_START(MYIDX).EQ.-1D0)THEN
-C...................IF NOT HIGH ENOUGH YET, DUCK OUT OF HERE
-C                   CHECK BOTH SIDES OF WEIR FOR THE ELEVATION SO
-C                   THEY REMAIN IN SYNC
-                    IF(NNODECODE(NBV(MYIDX)).NE.1.AND.
-     &                  NNODECODE(IBCONN(MYIDX)).NE.1)THEN
-#if defined(TVW_TRACE) || defined(ALL_TRACE)
-                        CALL allMessage(DEBUG,"Return")
-#endif
-                        CALL unsetMessageSource()
-                        RETURN
-                    ENDIF    
-                    IF(ETA2(NBV(MYIDX)).LE.BAR_ETA_MAX(MYIDX).AND.
-     &                 ETA2(IBCONN(MYIDX)).LE.BAR_ETA_MAX(MYIDX))THEN
-#if defined(TVW_TRACE) || defined(ALL_TRACE)
-                        CALL allMessage(DEBUG,"Return")
-#endif                
-                        CALL unsetMessageSource()
-                        RETURN
-                    ELSE
+                    IF(ETA2(NBV(MYIDX)).GT.BAR_ETA_MAX(MYIDX).AND.NNODECODE(NBV(MYIDX)).EQ.1)THEN
 C.......................WE NEED TO INITIALIZE OUR START TIME FOR THE FAILURE
                         BAR_DEG_START(MYIDX) = TIME
                         BAR_DEG_END(MYIDX) = TIME +
      &                      BAR_FAILURE_DURATION(MYIDX)
                         BAR_FAILURE_START(MYIDX) = 1D0
+                    ELSEIF(ETA2(IBCONN(MYIDX)).GT.BAR_ETA_MAX(MYIDX).AND.NNODECODE(IBCONN(MYIDX)).EQ.1)THEN
+C.......................WE NEED TO INITIALIZE OUR START TIME FOR THE FAILURE
+                        BAR_DEG_START(MYIDX) = TIME
+                        BAR_DEG_END(MYIDX) = TIME +
+     &                      BAR_FAILURE_DURATION(MYIDX)
+                        BAR_FAILURE_START(MYIDX) = 1D0
+                    ELSE
+#if defined(TVW_TRACE) || defined(ALL_TRACE)
+                        CALL allMessage(DEBUG,"Return")
+#endif                
+                        CALL unsetMessageSource()
+                        RETURN
                     ENDIF
                 ENDIF
 


### PR DESCRIPTION
The code was originally set up to first check if
either side of the weir was active and then check if
either side the weir had an elevation that could trigger
the boundary to change elevation. The check against nnodecode
needs to occur at the same time as the check against eta2.

The problem becomes when one side of the weir is active and the
other side has a topographic elevation greater than the weir
change criteria, the code will sense this incorrectly because
the active side of the weir will trigger the first check and the
topographic elevation will trigger the second, even though the
node is not active. This change performs both checks simultaneously
so that this is no longer an issue.