### PR TITLE
code modifications associated with NWS=7 

### DIFF
--- a/prep/adcprep.F
+++ b/prep/adcprep.F
@@ -792,14 +792,16 @@ C     jgf49.0804 NWS=29 does not need fort.22 decomposition.
 C     jgf: Added NWS=30 and changed to select/case.
 C     tcm v51.06.02 added NWS=16 GFDL Met Data
 c     arc added nws13 190110
+C     xyc v52.30 NWS=7 follows NWS=6 no longer need fort.22
+C     decomposition
          select case(ABS(NWS))
-         case(3,6,12,13,16,29,30)
+         case(3,6,7,12,13,16,29,30)
             call logMessage(INFO,
      & 'The meteorological data does not require domain decomposition.')
-         case(1,2,4,5,45,7)
+         case(1,2,4,5,45)
             call logMessage(INFO,
      &   'Ready to write subdomain fort.22 files.')
-C     jgf46.00 Added NWS=7
+C     jgf46.00 Added NWS=7 (removed NWS=7 xyc52.30)
 C     jgfdebug46.02 Added NWS=45
 C     jgf46.02 Added NWS=8
 C     jgf46.16 Merged:

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -1809,11 +1809,12 @@ C     jie added NWS=20: generalized asymmetric vortex model
 C     sb46.28sb01 added NWS=12: OWI format
 C     jgf50.38.05: added NWS=15: HWind format
 C     tcm v51.06.02 added NWS=16: GFDL Met Data
-      ! jgf: Added NWS=30 (GAHM+OWI)
+C     xyc v52.30 added NWS=7 to be consistent with NWS=6
 c     arc added nws13 190110
