### PR TITLE
Intel heap-arrays unlimited

### DIFF
--- a/cmake/architecture.cmake
+++ b/cmake/architecture.cmake
@@ -50,17 +50,21 @@ ELSEIF(Fortran_COMPILER_NAME MATCHES "ifort.*")
   STRING(STRIP "${STACKSIZE}" STACKSIZE_TRIMMED)
   IF("${STACKSIZE_TRIMMED}" STREQUAL "unlimited")
       MESSAGE(STATUS "Unlimited stack size detected. No heap array flag added.")    
+      SET(heaparray_FLAG " ")
   ELSE("${STACKSIZE_TRIMMED}" STREQUAL "unlimited")
       MESSAGE(STATUS "The compiler flag -heap-arrays ${STACKSIZE_TRIMMED} is being added. This should also be used to compile netcdf-fortran.")
-      SET(Fortran_COMPILER_SPECIFIC_FLAG "-heap-arrays ${STACKSIZE_TRIMMED}" CACHE STRING "Compiler specific flags")  
+      SET(heaparray_FLAG "-heap-arrays ${STACKSIZE_TRIMMED}")  
   ENDIF("${STACKSIZE_TRIMMED}" STREQUAL "unlimited")
   
   # 64 bit array sizing
   IF(ARCH EQUAL 64)
-    SET(Fortran_COMPILER_SPECIFIC_FLAG "${Fortran_COMPILER_SPECIFIC_FLAG} -assume byterecl -mcmodel=medium" CACHE STRING "Compiler specific flags")  
+    SET(ifort_FLAG "${heaparray_FLAG} -assume byterecl -mcmodel=medium")  
   ELSE(ARCH EQUAL 64)
-    SET(Fortran_COMPILER_SPECIFIC_FLAG "${Fortran_COMPILER_SPECIFIC_FLAG} -assume byterecl" CACHE STRING "Compiler specific flags")
+    SET(ifort_FLAG "${heaparray_FLAG} -assume byterecl")
   ENDIF(ARCH EQUAL 64)
+
+  STRING(STRIP ${ifort_FLAG} ifort_FLAG_TRIMMED)
+  SET(Fortran_COMPILER_SPECIFIC_FLAG ${ifort_FLAG_TRIMMED} CACHE STRING "Compiler specific flags")
 
 ELSEIF(Fortran_COMPILER_NAME MATCHES "pgf90.*")
   # pgf90


### PR DESCRIPTION
On machines where stack size is unlimited and Intel compilers are used, the flag `-heap arrays unlimited` was being added by CMake, which is not valid. This fix accounts for an unlimited stack and maintains the behavior when there is a limited stack size.