### PR TITLE
moving Ali dispersion to namelist from IM toggle

### DIFF
--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2302,6 +2302,13 @@ c...     wjp additions for WarnElev Namelist
             write(15,*) '! -- End WarnElev Control NameList --'
          ENDIF
 
+c...     wjp additions for Ali Dispersion Control Namelist
+         IF (FOUND_ALIDISP_NML) then  !If there was a namelist in the original fort.15 put it in the decomp 15's
+            write(15,*) '! -- Begin AliDispersion Control NameList --'
+            write(15,AliDispersionControl)
+            write(15,*) '! -- End AliDispersion Control NameList --'
+         ENDIF
+
          CLOSE(15)
 C
  1000 CONTINUE

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -236,6 +236,13 @@ c.... !wjp added for warnElev namelist
       INTEGER :: WarnElevDumpLimit = 50  !
       LOGICAL :: WARN_ELEV_FLAG = .FALSE.   
       LOGICAL :: FOUND_WARNELEV_NML = .false.  !
+      ! Ali Dispersion control namelist
+      NAMELIST /AliDispersionControl/ CAliDisp, Cs, Ad, Bd
+      REAL(SZ) :: Bd = 0.23394_SZ  ! exponent of depth (default)
+      REAL(SZ) :: Ad = 0.0050189_SZ ! coefficient of depth (default)
+      REAL(SZ) :: Cs = 1500.0_SZ ! Speed of sound in water
+      LOGICAL :: CAliDisp= .false.  !
+      LOGICAL :: FOUND_ALIDISP_NML = .false.  !
 
 C---------------------end of data declarations--------------------------------C
 
@@ -501,6 +508,7 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
       LOGICAL :: FOUND_WC_NML
       LOGICAL :: found_tvw_nml
       LOGICAL :: found_WarnElev_nml = .false.
+      LOGICAL :: found_AliDisp_nml = .false.
 C.... tcm v51.20.04 additions for station location file
       integer ::  ios_stations
       integer :: MNSTAE2,MNSTAV2,MNSTAC2,MNSTAM2
@@ -692,6 +700,14 @@ C.....REWIND THE FORT.15 FILE IN ORDER TO PROCESS THE REMAINING PIECES
          write(*,*) "INFO: The WarnElevControl namelist was not found."
       ELSE
          found_WarnElev_nml = .true.  
+      ENDIF
+      REWIND(15)
+      
+      READ(UNIT=15,NML=AliDispersionControl,IOSTAT=IOS)
+      IF (IOS.gt.0) THEN
+         write(*,*) "INFO: The AliDisp Control namelist was not found."
+      ELSE
+         found_AliDisp_nml = .true.  
       ENDIF
       REWIND(15)
 C

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -703,6 +703,17 @@ c..
      &         'The WarnElev namelist was not found.')
       endif
       rewind(15)  !Return to the top of the fort.15 file
+      
+      read(unit=15,nml=AliDispersionControl,iostat=ios)
+      if ( ios.ge.0) then
+         FOUND_ALIDISP_NML = .true.
+         call logMessage(INFO,
+     &         'The AliDispersion namelist was found.')
+      else
+         call logMessage(INFO,
+     &         'The AliDispersion namelist was not found.')
+      endif
+      rewind(15)  !Return to the top of the fort.15 file
 
       READ(15,80) RUNDES
 C

--- a/src/global.F
+++ b/src/global.F
@@ -56,7 +56,7 @@ C..   Ali's full dispersion coefficient for M2
       REAL(SZ) :: Bd = 0.23394_SZ  ! exponent of depth (default)
       REAL(SZ) :: Ad = 0.0050189_SZ ! coefficient of depth (default)
       REAL(SZ) :: Cs = 1500.0_SZ ! Speed of sound in water
-      REAL(SZ) :: Cs2 = 1500.0_SZ**2 ! Speed of sound in water^2
+      REAL(SZ) :: Cs2 ! Speed of sound in water^2
 C     jgf46.21 Added support for IBTYPE=52.
       REAL(SZ),ALLOCATABLE, TARGET ::   ElevDisc(:)
       REAL(SZ) FluxSettlingTime

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -164,6 +164,7 @@ C
      &  dynamicWaterLevelCorrectionRampReferenceTime
       NAMELIST /WarnElevControl/ WarnElev, WarnElevDump,
      &  WarnElevDumpLimit, ErrorElev
+      NAMELIST /AliDispersionControl/ CAliDisp, Cs, Ad, Bd
       CHARACTER(len=160) :: origLine     ! raw line of input from fort.15
       CHARACTER(len=200) :: modifiedLine ! converted to namelist
       CHARACTER(len=2000) :: origLineTVW
