### PR TITLE
Improving interpolation speed for non-regular met grids with NWS=14 option

### DIFF
--- a/src/mesh.F
+++ b/src/mesh.F
@@ -3969,11 +3969,13 @@
 
       END SUBROUTINE bl_interp
 !-----------------------------------------------------------------------
-      SUBROUTINE bl_interp2(xp, yp, x_mat, y_mat, x, y, ii, w)
+      SUBROUTINE bl_interp2(xp, yp, x_mat, y_mat, x, y, ii, w, tree)
           ! This function uses bilinear interpolation to get the
           ! interpolation weights, w and the indices for interpolation
           ! Assumed to be sampled on a structured unregular grid x values
           ! specified by x_mat and the grid y values specified by y_mat
+          use kdtree2_module, only: kdtree2, kdtree2_result, 
+     &                              kdtree2_n_nearest
           implicit none
           integer, intent(in) :: xp, yp           
           real, dimension(xp,yp), intent(in) :: x_mat, y_mat
@@ -3986,25 +3988,26 @@
           real(sz) :: y11, y21, y12, y22, y_vec(yp)
           real(sz) :: d11, d12, d21, d22, denom
           real(sz) :: p(2), a(2), b(2), c(2), d(2)
-          integer  :: i, j, jj, ir, jr, ia
+          integer  :: i, j, jj, ir, jr, ia, xi, yi, ind
+          type(kdtree2), pointer :: tree
+          type(kdtree2_result) :: kdresult(1)
 
-          ! Check if structured regular..
-          if (abs(x_mat(1,1) - x_mat(1,yp)) < 1d-6) then
-             x_array = x_mat(:,1)
-             y_array = y_mat(1,:)
-             ! This is much faster..
-             call bl_interp(xp, x_array, yp, y_array, x, y, ii, w)
-             !write(16,*) 'blout',x, y
-             !write(16,*) x_array(ii(1)), y_array(ii(2))
-             !write(16,*) x_array(ii(3)), y_array(ii(4))
-             !write(16,*) ii
-             !write(16,*) w
-             return;
-          endif       
+          ! find the closest point to this node and convert to subscript
+          call kdtree2_n_nearest(tp=tree,qv=[x,y],
+     &                           nn=1,results=kdresult)
+          ind = kdresult(1)%idx  ! location of closest point
+          xi  = ind/yp           ! ind2sub
+          yi  = mod(ind,yp)      ! ind2sub
+          if (yi == 0) then 
+             yi = yp
+          else
+             xi = xi + 1 
+          endif
  
           ii   = [-1, 0, 0, 0]; ! Default indices
           ia = 0
-          do i = 1,xp
+          ! loop over points close to the nearest one  
+          do i = max(1,xi-1),min(xi+1,xp) !1,xp
              ir = i + 1
              if (ir > xp) then
                 ! If wrapping around
@@ -4015,7 +4018,7 @@
                    exit
                 endif
              endif
-             do j = 1,yp-1
+             do j = max(1,yi-1),min(yi+1,yp-1) !1,yp-1
                 jr = j + 1
                 x11 = x_mat(i,j);  x21 = x_mat(ir,j) + ia*360d0
                 x12 = x_mat(i,jr); x22 = x_mat(ir,jr) + ia*360d0

--- a/src/wind.F
+++ b/src/wind.F
@@ -4920,18 +4920,16 @@ C     Calculate wind velocity and pressure at each node.
          DX(I)=(XCOOR(I)-lon)*DEG2RAD
          DY(I)=(YCOOR(I)-lat)*DEG2RAD
          THETA(I)=ATAN2(DY(I),DX(I))
