### PR TITLE
Adding multi-core builds to v54release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
         - checkout
         - run: 
             name: Build ADCIRC without external libraries using CMake
-            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DCMAKE_Fortran_FLAGS="-O0"; make 
+            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DCMAKE_Fortran_FLAGS="-O0"; make -j4 
   build_cmake_with_netcdf:
       docker:
         - image: zcobell/adcirc_20191101 
@@ -76,7 +76,7 @@ jobs:
         - checkout
         - run: 
             name: Build ADCIRC with netCDF using CMake
-            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DNETCDFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-O0" ; make
+            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DNETCDFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-O0" ; make -j4
   build_cmake_with_netcdf_and_xdmf:
       docker:
         - image: zcobell/adcirc_20191101 
@@ -84,7 +84,7 @@ jobs:
         - checkout
         - run: 
             name: Build ADCIRC with netCDF and XDMF using CMake
-            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DENABLE_OUTPUT_XDMF=ON -DNETCDFHOME=/usr -DXDMFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-O0" ; make
+            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DENABLE_OUTPUT_XDMF=ON -DNETCDFHOME=/usr -DXDMFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-O0" ; make -j4
   acceptance_tests:
     docker: 
       - image: zcobell/adcirc_20191101
@@ -92,7 +92,7 @@ jobs:
       - checkout
       - run: 
             name: Build ADCIRC with netCDF and XDMF using CMake
-            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DENABLE_OUTPUT_XDMF=ON -DNETCDFHOME=/usr -DXDMFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-march=native -fprofile-arcs -ftest-coverage -g" -DCMAKE_C_FLAGS="-O3 -march=native -fprofile-arcs -ftest-coverage -g" ; make
+            command: mkdir build ; cd build ; cmake .. -DBUILD_ADCIRC=ON -DBUILD_PADCIRC=ON -DBUILD_ADCSWAN=ON -DBUILD_PADCSWAN=ON -DBUILD_ADCPREP=ON -DBUILD_UTILITIES=ON -DBUILD_ASWIP=ON -DBUILD_SWAN=ON -DBUILD_PUNSWAN=ON -DBUILD_LIBADCIRC_STATIC=ON -DBUILD_LIBADCIRC_SHARED=ON -DENABLE_OUTPUT_NETCDF=ON -DENABLE_OUTPUT_XDMF=ON -DNETCDFHOME=/usr -DXDMFHOME=/usr -DBUILD_UTILITIES=ON -DCMAKE_Fortran_FLAGS="-march=native -fprofile-arcs -ftest-coverage -g" -DCMAKE_C_FLAGS="-O3 -march=native -fprofile-arcs -ftest-coverage -g" ; make -j4
       - run:
           name: Retrieve Test Suite
           command: git clone --depth=1 -b master https://github.com/adcirc/adcirc-cg-testsuite.git /root/adcirc-cg-testsuite

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -97,9 +97,8 @@ MACRO(swanConfigureAdcswan)
         )
     ELSE(WIN32)
         ADD_CUSTOM_COMMAND( OUTPUT ${SWAN1SERIAL_SOURCES} ${SWAN2SERIAL_SOURCES}
-            COMMAND ${PERL} switch.pl -adcirc -unix *.ftn *.ftn90
             COMMAND mkdir -p ${CMAKE_BINARY_DIR}/CMakeFiles/swan_serial_source
-            COMMAND mv *.f *.f90 ${CMAKE_BINARY_DIR}/CMakeFiles/swan_serial_source/.
+            COMMAND ${PERL} switch.pl -adcirc -unix -outdir ${CMAKE_BINARY_DIR}/CMakeFiles/swan_serial_source *.ftn *.ftn90
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/swan
             COMMENT "Generating Serial unSWAN Sources..."
         )