@@ -557,6 +558,29 @@ C     WJP add namelist
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 
+!     WJP add namelist for Ali's dispersion
+!     Defaults are already in global 
+      namelistSpecifier = 'AliDispersionControl'
+      read(unit=15,nml=AliDispersionControl,iostat=IOS)
+      call logNameListReadStatus(namelistSpecifier,ios)
+!     Process the speed of sound squared
+      if (Cs.le.0.0_SZ) then
+         Cs2 = huge(0.0_SZ)
+      else
+         Cs2 = Cs*Cs
+      endif
+      write(scratchMessage,'(a,l)') "CAliDisp=",CAliDisp
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "Speed of sound=",Cs
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,e15.8)') "Speed of sound squared=",Cs2
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "Ad coefficient=",Ad
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "Bd coefficient=",Bd
+      call logMessage(ECHO,trim(scratchMessage))
+      rewind(15)
+
 C...
 C...  INPUT FROM UNIT 15 AND OUTPUT TO UNIT 16 RUN DESCRIPTION AND RUN
 C...  IDENTIFICATION
@@ -861,7 +885,7 @@ c     - - - - - - - - - - - - - - - - - - - - - - - -
 c     - - - - - - - - - - - - - - - - - - - - - - - -
 c     f i n e   g r a i n e d   o p t i o n s ( i m )
 c     - - - - - - - - - - - - - - - - - - - - - - - -
-      ELSEIF ((IM.GE.111111).AND.(IM.LE.634322)) THEN
+      ELSEIF ((IM.GE.111111).AND.(IM.LE.634326)) THEN
          IMDig1 = IM/100000
          IMDig2 = (IM - 100000*IMDig1)/10000
          IMDig3 = (IM - 100000*IMDig1 - 10000*IMDig2)/1000
@@ -969,30 +993,22 @@ c     - - - - - - - - - - - - - - - - - - - - - - - -
      &           'Momentum Eqs.'
          ENDIF
 c     - - - - - - - - - - - - - - - - - - - - - - - -
-         IF (mod(IMDig6,4).EQ.1) THEN
+         IF (mod(IMDig6,3).EQ.1) THEN
             ILump=0
             WRITE(16,*) '        Consistent GWCE mass matrix'
-         ELSEIF (mod(IMDig6,4).EQ.2) THEN
+         ELSEIF (mod(IMDig6,3).EQ.2) THEN
             ILump=1
             CGWCE_Lump = .TRUE.
             WRITE(16,*) '        Lumped GWCE mass matrix'
-         ELSEIF (mod(IMDig6,4).EQ.3) THEN
+         ELSEIF (mod(IMDig6,3).EQ.0) THEN
             ILump=0
             WRITE(16,*) '        Consistent GWCE mass matrix'
             CGWCE_HDP = .TRUE.
             IFNL_HDP = 1
             WRITE(16,*) '        w/ implicit finite-amplitude term'
-         ELSEIF (mod(IMDig6,4).EQ.0) THEN
-            ILump=0
-            WRITE(16,*) '        Consistent GWCE mass matrix'
-            CGWCE_HDP = .TRUE.
-            IFNL_HDP = 1
-            WRITE(16,*) '        w/ implicit finite-amplitude term'
-            CAliDisp = .TRUE.
-            WRITE(16,*) '        & Alis improved dispersion relation'
          ENDIF
          ! WJP modifications for adding baroclinic mode
-         IF (IMDig6 > 4) THEN
+         IF (IMDig6 > 3) THEN
             CBaroclinic = .TRUE.
             WRITE(16,*) '        and baroclinic mode'
          ENDIF
@@ -1397,17 +1413,7 @@ C...
 C...
 C...  READ AND PROCESS NTIP - TIDAL POTENTIAL FORCING
 C...
-      if (mod(IMDig6,4).eq.0) then
-         ! WJP: read speed of sound and Ali's dispersion relation coefficients
-         READ(15,*) NTIP, Cs, Ad, Bd
-         if (Cs.le.0.0_SZ) then
-             Cs2 = huge(0.0_SZ)
-         else
-             Cs2 = Cs*Cs
-         endif
-      else
-         READ(15,*) NTIP
-      endif
+      READ(15,*) NTIP
       IF((NTIP.LT.0).OR.(NTIP.GT.2)) THEN
          IF(NSCREEN.NE.0.AND.MYPROC.EQ.0) THEN
             WRITE(ScreenUnit,9972)
@@ -1457,12 +1463,6 @@ C...
          WRITE(16,239)
  239     FORMAT(9X,'SELF ATTRACTION/LOAD TIDE FORCING IS ALSO USED ',
      &        'IN THE COMPUTATION')
-      ENDIF
-      if (mod(IMDig6,4).eq.0) then
-         ! WJP: read Ali's dispersion relation coefficients
-         WRITE(16,*) '     Speed of sound squared = ',Cs2
-         WRITE(16,2399) Ad, Bd
- 2399    FORMAT(/,5X,'Ali Disp coefs: Ad = ',F13.10,', Bd = ',F10.7)
       ENDIF
 C...
 C...  READ AND PROCESS NWS - WIND AND PRESSURE FORCING & WAVE RADIATION


### PR DESCRIPTION
I removed the IMDig6 = 4 which toggled on the dispersion correction for long waves on a elastic earth using Ali's theory. Also was reading in some coefficients on the NTIP line.
Moved these to a namelist option.
Now IMDig6 should 1-3 for barotropic and 4-6 for baroclinic. 