### PR TITLE
Fix ascii fort.53 node number output

### DIFF
--- a/src/write_output.F
+++ b/src/write_output.F
@@ -2468,7 +2468,7 @@ C-----------------------------------------------------------------------
       USE MESH, ONLY : labels
       USE GLOBAL, ONLY : OutputDataDescript_t, screenMessage, ERROR,
      &                   DEBUG, setMessageSource, unsetMessageSource,
-     &                   allMessage, scratchMessage
+     &                   allMessage, scratchMessage, labels_g
 #ifdef ADCNETCDF
       USE NETCDFIO, ONLY: writeOutArrayNetCDF
 #endif
@@ -2503,7 +2503,7 @@ C     write data according to format specifier from fort.15 (e.g., NHASE)
             end do
             write(lun,*) mag1%num_fd_records
             DO N=1,mag1%num_fd_records
-               write(lun,*) labels(N)
+               write(lun,*) labels_g(N)
                do i=1,nfreq+nf
                   if (sets.eq.2) then
                      write(lun,6636) mag1%array2D_g(i,n),


### PR DESCRIPTION
Hello ADCIRC community! This PR is just a tiny bug fix for the global ascii fort.53 output. Previously, the local `labels` array was being used to write the node numbers for the global file. I switched this to `labels_g` to get the correct values.