### PR TITLE
Fixing bug where adcprep did not write WTIMINC to partitioned fort.15

### DIFF
--- a/prep/prep.F
+++ b/prep/prep.F
@@ -1567,7 +1567,7 @@ C     tcm v51.06.02 added NWS=16: GFDL Met Data
       ! jgf: Added NWS=30 (GAHM+OWI)
          IF ((ABS(NWS).EQ.2).OR.(ABS(NWS).EQ.4).OR.(ABS(NWS).EQ.45).OR.
      &        (ABS(NWS).EQ.5).OR.(ABS(NWS).EQ.6).OR.(ABS(NWS).EQ.8)
-     &        .OR.(ABS(NWS).EQ.12).OR.(ABS(NWS).EQ.15)
+     &        .OR.(ABS(NWS).EQ.10).OR.(ABS(NWS).EQ.12).OR.(ABS(NWS).EQ.15)
      &        .OR.(ABS(NWS).EQ.16).OR.(ABS(NWS).eq.30)
      &         .OR.(ABS(NWS).EQ.19).OR.(ABS(NWS).EQ.29).OR.
      &          (ABS(NWS).EQ.20))THEN


### PR DESCRIPTION
NWS=10 ran in serial but not parallel. The issue was that in `prep.F`, nws=10 was not in the list of formats to write `WTIMINC` to the partitioned fort.15.