### PR TITLE
3D fixes for div by zero and uninitialized boundaries

### DIFF
--- a/src/mesh.F
+++ b/src/mesh.F
@@ -1994,6 +1994,9 @@ C...           VALUE IF THE BOUNDARY IS CLOSED
                   COSTHETA1=COSTHETA
                ENDIF
 
+               ! @jasonfleming set the boundary array to the ibtype value
+               LBCODEI(JGW)=IBTYPE(K)
+
 C...           CHECK WHETHER ANGLE IS LESS THAN MINIMUM ANGLE, IF SO CHANGE THE
 C...           BOUNDARY CODE TO ZERO TANGENTIAL VELOCITIES 
 
@@ -2002,7 +2005,6 @@ C...           BOUNDARY CODE TO ZERO TANGENTIAL VELOCITIES
                ! as an interim measure, I am making this boundary type
                ! modification a 2DDI-only feature.
                if (C2DDI.eqv..true.) then
-                  LBCODEI(JGW)=IBTYPE(K)
                   IF((COSTHETA.GT.COSTSET).AND.(CROSS.GT.0.0)) THEN
                      IF(IBTYPE(K).EQ.0) LBCODEI(JGW)=10
                      IF(IBTYPE(K).EQ.1) LBCODEI(JGW)=11
@@ -2197,7 +2199,7 @@ C...........   WRITE OUT BOUNDARY CONDITION ARRAY INFORMATION
 
                WRITE(16,1857) JGW,JME,ME2GW(JME),NBV(JGW),LBCODEI(JGW),
      &              THETA,CSII(JGW),SIII(JGW),BNDLEN2O3(JGW)
- 1857          FORMAT(1X,I6,1X,I6,1X,I6,3X,I8,3X,I4,8X,E12.4,2X,E16.8,
+ 1857          FORMAT(1X,I6,1X,I6,1X,I6,3X,I8,3X,I6,6X,E12.4,2X,E16.8,
      &              1X,E16.8,2X,E16.8)
 
 C...........   CHECK EXTERNAL BARRIER HEIGHTS AGAINST DEPTHS

--- a/src/vsmy.F
+++ b/src/vsmy.F
@@ -1068,13 +1068,9 @@ C    kmd48.33bc added in spherical factors for 3D
 !               If ( element_peclet_number > 2.0 ) Then
 !                  Biharmonic_viscosity = velocity_magnitude * length / 2.0d0
 !               End If
-
-
-
-
                ! 3.9. save the viscosity parameter for using in the transport equation
                 Biharmonic_viscosity_modified_Leith ( NH, k ) = Biharmonic_viscosity
-                !write(6,*) 'nh, k, biharmonic_viscosity_modified_leith ',nh, k, Biharmonic_viscosity_modified_Leith(nh,k) !jgfdebug
+               !write(6,'("nh, k, nele, ncele, biharmonic_viscosity_modified_leith",i0,1x,i0,1x,i0,1x,i0,f8.2)'),nh, k, nele, ncele, Biharmonic_viscosity_modified_Leith(nh,k) !jgfdebug
                ! 4. congratulations! we have computed modified Leith viscosity!
                Biharmonic_LStress(k) = -3.d0 * Biharmonic_viscosity * (Biharmonic_DqDXDPhiDX2A+Biharmonic_DqDYDPhiDY2A)
      &              /TotalArea2
@@ -4303,7 +4299,7 @@ C*****************************************************************************
 
        Subroutine Gaussian_filter_complex ( X, Y, NeiTab, NNeigh, quantity, NP, NFEN, MNEI )
 
-       Use Global,      Only : IFNLFA, ETA2
+       Use Global,      Only : IFNLFA, ETA2, nodecode
        Use Mesh,        Only : DP
        Use Global_3DVS, Only : SIGMA, AMB, B, Biharmonic_viscosity_modified_Leith
 
@@ -4349,6 +4345,10 @@ C*****************************************************************************
 
        ! loop on all nodes, and apply the Gaussian filter
        Do I = 1, NP
+          ! @jasonfleming : this loop does not take into account that a 
+          ! node may be dry so I've added a statement to skip dry nodes
+          if (nodecode(i).eq.0) cycle
+          !
           ! 1. compute maximum distance between the node of interest, and the neighbor nodes
           !    this will be used to compute sigma2
           length_max = 0.0d0
@@ -4375,7 +4375,10 @@ C*****************************************************************************
           average_viscosity = average_viscosity / NFEN
 
           ! 1.3.1 compute the element Peclet number
-          !write(6,*) 'i, average_viscosity ',i, average_viscosity !jgfdebug
+          !write(6,'("i=",i0," nodecode=",i0," average_viscosity=",f8.2)') i, nodecode(i), average_viscosity !jgfdebug
+          ! @jasonfleming : the average viscosity will be zero if the node
+          ! is dry, producing a division by zero error here. So I've added
+          ! a statement to skip dry nodes at the top of this loop.
           element_peclet_number = length_max * velocity_magnitude_max_in_xy / average_viscosity !constant_diffusivity !average_viscosity
           !average_element_peclet_number = length_max * average_velocity / average_viscosity 
           average_element_peclet_number = length_max * velocity_magnitude_max_in_xy / average_viscosity 


### PR DESCRIPTION
@rluettich @cfulcherunc @zcobell @clintdawson @arashfathi @kdresback @caseydietrich This patch is meant to resolve the issue with uninitialized boundaries in 3D as well as a division by zero issue in the gaussian_filter_complex() subroutine. This subroutine does not take into account the possibility of dry nodes, and gives a division by zero error when it encounters them. I added a statement to skip dry nodes in this filter but I am not sure if that is a valid approach to the issue. Also, the uninitialized boundaries problem was very simple to fix; the setting of the values of the LBCODEI array was being done inside an 'if (2DDI) then' construct so it just wasn't happening in 3D. So I moved the setting of LBCODEI outside that if statement. However, even after these two fixes, the code blows up catastrophically on the 2nd timestep using Crystal's 3D test case that used to run successfully on older versions of the code. Also, I had to change type 11 boundaries in that test case mesh to type 1 boundaries because vsmy.F skips a lot of its code when encountering boundary types 10-19; this also results in a division by zero error. We need a recent working version of the 3D code and a test case that runs successfully with it so we can figure out why 3D is not working in v53. 