### PR TITLE
Fixing bug for vector quantities in sparse output

### DIFF
--- a/src/globalio.F
+++ b/src/globalio.F
@@ -929,7 +929,12 @@ C
                j = 1 + (i-istart)*descript % num_items_per_record
    
                !If values are eqaul to the default value, skip this node
-               if(resultBuf(j).eq.descript % alternate_value) cycle
+               if(descript%num_items_per_record.eq.2)then
+                   if(resultBuf(j  ).eq.descript % alternate_value .and.
+     &                resultBuf(j+1).eq.descript % alternate_value) cycle
+               else
+                   if(resultBuf(j).eq.descript % alternate_value) cycle
+               endif
    
                write(descript % lun, 1000) labels_g(i), (resultBuf(k), k = j, j +
      &           descript % num_items_per_record - 1)


### PR DESCRIPTION
If a vector quantity was written to a sparse file, only
the first value of the vector was checked if it was a default
value. This can cause errors for winds with no U-component