### PR TITLE
Adding elapsed/remaining wallclock timers

### DIFF
--- a/src/cstart.F
+++ b/src/cstart.F
@@ -31,7 +31,8 @@ C
      &    igep, ndsetsw, nspoolgw, igrads, nscougc, igcp, c2ddi, iden, 
      &    rundes, runid, dtdp, ntrspm, nspoolm, nscoub, ibstp, nscouge, 
      &    ndsetsc, nspoolgc, nscougb, igbp, c3d, ipstp, nstav_g, nstav,
-     &    ntrspv, iicestp, nstam_g, nstam, openfileforread, cbaroclinic
+     &    ntrspv, iicestp, nstam_g, nstam, openfileforread, cbaroclinic,
+     &    model_startwallclock,model_startclockrate,model_startclockmax
       USE GLOBAL_3DVS, ONLY: I3DSD, I3DSV, I3DST, I3DGD, I3DGV, I3DGT
       USE MESH, ONLY : NE, NP, X, Y, SLAM, SFEA, ICS, DP, NM, MJU, AID4,
      &    agrid 
@@ -81,6 +82,8 @@ C
 #endif
       metOutputOn = .FALSE.
       nonMetOutputOff = .FALSE.
+      CALL SYSTEM_CLOCK(model_startwallclock,model_startclockrate,model_startclockmax)
+      model_startwallclock = MOD(model_startwallclock,model_startclockmax) / model_startclockrate
       !
       call initializeWettingAndDrying()
 

--- a/src/global.F
+++ b/src/global.F
@@ -626,6 +626,7 @@ C     kmd48.33bc - added variables for 3D boundary conditions
 #ifdef DATETIME
       type(datetime) :: basedatetime
 #endif
+      INTEGER(8)    :: model_startwallclock,model_startclockrate,model_startclockmax
       CHARACTER(80) :: comments    ! miscellaneous information about the data
       CHARACTER(80) :: host
       CHARACTER(80) :: convention
@@ -2033,6 +2034,69 @@ C     available to different parts of ADCIRC.
           ENDDO
       END FUNCTION toUppercase
 
+      SUBROUTINE print_remaining_time(it)
+          IMPLICIT NONE
+          INTEGER,INTENT(IN) :: it
+          INTEGER(8)         :: time_now
+          INTEGER(8)         :: count_rate
+          INTEGER(8)         :: count_max
+          REAL(8)            :: remaining
+          REAL(8)            :: elapsed
+          INTEGER(8)         :: days_elapsed
+          INTEGER(8)         :: hours_elapsed
+          INTEGER(8)         :: minutes_elapsed
+          INTEGER(8)         :: seconds_elapsed
+          INTEGER(8)         :: days_remaining
+          INTEGER(8)         :: hours_remaining
+          INTEGER(8)         :: minutes_remaining
+          INTEGER(8)         :: seconds_remaining
+
+          CALL SYSTEM_CLOCK(time_now,count_rate,count_max)
+          time_now = MOD(time_now,count_max) / count_rate
+          elapsed = REAL(time_now - model_startwallclock,8)
+          remaining = (elapsed / REAL(it,8)) * REAL(NT-IT-ITHS,8)
+
+          days_elapsed = FLOOR(elapsed / 86400D0)
+          elapsed = elapsed - days_elapsed * 86400D0
+          hours_elapsed = FLOOR(elapsed / 3600D0)
+          elapsed = elapsed - hours_elapsed * 3600D0
+          minutes_elapsed = FLOOR(elapsed / 60D0)
+          elapsed = elapsed - minutes_elapsed * 60D0
+          seconds_elapsed = elapsed
+
+          days_remaining = FLOOR(remaining / 86400D0)
+          remaining = remaining - days_remaining * 86400D0
+          hours_remaining = FLOOR(remaining / 3600D0)
+          remaining = remaining - hours_remaining * 3600D0
+          minutes_remaining = FLOOR(remaining / 60D0)
+          remaining = remaining - minutes_remaining * 60D0
+          seconds_remaining = remaining
+
+          WRITE(SCREENUNIT,'(2X,A,$)') "WALL CLOCK TIME ELAPSED: "
+          IF(days_elapsed.GT.0D0)THEN
+            WRITE(SCREENUNIT,10) days_elapsed,hours_elapsed,minutes_elapsed
+          ELSEIF(hours_elapsed.GT.0D0)THEN
+            WRITE(SCREENUNIT,11) hours_elapsed,minutes_elapsed,seconds_elapsed
+          ELSE
+            WRITE(SCREENUNIT,12) minutes_elapsed,seconds_elapsed
+          ENDIF
+          WRITE(*,'(A,$)') ", "
+
+          WRITE(SCREENUNIT,'(2X,A,$)') "WALL CLOCK TIME REMAINING: "
+          IF(days_remaining.GT.0D0)THEN
+            WRITE(SCREENUNIT,10) days_remaining,hours_remaining,minutes_remaining
+          ELSEIF(hours_remaining.GT.0D0)THEN
+            WRITE(SCREENUNIT,11) hours_remaining,minutes_remaining,seconds_remaining
+          ELSE
+            WRITE(SCREENUNIT,12) minutes_remaining,seconds_remaining
+          ENDIF
+          WRITE(*,'(A)') ""
+
+10        FORMAT(I3,"d",I2.2,"h",I2.2,"m",$)
+11        FORMAT(I2,"h",I2.2,"m",I2.2,"s",$)
+12        FORMAT(I2,"m",I2.2,"s",$)
+
+      END SUBROUTINE print_remaining_time
 
 C     ------------------------------------------------------------------
 C     ------------------------------------------------------------------

