### PR TITLE
Fixing bug where certain SWAN outputs could not be turned off

### DIFF
--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -592,6 +592,9 @@ C.....REWIND THE FORT.15 FILE IN ORDER TO PROCESS THE REMAINING PIECES
       READ(UNIT=15,NML=SWANOutputControl,IOSTAT=IOS)
       IF (IOS.gt.0) THEN
          write(*,*)"INFO: The SWANOutputControl namelist was not found."
+         SWAN_OutputHS=.TRUE.
+         SWAN_OutputTPS=.TRUE.
+         SWAN_OutputDIR=.TRUE.
       ENDIF
       REWIND(15)
 #endif

--- a/src/global.F
+++ b/src/global.F
@@ -267,13 +267,13 @@ Casey 090302: Added the following arrays for output of radiation stress gradient
 
 #if defined CSWAN || defined ADCSWAN      
 Cobell 20120510: Added logicals for turning on/off swan output files   
-      LOGICAL                      :: SWAN_OutputHS = .TRUE.
-      LOGICAL                      :: SWAN_OutputDIR = .TRUE.
+      LOGICAL                      :: SWAN_OutputHS = .FALSE.
+      LOGICAL                      :: SWAN_OutputDIR = .FALSE.
       LOGICAL                      :: SWAN_OutputTM01 = .FALSE.
-      LOGICAL                      :: SWAN_OutputTPS = .TRUE.
+      LOGICAL                      :: SWAN_OutputTPS = .FALSE.
       LOGICAL                      :: SWAN_OutputWIND = .FALSE.
       LOGICAL                      :: SWAN_OutputTM02 = .FALSE.
-      LOGICAL                      :: SWAN_OutputTMM10 = .TRUE.
+      LOGICAL                      :: SWAN_OutputTMM10 = .FALSE.
       LOGICAL                      :: SWAN_OutputAgg(7)
 #endif
 

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -267,6 +267,11 @@ c     a non-default value we can determine this was the case.
       ! on and off. Similar to tcm's timevaryingbathy namelist.
       namelistSpecifier = 'SWANOutputControl'
       read(unit=15,nml=SWANOutputControl,iostat=ios)
+      IF(IOS.GT.0)THEN
+        SWAN_OutputHS=.TRUE.
+        SWAN_OutputTPS=.TRUE.
+        SWAN_OutputDIR=.TRUE.
+      ENDIF
       call logNamelistReadStatus(namelistSpecifier, ios)     
       call logMessage(ECHO,
      &    "The values of SWANOutputControl are as follows:")


### PR DESCRIPTION
Previously, certain SWAN outputs were unintentionally hardwired to on. This is fixed and the correct behavior is observed. Only outputs specified in the SWAN output namelist will be written. 

If no SWAN output namelist is provided, wave height, period, and direction will be written by default. Otherwise, only items in the namelist will be written