### PR TITLE
Allowing to output nan instead of zero values for dry velocity staitons.

### DIFF
--- a/src/write_output.F
+++ b/src/write_output.F
@@ -518,6 +518,7 @@ C
       VelStaDescript % array2_g             => VV00_g
       VelStaDescript % interped_array       => UU2
       VelStaDescript % interped_array2      => VV2
+      VelStaDescript % ConsiderWetDry       = .TRUE.
       VelStaDescript % field_name           = 'VelSta'
       VelStaDescript % isStation            = .true.
       VelStaDescript % startTimeStep           = NTCYSV


### PR DESCRIPTION
Currently, a dry elevation station will output nan values, while a dry velocity station at the same location will output zero values. It can be misleading to determine the dry/wet states based on a velocity station only. Should we make the two files more consistent by considering wet/dry states for velocity stations? Or is there a particular reason to assign zero velocity to dry stations? 