-C   RJW v48.45
-C     compute the distances based on haversine formula for distance along a sphere
-        rad(i) = sphericalDistance(DX(I),DY(I),lat, ycoor(i))
-C       Rad(i)=Rearth*(2.0d0*ASIN(sqrt(sin(DY(I)/2.0d0)**2.0d0+
-C     & cos(lat*DEG2RAD)*cos(YCOOR(i)*DEG2RAD)*sin(DX(I)/2.0d0)**2.0d0)))
-C compute coriolis
-        coriolis = 2.0d0 * omega * sin(YCOOR(I)*DEG2RAD)
-
-        PRESS(I)=(cpress+(centralPressureDeficit)*
+C     RJW v48.45
+C     Compute the distances based on haversine formula for distance along a sphere
+         rad(i) = sphericalDistance(DX(I),DY(I),lat, ycoor(i))
+C     Compute coriolis
+         coriolis = 2.0d0 * omega * sin(YCOOR(I)*DEG2RAD)
+C     Compute pressure field
+         PRESS(I)=(cpress+(centralPressureDeficit)*
      &        EXP(-(RMW*1000.d0/RAD(I))**B)) / (RHOWAT0*G)
-C
-C       WJP: added absolute around CORIOLIS for Southern Hempisphere
+C     Compute velocity field with absolute around 
+C     CORIOLIS for the Southern Hempisphere
          V_r(I) = sqrt(
      &        (RMW*1000.d0/RAD(I))**B *
      &        EXP(1.d0-(RMW*1000.d0/RAD(I))**B)*spd**2.d0
@@ -8731,14 +8729,18 @@ C----------------------------------------------------------------------
       END SUBROUTINE NWS14INIT
 C----------------------------------------------------------------------
       SUBROUTINE NWS14GET(WVNX2,WVNY2,PRN2,CICE2)
-      use mesh, only: NP, SLAM, SFEA, bl_interp2
+      use mesh, only: NP, SLAM, SFEA, bl_interp, bl_interp2
+      use kdtree2_module, only: kdtree2, kdtree2_create
       implicit none
 
       real(sz),intent(out) :: PRN2(NP), WVNX2(NP), WVNY2(NP)
       real(sz),intent(out),optional :: CICE2(NP)
-      integer :: i, ii, nxp, nyp, indt(4), NTkeep
+      integer :: i, ii, nxp, nyp, indt(4), NTkeep, xi, yi, cc
       real,allocatable,dimension(:,:) :: Pmsl, U10, V10, Cice, lat, lon
+      real(sz), allocatable ::  lonv(:), latv(:), XY(:,:)
       real(sz) :: xx, yy, wt(4) 
+      logical :: regular_grid
+      type(kdtree2), pointer :: tree
 
       ! Show the date in str_date format
       call logMessage(ECHO,'CurDT strng: '//
@@ -8775,12 +8777,38 @@ C----------------------------------------------------------------------
                call READNWS14(Wfile,Winv,Uvar,lon,lat)
             endif
             nxp = ubound(lon,1); nyp = ubound(lat,2)
+            ! Check if structured regular..
+            if (abs(lon(1,1) - lon(1,nyp)) < 1d-6) then
+               regular_grid = .true. 
+               allocate(lonv(nxp),latv(nyp))
+               lonv = lon(:,1)
+               latv = lat(1,:)
+            else       
+               regular_grid = .false. 
+               ! Convert point matrices to 2 X (NXP*NYP) point vector
+               allocate(XY(2,nxp*nyp))
+               cc = 0
+               do xi = 1,nxp
+                  do yi = 1,nyp
+                     cc = cc + 1
+                     XY(1,cc) = lon(xi,yi)
+                     XY(2,cc) = lat(xi,yi)
+                  enddo
+               enddo
+               ! Create the search tree
+               tree => kdtree2_create(XY) 
+            endif
+            ! Loop over each node and interpolate
             do i = 1,np
                xx = rad2deg*slam(i)
                ! Convert our numbers if grids are 0 to 360
                if (maxval(lon).gt.180d0.and.xx < 0d0) xx = xx + 360d0
                yy = rad2deg*sfea(i)
-               call bl_interp2(nxp,nyp,lon,lat,xx,yy,indt,wt)
+               if (regular_grid) then
+                  call bl_interp(nxp,lonv,nyp,latv,xx,yy,indt,wt)
+               else
+                  call bl_interp2(nxp,nyp,lon,lat,xx,yy,indt,wt,tree)
+               endif
                indp(ii,:,i) = indt
                weightsp(ii,:,i) = wt
 #ifdef DEBUG_NWS14
@@ -8798,7 +8826,11 @@ C----------------------------------------------------------------------
                write(16,*) 'Indices',indt
 #endif
             enddo
-            deallocate(lon,lat)
+            if (regular_grid) then
+               deallocate(lon,lat,latv,lonv)
+            else
+               deallocate(lon,lat,XY)
+            endif
          enddo
       endif
       


### PR DESCRIPTION
- Added KDTREE to get the nearest neighbour before applying point-in-triangle test on nearby grid points to avoid excessive loops over the entire grid for each mesh vertex in bl_interp2 (example I did on a large met grid reduced this pre-processing step from ~10 minutes to <1 min)
- Directly call bl_interp from NWS14GET subroutine instead of inside bl_interp2 for regular grids