@@ -119,9 +118,8 @@ MACRO(swanConfigurePadcswan)
         )  
     ELSE(WIN32)
         ADD_CUSTOM_COMMAND( OUTPUT ${SWAN1PARALLEL_SOURCES} ${SWAN2PARALLEL_SOURCES}
-            COMMAND ${PERL} switch.pl -pun -adcirc -unix *.ftn *.ftn90
             COMMAND mkdir -p ${CMAKE_BINARY_DIR}/CMakeFiles/swan_parallel_source
-            COMMAND mv *.f *.f90 ${CMAKE_BINARY_DIR}/CMakeFiles/swan_parallel_source/.
+            COMMAND ${PERL} switch.pl -pun -adcirc -unix -outdir ${CMAKE_BINARY_DIR}/CMakeFiles/swan_parallel_source *.ftn *.ftn90
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/swan
             COMMENT "Generating Parallel unSWAN Sources..."
         )
@@ -141,9 +139,8 @@ MACRO(swanConfigureSerial)
         )  
     ELSE(WIN32)
         ADD_CUSTOM_COMMAND( OUTPUT ${SWANONLY_SERIAL_SOURCES} 
-            COMMAND ${PERL} switch.pl -unix *.ftn *.ftn90
             COMMAND mkdir -p ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_serial_source
-            COMMAND mv *.f *.f90 ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_serial_source/.
+            COMMAND ${PERL} switch.pl -unix -outdir ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_serial_source *.ftn *.ftn90
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/swan
             COMMENT "Generating Serial SWAN stand alone Sources..."
         )
@@ -163,9 +160,8 @@ MACRO(swanConfigureParallel)
         )  
     ELSE(WIN32)
         ADD_CUSTOM_COMMAND( OUTPUT ${SWANONLY1_PARALLEL_SOURCES} ${SWANONLY2_PARALLEL_SOURCES}
-            COMMAND ${PERL} switch.pl -pun -unix *.ftn *.ftn90
             COMMAND mkdir -p ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_parallel_source
-            COMMAND mv *.f *.f90 ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_parallel_source/.
+            COMMAND ${PERL} switch.pl -pun -unix -outdir ${CMAKE_BINARY_DIR}/CMakeFiles/swanonly_parallel_source *.ftn *.ftn90
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/swan
             COMMENT "Generating Parallel unSWAN Sources..."
         )

--- a/swan/switch.pl
+++ b/swan/switch.pl
@@ -15,6 +15,7 @@ $adc = "FALSE";
 $coh = "FALSE";
 $ncf = "FALSE";
 $mv4 = "FALSE";
+$outdir=".";
 while ( $ARGV[0]=~/-.*/ )
    {
    if ($ARGV[0]=~/-esmf/) {$esmf="TRUE";shift;}
@@ -33,6 +34,11 @@ while ( $ARGV[0]=~/-.*/ )
    if ($ARGV[0]=~/-coh/) {$coh="TRUE";shift;}
    if ($ARGV[0]=~/-netcdf/) {$ncf="TRUE";shift;}
    if ($ARGV[0]=~/-matl4/) {$mv4="TRUE";shift;}
+   if ($ARGV[0]=~/-outdir/){
+       shift;
+       $outdir=$ARGV[0];
+       shift;
+       }
    }
 
 # --- make a list of all files
@@ -49,13 +55,13 @@ foreach $file (@files)
   {
     ($tempf)=split(/.ftn/, $file);
     $ext = ($file =~ m/ftn90/) ? "f90" : "f";
-    $outfile = join(".",$tempf,$ext);
+    $outfile = join("",$outdir,"/",$tempf,".",$ext);
   }
   else
   {
     ($tempf)=split(/.ftn/, $file);
     $ext = ($file =~ m/ftn90/) ? "f90" : "for";
-    $outfile = join(".",$tempf,$ext);
+    $outfile = join("",$outdir,"/",$tempf,".",$ext);
   }
 # --- process file
   if (   (! -e $outfile)            #outfile doesn't exist


### PR DESCRIPTION
Multicore builds enabled using cmake and the syntax:
```
make -j#
```
where `#` is the number of processors. Each executable will be compiled on its own processor, but it will only scale so far. The CircleCI build time was decreased from 13 minutes to 3 minutes using 4 processors.