+      ! jgf: Added NWS=30 (GAHM+OWI)
          IF ((ABS(NWS).EQ.2).OR.(ABS(NWS).EQ.4).OR.(ABS(NWS).EQ.45).OR.
-     &        (ABS(NWS).EQ.5).OR.(ABS(NWS).EQ.6).OR.(ABS(NWS).EQ.8)
-     &       .OR.(ABS(NWS).EQ.10).OR.(ABS(NWS).EQ.12)
+     &        (ABS(NWS).EQ.5).OR.(ABS(NWS).EQ.6).OR.(ABS(NWS).EQ.7)
+     &       .OR.(ABS(NWS).EQ.8).OR.(ABS(NWS).EQ.10).OR.(ABS(NWS).EQ.12)
      &       .OR.(ABS(NWS).EQ.15).OR.(ABS(NWS).EQ.14)
      &       .OR.(ABS(NWS).EQ.16).OR.(ABS(NWS).EQ.30)
      &       .OR.(ABS(NWS).EQ.19).OR.(ABS(NWS).EQ.29)

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -1021,7 +1021,8 @@ C.... tcm v48.4641 additions for ice
         MNWP=MNP
       ENDIF
 C.... tcm v49.64.01 additions for ice
-      IF(ABS(NWS).EQ.6) THEN
+C.... xyc v52.30 NWS=7 follow the same format as NWS=6
+      IF((ABS(NWS).EQ.6).OR.(ABS(NWS).EQ.7)) THEN
         IF((NCICE.EQ.0).AND.(NRS.EQ.0)) READ(15,*) WTIMINC            !SKIP OVER WTIMINC
         IF((NCICE.EQ.0).AND.(NRS.GE.1)) READ(15,*) WTIMINC,RSTIMINC
         IF((NCICE.GE.1).AND.(NRS.EQ.0)) READ(15,*) WTIMINC,CICE_TIMINC            !SKIP OVER WTIMINC
@@ -1391,11 +1392,12 @@ C
       IF(ABS(NWS).EQ.45) WRITE(*,3015) !jgfdebug46.02
       IF(ABS(NWS).EQ.5) WRITE(*,3016)
       IF(ABS(NWS).EQ.6) WRITE(*,3017)
+      IF(ABS(NWS).EQ.7) WRITE(*,3033)  !xyc52.30 added
       IF(ABS(NWS).EQ.8) WRITE(*,3217)
       IF(NRS.GE.1) WRITE(*,3018) ! sb46.28sb03
       IF(NWS.EQ.10) WRITE(*,3019)
       IF(NWS.EQ.11) WRITE(*,3020)
-C     sb46.28sb01 added NWS=12: OWI format
+C     sb46.28sb01 added NWS=12: OWI format 
       IF(ABS(NWS).EQ.12) WRITE(*,3023)
       IF(ABS(NWS).EQ.19) WRITE(*,3219)
       IF(ABS(NWS).EQ.20) WRITE(*,3220)
@@ -1445,6 +1447,7 @@ C
  3015 FORMAT(' *   Also, NWS=+-4 meteorological forcing is used,   *')
  3016 FORMAT(' *   Also, NWS=+-5 meteorological forcing is used,   *')
  3017 FORMAT(' *   Also, NWS=+-6 meteorological forcing is used,   *')
+ 3033 FORMAT(' *   Also, NWS=+-7 meteorological forcing is used,   *')
  3217 FORMAT(' *   Also, NWS=+-8 Holland wind forcing is used,     *')
  3219 FORMAT(' *   Also, NWS=+-19 Asymmetric Holland wind v2.0     *',/,
      &       ' *                 forcing is used,                  *')

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -914,6 +914,7 @@ Casey 180318: Added NWS=13
         IF((NWS.NE.0).AND.    (NWS.NE.1 ) .AND.(ABS(NWS).NE.2).AND.
      &       (NWS.NE.3).AND.(ABS(NWS).NE.4) .AND.(ABS(NWS).NE.5).AND.
      &       (ABS(NWS).NE.45).AND.(ABS(NWS).NE.6).AND.
+     &       (ABS(NWS).NE.7).AND.   ! xyc52.30
      &       (ABS(NWS).NE.8).AND.(ABS(NWS).NE.15).AND. !jgf50.38.05 Added NWS=15
      &       (ABS(NWS).NE.12).AND.(ABS(NWS).NE.13).AND.
      &       (ABS(NWS).NE.14).AND.(ABS(NWS).NE.19).AND.
@@ -925,6 +926,7 @@ Casey 180318: Added NWS=13
 C
 C... TCM v49.64.02 -- added
 C...  BE SURE NWS AND NCICE ARE COMPATABLE
+C...  xyc v52.30: note:Not sure if NWS.EQ.7 here should be removed 
       IF((NCICE.GT.0).AND.
      &       ((NWS.EQ.1).OR.(NWS.EQ.2).OR.(NWS.EQ.7))) THEN
          PRINT*,'NCICE = ',NCICE
@@ -1080,7 +1082,8 @@ C     parse out the WTIMINC or other parameters.
          READ(15,80) WSMSG1
       ENDIF
 C
-      IF(ABS(NWS).EQ.6) THEN
+C...  xyc52.30 added NWS=7 to follow NWS=6
+      IF((ABS(NWS).EQ.6) .OR. (ABS(NWS).EQ.7)) THEN
          READ(15,80) WSMSG1
 C..... tcm v49.64.01 additions for ICE
          IF((NCICE.EQ.0).AND.(NRS.EQ.0)) THEN

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -1725,12 +1725,15 @@ C.... tcm v49.46 rewrote to combine different 100's power NRS
      &    'DRAG LAW.')
       ENDIF
 C     jgf46.00 Added NWS=7 (direct surface stress).
+C     xyc52.30 corrected NWS=7 (direct surface stress on regular grid as
+C     in NWS=6)
       IF(NWS.EQ.7) THEN
          WRITE(16,1234) NWS
  1234    FORMAT(/,5X,'NWS = ',I3,
      &    /,9X,'SURFACE STRESS AND PRESSURE ARE USED TO FORCE',
      &    /,9X,' THE COMPUTATION',
-     &    /,9X,'VALUES ARE READ AT ADCIRC GRID NODES FROM UNIT 22',
+     &    /,9X,'VALUES ARE READ FROM A REGULARLY SPACED GRID',
+     &    /,9X,'FROM UNIT 22',
      &    /,9X,'THE UNIT 22 FILE BEGINS AT TIME=STATIM.',
      &    /,9X,'INTERPOLATION IN TIME IS DONE TO SYNC THE STRESS DATA ',
      &    /,9X,'WITH THE MODEL TIME STEP.')
@@ -1740,7 +1743,8 @@ C     jgf46.00 Added NWS=7 (direct surface stress).
  1235    FORMAT(/,5X,'NWS = ',I3,
      &    /,9X,'SURFACE STRESS AND SURFACE PRESSURE ARE USED TO FORCE',
      &    /,9X,' THE COMPUTATION',
-     &    /,9X,'VALUES ARE READ AT ADCIRC GRID NODES FROM UNIT 22',
+     &    /,9X,'VALUES ARE READ FROM A REGULARLY SPACED GRID',
+     &    /,9X,'FROM UNIT 22',
      &    /,9X,'THE UNIT 22 FILE BEGINS AT THE TIME OF THE HOT START.',
      &    /,9X,'INTERPOLATION IN TIME IS DONE TO SYNC THE STRESS DATA ',
      &    /,9X,'WITH THE MODEL TIME STEP.')
@@ -2404,7 +2408,8 @@ C...     TCM V49.64.01 ADDITIONS FOR ICE CONCENTRATION
          IF((NCICE.GE.1).AND.(NRS.EQ.0)) READ(15,*) WTIMINC,CICE_TIMINC
          IF((NCICE.GE.1).AND.(NRS.GE.1)) READ(15,*) WTIMINC,RSTIMINC,CICE_TIMINC
       ENDIF
-      IF(NWS.EQ.6) THEN
+C...  xyc v52.30: corrected NWS=7 to follow NWS=6 (structured grid input)
+      IF((NWS.EQ.6).OR.(ABS(NWS).EQ.7)) THEN
 C...     TCM V49.64.01 ADDITIONS FOR ICE CONCENTRATION
          IF((NCICE.EQ.0).AND.(NRS.EQ.0)) READ(15,*) NWLAT,NWLON,WLATMAX,
      &        WLONMIN,WLATINC,WLONINC,WTIMINC
@@ -2416,10 +2421,10 @@ C...     TCM V49.64.01 ADDITIONS FOR ICE CONCENTRATION
      &        WLONMIN,WLATINC,WLONINC,WTIMINC,RSTIMINC,CICE_TIMINC
       ENDIF
 C     jgf46.00 Added NWS=7 (direct surface stress).
-      IF(ABS(NWS).EQ.7) THEN
-         IF(NRS.EQ.0) READ(15,*) WTIMINC
-         IF(NRS.GE.1) READ(15,*) WTIMINC,RSTIMINC ! sb46.28sb03
-      ENDIF
+C      IF(ABS(NWS).EQ.7) THEN
+C         IF(NRS.EQ.0) READ(15,*) WTIMINC
+C         IF(NRS.GE.1) READ(15,*) WTIMINC,RSTIMINC ! sb46.28sb03
+C      ENDIF
 C     jgf46.05 Added NWS=8 (Holland Wind Model).
 C     jgf46.28 Changed WTIMINC to StormNumber for activating
 C     wind multiplier to final wind speeds from Holland model.

--- a/src/wind.F
+++ b/src/wind.F
@@ -1818,10 +1818,17 @@ C....                           to correspond with having only a global wind fil
 
 C     jgf46.00 Added option to directly apply surface stress without any
 C     other correction factors.
+C     xyc52.30 corrected NWS=7 (wind stress input provided on a
+C     rectangular grid, same as NWS=6) 
       IF(ABS(NWS).EQ.7) THEN
-         OPEN(22,FILE=TRIM(INPUTDIR)//'/'//'fort.22')
-         READ(22,*) (NHG,WVNX1(I),WVNY1(I),PRN1(I),I=1,NP)
-         READ(22,*) (NHG,WVNX2(I),WVNY2(I),PRN2(I),I=1,NP)
+C         OPEN(22,FILE=TRIM(INPUTDIR)//'/'//'fort.22')
+C         READ(22,*) (NHG,WVNX1(I),WVNY1(I),PRN1(I),I=1,NP)
+C         READ(22,*) (NHG,WVNX2(I),WVNY2(I),PRN2(I),I=1,NP)
+         OPEN(22,FILE=TRIM(GBLINPUTDIR)//'/'//'fort.22')
+         CALL NWS7GET()
+         wvnx1 = wvnx2
+         wvny1 = wvny2
+         CALL NWS7GET()
          WTIME1 = STATIM*86400.D0
          WTIME2 = WTIME1 + WTIMINC
       ENDIF


### PR DESCRIPTION
In version 52.30, NWS=7 can not read in wind stress provided on a rectangular grid successfully. The original code was written to read in input wind stress formatted as NWS=2.

Modifications are made such that NWS=7 can read in wind stress in the same way as NWS=6, which is designed to read in wind speed provided on a rectangular grid. 

To use NWS=7, parameters of the rectangular grid and time increment (NWLAT, NWLON, WLATMAX, WLONMIN, WLATINC, WLONINC, WTIMINC) need to be provided in the fort.15 file as it is for NWS=6. This information will also need to be updated in the ADCIRC manual if modifications are adopted. 


