### PR TITLE
Negative IRE

### DIFF
--- a/src/cstart.F
+++ b/src/cstart.F
@@ -1429,9 +1429,7 @@ C----------------------------------------------------------------------
       ! jgf52.08.01: Simplified to just adding the initial river elevation to 
       ! eta2 wherever the initial river elevation is greater than zero.
       if (LoadRiver_et_WSE.eqv..true.) then
-         where (River_et_WSE.GT.0.d0) 
-            eta2 = eta2 + River_et_WSE 
-         end where
+         eta2 = eta2 + River_et_WSE 
          ! tcmv51.27 20140502 Added to remove this nodal attribute
          ! as it is only used at Cold Start
          deallocate (River_et_WSE)


### PR DESCRIPTION
No matter which negative initial_river_elevation (IRE) value is used, ADCIRC will fill it up to the MSL from the start. This commit is proposed to allow ADCIRC to accept a user-specified negative IRE, when a low-lying area (e.g. New Orleans region) needs to start with an initial water surface lower than MSL.