### PR TITLE
Fixed incorrect messaging statement

### DIFF
--- a/src/read_input.F
+++ b/src/read_input.F
@@ -1106,7 +1106,7 @@ C      ENDIF
          ENDIF
          WRITE(16,9972)
          WRITE(16,*) 'NOLICAT =',NOLICAT
-         WRITE(16,9727)
+         WRITE(16,9726)
          WRITE(16,9974)
          IF(NFOVER.EQ.1) THEN
             if (myproc == 0) WRITE(ScreenUnit,9974)
@@ -1120,7 +1120,7 @@ C      ENDIF
          IF(NSCREEN.NE.0.AND.MYPROC.EQ.0) THEN
             WRITE(ScreenUnit,9972)
             WRITE(ScreenUnit,*) 'NOLICAT =',NOLICAT
-            WRITE(ScreenUnit,9726)
+            WRITE(ScreenUnit,9727)
             IF(NFOVER.EQ.1) THEN
                WRITE(ScreenUnit,9974)
             ELSE


### PR DESCRIPTION
@azundel noted in an email to the ADCIRC listserv that an error didn't make sense given his inputs.  It was because numbered FORMAT() statements were being used in the wrong places in read_input.F, and has been fixed here.  

Alan's email:  
ADCIRC world,
  I am looking for a little clarification on compatible values of the FORT.15 paramaters NOLIFA, NOLICA and NOLICAT.

  If we look at the web site, when describing these variables:

https://adcirc.org/home/documentation/users-manual-v53/parameter-definitions/#NOLIFA  

  We see that:
1- NOLIFA can have values 0, 1 or 2
2- NOLICA can have values 0, 1
3- NOLICAT can have values 0, 1

  There is a note under the NOLIFA section that reads:

when NOLIFA>0, then NOLICAT=1  

  There is also a note under the NOLICA section that reads:

i.e. when NOLICA=1, NOLICAT=1  

If I invoke ADCIRC with:  

2               ! NOLIFA - OPTION TO INCLUDE FINITE AMPLITUDE TERMS
0               ! NOLICA - OPTION TO INCLUDE CONVECTIVE ACCELERATION TERMS
1               ! NOLICAT - OPTION TO CONSIDER TIME DERIVATIVE OF CONV ACC TERMS 
 
  ADCIRC gives a warning that:

Your selection of NOLICAT (a UNIT 15 input parameter) is inconsistent with your selection of NOLIFA and may lead to mass balance problems.

  This seems to be in direct conflict with the message in the NOLIFA section of the document.  NOLIFA is not zero and NOLICAT is therefore 1.

  Is there more to this dependency that meets the eye?

Alan