--- a/src/hstart.F
+++ b/src/hstart.F
@@ -186,6 +186,8 @@ C     kmd -- Added variables for initial conditions
       !
       metOutputOn = .FALSE.
       nonMetOutputOff = .FALSE.
+      CALL SYSTEM_CLOCK(model_startwallclock,model_startclockrate,model_startclockmax)
+      model_startwallclock = MOD(model_startwallclock,model_startclockmax) / model_startclockrate
       !
       call initializeWettingAndDrying()
       !

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -62,7 +62,7 @@ C
      &    QNPH, QNAM, ENPH, ENAM, ETRF, FPER, FFACE, ETA1, FAMIG, LNM_BC,
      &    BCFLAG_LNM, usingDynamicWaterLevelCorrection,
      &    dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, L_N, TKM, 
-     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE
+     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE, print_remaining_time
 #ifdef CSWAN
      &  , waveWindMultiplier
 #endif
@@ -96,7 +96,6 @@ C.....sb46.28sb03 added 09/xx/2006
 c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D wet/dry.
       USE GLOBAL_3DVS, ONLY:
      &     A, B, BSX, BSY, EVTOT, ISLIP, KP, Q, SIGMA, Z0B,NFEN
-
 ! arash 1/20/2016
      &     , BPG
 
@@ -1199,8 +1198,8 @@ C     the screen.
                WRITE(ScreenUnit,1991)
      &            IT,runperccomplete,NUMITR,TimeLoc,0.,KEMAX,VELMAX,
      &            KVMAX,MYPROC
-
             ENDIF
+            IF(MYPROC.EQ.0) CALL print_remaining_time(it)
  1991       FORMAT(1X,'TIME STEP =',I8,1x,F6.2,'% COMPLETE',
      &           5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
@@ -1263,6 +1262,7 @@ C     output the global node number to debug the local PE fort.14s
                WRITE(ScreenUnit,1992)
      &              IT,runperccomplete,NUMITR,TimeLoc,0.,KEMAX,VELMAX,KVMAX
             ENDIF
+            CALL print_remaining_time(it)
  1992       FORMAT(1X,'TIME STEP =',I8,1x,F6.2,'% COMPLETE',
      &           5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,


### PR DESCRIPTION
Adding a minor enhancement whereby ADCIRC will print out the elapsed wallclock time and estimated wallclock time until completion at each `NSCREEN` interval. This is something I've wanted for some time as I usually have to do this math by hand during my runs anyway to get some estimates when they'll complete. I'm seeking feedback on the format of the output as it's easily changed, but conceptually, this is what is currently in this change. Is the display intuitive/pretty enough for what we want? Also, I think you could further enhance this, if someone wanted to, to consider weighting the last X% of the simulation more heavily as maybe the iteration count in SWAN during an early portion of the storm (which tends to be slower) leads to an incorrect estimate during the peak of the storm when it tends to converge quickly. Right now it just assumes all model time steps occurred in constant time. 
```
 TIME STEP =   55000   2.46% COMPLETE     ITERATIONS =   11     TIME =  0.11000000E+07
  ELMAX =  2.3911E-001 AT NODE      224  SPEEDMAX =  1.9095E-001 AT NODE     1240  ON MYPROC =    0
  WALL CLOCK TIME ELAPSED:  3m33s,   WALL CLOCK TIME REMAINING:  2h20m53s
 TIME STEP =   56000   2.50% COMPLETE     ITERATIONS =   11     TIME =  0.11200000E+07
  ELMAX =  1.4053E-001 AT NODE     1441  SPEEDMAX =  3.7163E-001 AT NODE     1240  ON MYPROC =    0
  WALL CLOCK TIME ELAPSED:  3m37s,   WALL CLOCK TIME REMAINING:  2h20m54s
 TIME STEP =   57000   2.55% COMPLETE     ITERATIONS =   11     TIME =  0.11400000E+07
  ELMAX =  3.1309E-001 AT NODE      256  SPEEDMAX =  2.3507E-001 AT NODE     1179  ON MYPROC =    0
  WALL CLOCK TIME ELAPSED:  3m41s,   WALL CLOCK TIME REMAINING:  2h20m55s
```

The timers will switch between the following formats dependent upon how much time is remaining:
```
2m20s
2h20m55s
2d20h55m
```

Also, I've seen requests for the simulation time elapsed to be displayed in a similar format. You could use the same subroutines to do something like:
```
 TIME STEP =   55000   2.46% COMPLETE     ITERATIONS =   11     TIME =  0.11000000E+07 (12d20h38m)
  ELMAX =  2.3911E-001 AT NODE      224  SPEEDMAX =  1.9095E-001 AT NODE     1240  ON MYPROC =    0
```