### PR TITLE
Fixing issue with initialization of SWAN output files

### DIFF
--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -590,7 +590,7 @@ C.....REWIND THE FORT.15 FILE IN ORDER TO PROCESS THE REMAINING PIECES
       ! on and off. Similar to tcm's timevaryingbathy namelist.
       IOS = 0
       READ(UNIT=15,NML=SWANOutputControl,IOSTAT=IOS)
-      IF (IOS.gt.0) THEN
+      IF (IOS.ne.0) THEN
          write(*,*)"INFO: The SWANOutputControl namelist was not found."
          SWAN_OutputHS=.TRUE.
          SWAN_OutputTPS=.TRUE.


### PR DESCRIPTION
SWAN netCDF files not correctly initialized when user omitted `&SWANOutputControl` namelist. Changed IOS check to be `ne` instead of `gt`. 