### PR TITLE
NWS14 (netcdf) interpolator fix for descending latitude array

### DIFF
--- a/src/mesh.F
+++ b/src/mesh.F
@@ -3846,7 +3846,7 @@
 
           integer :: binarysearch
 
-          integer :: left, middle, right
+          integer :: left, middle, right, orientation
           real(sz) :: d
 
           if (present(delta) .eqv. .true.) then
@@ -3854,7 +3854,10 @@
           else
              d = 1d-9
           endif
-        
+
+          orientation = 1
+          if (array(2) < array(1)) orientation = -1
+       
           left = 1
           right = length
           do
@@ -3863,11 +3866,21 @@
              if ( abs(array(middle) - value) <= d) then
                 binarySearch = middle
                 return
-             elseif (array(middle) > value) then
-                right = middle - 1
-             else
-                left = middle + 1
-             end if
+             endif
+             select case(orientation)
+             case(1) 
+                if (array(middle) > value) then
+                   right = middle - 1
+                else
+                   left = middle + 1
+                end if
+             case(-1)
+                if (array(middle) < value) then
+                   right = middle - 1
+                else
+                   left = middle + 1
+                end if
+             end select
           end do
           binarysearch = right
 

--- a/src/wind.F
+++ b/src/wind.F
@@ -8767,7 +8767,18 @@ C----------------------------------------------------------------------
                yy = rad2deg*sfea(i)
                call bl_interp2(nxp,nyp,lon,lat,xx,yy,indt,wt)
                indp(ii,:,i) = indt
-               weightsp(ii,:,i) = wt 
+               weightsp(ii,:,i) = wt
+               if (i.gt.1) cycle 
+               write(16,*) 'NWS=14 Interpolating check: xx',xx,'yy',yy
+               write(16,*) 'Lon',lon(indt(1),indt(2)),
+     &                           lon(indt(3),indt(2)),
+     &                           lon(indt(1),indt(4)),
+     &                           lon(indt(3),indt(4))
+               write(16,*) 'Lat',lat(indt(1),indt(2)),
+     &                           lat(indt(3),indt(2)),
+     &                           lat(indt(1),indt(4)),
+     &                           lat(indt(3),indt(4))
+               write(16,*) 'Weights',wt
             enddo
             deallocate(lon,lat)
 !            srtI(ii,:) = [minval(indp(ii,1,:)),minval(indp(ii,2,:))]
@@ -8919,6 +8930,7 @@ C----------------------------------------------------------------------
             call Check_err(nf90_inquire_variable(NC_ID,Lat_ID,
      &                     ndims=ndims))
             call Check_err(NF90_INQ_VARID(NC_ID,Lonvar,Lon_ID))
+            write(16,*) 'Lon/Lat dimensions = ',ndims
             if (ndims.eq.3) then
                call Check_err(NF90_GET_VAR(NC_ID,Lat_ID,data22,
      &                        start=[1, 1, NT],count=[NX, NY, 1]))


### PR DESCRIPTION
adding a fix for the binarysearch function when array is descending for e.g., ERA5 netcdf data that has the latitude array in descending order. Also added some message lines which the user can use to check that the interpolating factors are correct