### PR TITLE
Changes the default value of NABOUT for TRACE mode

### DIFF
--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -157,7 +157,7 @@ C
       !
       call initLogging()
       nabout = 0 !jgf52.08.01: Initialize log level to ECHO.
-#ifdef EBUG
+#if defined(ADCIRC_TRACE) || defined(ALL_TRACE)
       nabout = -1 !jgf52.08.01: Initialize log level to DEBUG if so compiled
 #endif
       call setMessageSource("ADCIRC_Init")


### PR DESCRIPTION
Without this change, the default value of NABOUT is 0 unless -DEBUG is used at compilation. This default value is valid until it is set to be the value specified in fort.15. Between the beginning to the point where fort.15 is read, even if -DADCIRC_TRACE or -DALL_TRACE is used at compilation and if -DEBUG is not used, no trace message is printed. This change fixes this behavior by setting the default value of NABOUT to be -1 when _DADCIRC_TRACE or -DALL_TRACE is used.