### PR TITLE
Add the IBTYPE=64 weir boundary (=vertical element wall) and nodal attribute "condensed_nodes" (1D condensation)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,7 @@ workflows:
                         - adcirc_katrina-2d-parallel
                         - adcirc_nws30_wlcorrection
                         - adcirc_nws30_wlcorrection-parallel
+                        - adcirc_slopingbeach_vew1d-parallel
       - test_grib2:
             requires: 
                 - build_cmake_with_netcdf_and_xdmf_grib

--- a/cmake/adcirc.cmake
+++ b/cmake/adcirc.cmake
@@ -6,6 +6,7 @@ if(BUILD_ADCIRC)
       ${CMAKE_SOURCE_DIR}/src/global.F
       ${CMAKE_SOURCE_DIR}/src/boundaries.F
       ${CMAKE_SOURCE_DIR}/src/mesh.F
+      ${CMAKE_SOURCE_DIR}/src/vew1d.F
       ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
       ${CMAKE_SOURCE_DIR}/src/harm.F
       ${CMAKE_SOURCE_DIR}/wind/vortex.F

--- a/cmake/adcprep.cmake
+++ b/cmake/adcprep.cmake
@@ -7,6 +7,7 @@ if(BUILD_ADCPREP)
       ${CMAKE_SOURCE_DIR}/src/boundaries.F
       ${CMAKE_SOURCE_DIR}/src/hashtable.F
       ${CMAKE_SOURCE_DIR}/src/mesh.F
+      ${CMAKE_SOURCE_DIR}/src/vew1d.F
       ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
       ${CMAKE_SOURCE_DIR}/wind/vortex.F
       ${CMAKE_SOURCE_DIR}/src/owiwind.F

--- a/cmake/adcswan.cmake
+++ b/cmake/adcswan.cmake
@@ -80,6 +80,7 @@ if(BUILD_ADCSWAN AND PERL_FOUND)
       ${CMAKE_SOURCE_DIR}/src/global.F
       ${CMAKE_SOURCE_DIR}/src/boundaries.F
       ${CMAKE_SOURCE_DIR}/src/mesh.F
+      ${CMAKE_SOURCE_DIR}/src/vew1d.F
       ${CMAKE_SOURCE_DIR}/src/hashtable.F
       ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
       ${CMAKE_SOURCE_DIR}/src/harm.F

--- a/cmake/libadcirc.cmake
+++ b/cmake/libadcirc.cmake
@@ -6,6 +6,7 @@ set(LIBADC_SOURCES
     ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
     ${CMAKE_SOURCE_DIR}/src/messenger.F
     ${CMAKE_SOURCE_DIR}/src/mesh.F
+    ${CMAKE_SOURCE_DIR}/src/vew1d.F
     ${CMAKE_SOURCE_DIR}/src/harm.F
     ${CMAKE_SOURCE_DIR}/wind/vortex.F
     ${CMAKE_SOURCE_DIR}/src/wind.F

--- a/cmake/padcirc.cmake
+++ b/cmake/padcirc.cmake
@@ -8,6 +8,7 @@ if(BUILD_PADCIRC)
       ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
       ${CMAKE_SOURCE_DIR}/src/messenger.F
       ${CMAKE_SOURCE_DIR}/src/mesh.F
+      ${CMAKE_SOURCE_DIR}/src/vew1d.F
       ${CMAKE_SOURCE_DIR}/src/harm.F
       ${CMAKE_SOURCE_DIR}/wind/vortex.F
       ${CMAKE_SOURCE_DIR}/src/wind.F

--- a/cmake/padcswan.cmake
+++ b/cmake/padcswan.cmake
@@ -82,6 +82,7 @@ if(BUILD_PADCSWAN AND PERL_FOUND)
       ${CMAKE_SOURCE_DIR}/src/global_3dvs.F
       ${CMAKE_SOURCE_DIR}/src/messenger.F
       ${CMAKE_SOURCE_DIR}/src/mesh.F
+      ${CMAKE_SOURCE_DIR}/src/vew1d.F
       ${CMAKE_SOURCE_DIR}/src/harm.F
       ${CMAKE_SOURCE_DIR}/wind/vortex.F
       ${CMAKE_SOURCE_DIR}/src/wind.F

--- a/prep/decomp.F
+++ b/prep/decomp.F
@@ -555,7 +555,7 @@ C----------------------------------------------------------------------
          do k = 1,nbou
             select case(ibtype(k))
             ! weir boundaries
-            case(4,24,5,25)
+            case(4,24,64,5,25)
                do i = 1,nvell(k)
                   indx = nbvv(k,i)
                   index2 = ibconnr(k,i)

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -657,14 +657,14 @@ C  This section for prep15
          ENDDO
       ENDDO
       !zc...If we're using time varying weirs, we need to
-      !     find out which processors have weir (4,24) boundaries
+      !     find out which processors have weir (4,24,64) boundaries
       !     in the case that we're not passing through PREP14
       IF(USE_TVW)THEN
         ALLOCATE(ISWEIR(1:NNODG))
         ISWEIR(:) = .FALSE.
         DO K=1,NBOU
             SELECT CASE(IBTYPE(K))
-                CASE(4,24,5,25)
+                CASE(4,24,64,5,25)
                     DO J=1,NVELL(K)
                         ISWEIR(NBVV(K,J))=.TRUE.
                         ISWEIR(IBCONNR(K,J))=.TRUE.
@@ -794,8 +794,13 @@ C        Transcribe attribute names from full domain file to subdomains.
                WRITE(sdu(IPROC),'(A80)') AttrName(k)!tgaf13mod
                WRITE(sdu(IPROC),'(A80)') Units
                WRITE(sdu(IPROC),*) NoOfVals(k)
-               WRITE(sdu(IPROC),'(12(1x,e16.9))')
-     &          (DefaultVal(m),m=1,NoOfVals(k))
+               if (trim(adjustl(AttrName(k))).eq."condensed_nodes") then !sb20221013
+                  WRITE(sdu(IPROC),'(99(1x,i10))')
+     &             (NINT(DefaultVal(m)),m=1,NoOfVals(k))
+               else
+                  WRITE(sdu(IPROC),'(12(1x,e16.9))')
+     &             (DefaultVal(m),m=1,NoOfVals(k))
+               end if
             END DO
          END DO
 C
@@ -981,7 +986,13 @@ CTGA 20180524: Adjusted code to better handle out-of-order attributes in the bod
                IF (Mode.eq.0) SDNumND(iproc,k) = SDNumND(iproc,k)+1
                IF (Mode.eq.1) THEN
                   SDNode = IMAP_NOD_GL(2,NodeNum)
-                  WRITE(sdu(iproc),1100) NodeNum,(AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                  IF (trim(adjustl(curAttrName)).eq."condensed_nodes") THEN !sb20221022
+                     WRITE(sdu(iproc),1101) NodeNum,
+     &                  (NINT(AttrData(j)),j=1,NumCol(curAttrInd))!tgaf13mod
+                  ELSE
+                     WRITE(sdu(iproc),1100) NodeNum,
+     &                  (AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                  ENDIF
                ENDIF
             ELSE
                DO m=1, ITOTPROC(NodeNum)
@@ -993,8 +1004,13 @@ CTGA 20180524: Adjusted code to better handle out-of-order attributes in the bod
                         ENDIF
                         IF (Mode.eq.1) THEN
                            SDNode = IMAP_NOD_GL2(2*(m-1)+2,NodeNum)
-                           WRITE(sdu(iproc),1100) NodeNum,
-     &                          (AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                           IF (trim(adjustl(curAttrName)).eq."condensed_nodes") THEN !sb20221022
+                              WRITE(sdu(iproc),1101) NodeNum,
+     &                             (NINT(AttrData(j)),j=1,NumCol(curAttrInd))
+                           ELSE
+                              WRITE(sdu(iproc),1100) NodeNum,
+     &                             (AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                           ENDIF
                         ENDIF
                      ENDIF
                   END DO
@@ -1013,6 +1029,7 @@ C
  1021 FORMAT('contains invalid name: ',A80)
  1031 FORMAT('WARNING: Processed only one column of unrecognized ',A80)
  1100 FORMAT(I10,32000(2X,E16.8))
+ 1101 FORMAT(I10,32000(2X,I10))
 C
       RETURN
 C     ----------------------------------------------------------------
@@ -1130,8 +1147,12 @@ C        Transcribe header information into subdomain unit 13 files
                write(sdu(iproc),'(a)') trim(adjustl(na(i)%attrName))
                write(sdu(iproc),'(a)') trim(adjustl(na(i)%units))
                write(sdu(iproc),'(99(i0))') na(i)%numVals
-               write(sdu(iproc),'(99(F15.7))') (na(i)%defaultVals(j), j=1,na(i)%numVals)
-            end do
+               if (trim(adjustl(na(i)%attrName)).eq."condensed_nodes") then !sb20221013
+                  write(sdu(iproc),'(99(I10))') (nint(na(i)%defaultVals(j)), j=1,na(i)%numVals)
+               else
+                  write(sdu(iproc),'(99(F15.7))') (na(i)%defaultVals(j), j=1,na(i)%numVals)
+               end if
+         end do
          end do
 C
 C        Allocate and initialize the matrix for the number of Non Default
@@ -1282,7 +1303,7 @@ C
             select case(IBTYPE(K))
             !
             ! weir boundaries
-            case(4,24,5,25)
+            case(4,24,64,5,25)
                DO I = 1,NVELL(K)
                   INDX = NBVV(K,I)
                   INDEX2 = IBCONNR(K,I)
@@ -1491,7 +1512,7 @@ C     jgf46.21 Added support for IBTYPE=52.
                DISC = DISC + NVELLP(K)
             case(3,13,23)
                BBN = BBN + NVELLP(K)
-            case(4,24)
+            case(4,24,64)
                IBP = IBP + NVELLP(K)
             case(5,25)
                IBPPipe = IBPPipe + NVELLP(K)
@@ -1658,7 +1679,7 @@ C
                      WRITE(14,81) LABELS(IMAP_NOD_LG(NBVVP(K,I),IPROC)),
      &                            BAR1(K,INDX),BAR2(K,INDX)
                   ENDDO
-               case(4,24)
+               case(4,24,64)
                   IF(USE_TVW)NWEIRBNDRY(IPROC) = 1
                   DO I = 1,NVELLP(K)
                      INDX = LBINDEX_LG(K,I)

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -418,7 +418,7 @@ C     jgf46.21 Added support for IBTYPE=52.
          case(3,13,23)
             NFLUXB=1
             NBBN=NBBN+NBN
-         case(4,24)
+         case(4,24,64)
             NFLUXI=1
             NIBP=NIBP+NBN
          case(5,25)

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -209,7 +209,7 @@ C
                NBVV(K,I) = find(node_dict,n1)
               IBCONNR(K,I) = 0
             ENDDO
-         case(4,24)
+         case(4,24,64)
             DO I=1,NVELL(K)
                READ(14,*) n1,IBCONNR(K,I),
      &                    BAR1(K,I),BAR2(K,I),BAR3(K,I)
@@ -1318,7 +1318,7 @@ C........CHECK FOR WEIR FLUX BOUNDARIES
         SELECT CASE(LBCODE(I))
             CASE(3,13,23)
                 NFLUXB = 1
-            CASE(4,24)
+            CASE(4,24,64)
                 NFLUXIB = 1
             CASE(5,25)
                 NFLUXIBP = 1

--- a/src/boundaries.F
+++ b/src/boundaries.F
@@ -17,6 +17,7 @@ C     ------------------------------------------------------------------
       implicit none
       REAL(SZ),ALLOCATABLE ::   BNDLEN2O3(:)
       REAL(SZ),ALLOCATABLE ::   CSII(:),SIII(:)
+      REAL(SZ),ALLOCATABLE ::   CSIICN(:),SIIICN(:) ! normal direction at condensed nodes 09/22/2022 SB
       INTEGER,ALLOCATABLE ::    ME2GW(:)
       INTEGER,ALLOCATABLE ::    NBV(:),LBCODEI(:)
  
@@ -34,6 +35,7 @@ C.....for internal barrier boundaries with flowthrough pipes
       REAL(SZ),ALLOCATABLE ::   BARINHT(:),BARINCFSB(:),BARINCFSP(:)
       REAL(SZ),ALLOCATABLE ::   PIPEHT(:),PIPECOEF(:),PIPEDIAM(:)
       INTEGER, ALLOCATABLE ::   IBCONN(:)
+      INTEGER, ALLOCATABLE ::   ISSUBMERGED64(:) ! used to identify submerged ibtype=64 weir  SB
       ! these arrays will only be needed temporarily, between reading 
       ! the ascii mesh file and initializing the boundaries
       REAL(SZ),ALLOCATABLE ::   BARLANHTR(:,:),BARLANCFSPR(:,:)
@@ -58,6 +60,7 @@ C.....for internal barrier boundaries with flowthrough pipes
       INTEGER  IM,JGW,JKI,JME
       INTEGER  NFLUXIBP,NPIPE
       integer  nfluxb,nfluxf,nfluxib,nfluxrbc,nfluxgbc
+      integer  nfluxib64, nfluxib64_gbl !sb flag to indicate that ibtype=64 (vertical element wall) boundary exists
       real(sz) :: costset
       real(sz) :: anginn
 
@@ -108,7 +111,7 @@ C.....for internal barrier boundaries with flowthrough pipes
       integer :: numExternalFluxBoundaries 
       integer :: efCount   ! index into the externalFluxBoundaries array
       !
-      ! flux boundaries where ibtype = 4, 24
+      ! flux boundaries where ibtype = 4, 24, 64
       type internalFluxBoundary_t
          integer :: indexNum               ! order within the fort.14 file
          integer :: informationID              ! xdmf ID for IBTYPE info
@@ -260,6 +263,7 @@ C     ---------
       allocate ( pipeht(mnvel),pipecoef(mnvel),pipediam(mnvel))
       allocate ( ibconn(mnvel))
       allocate ( nbvv(mnbou,0:mnvel))
+      allocate ( issubmerged64(mnvel))
       allocate ( bndlen2o3(mnvel))
       allocate ( ntran1(mnvel),ntran2(mnvel))
       allocate ( btran3(mnvel),btran4(mnvel),btran5(mnvel))
@@ -331,7 +335,7 @@ C     ---------
             allocate(externalFluxBoundaries(efCount)%barlancfsp(nvell(i)))
             allocate(externalFluxBoundaries(efCount)%xdmf_nodes(nvell(i)))
             efCount = efCount + 1
-         case(4,24)        
+         case(4,24,64)        
             allocate(internalFluxBoundaries(ifCount)%nodes(nvell(i)))
             allocate(internalFluxBoundaries(ifCount)%ibconn(nvell(i)))
             allocate(internalFluxBoundaries(ifCount)%barinht(nvell(i)))
@@ -435,6 +439,7 @@ C     ------------------------------------------------------------------
       allocate ( barinht(mnvel),barincfsb(mnvel),barincfsp(mnvel))
       allocate ( pipeht(mnvel),pipecoef(mnvel),pipediam(mnvel))
       allocate ( ibconn(mnvel))  
+      allocate ( issubmerged64(mnvel))
 
       allocate ( nbvv(mnbou,0:mnvel))
       allocate ( nvell(mnbou), ibtype(mnbou), ibtype_orig(mnbou))
@@ -489,7 +494,7 @@ C     ------------------------------------------------------------------
       nweir = 0
       do k = 1,nbou
          select case(ibtype(k))
-         case(4,24)
+         case(4,24,64)
             nweir = nweir + nvell(k)
          case(5,25)
             print *, 'error: ibtype 5 and 25 not supported by adcprep.'

--- a/src/global.F
+++ b/src/global.F
@@ -386,7 +386,9 @@ C- DMW
       REAL(SZ),ALLOCATABLE ::   L_N(:,:)    ! WJP The array for TIP multiplier
       REAL(SZ),ALLOCATABLE ::   SALTAMP(:,:),SALTPHA(:,:)
       REAL(SZ),ALLOCATABLE ::   OBCCOEF(:,:),COEF(:,:)
-      REAL(SZ),ALLOCATABLE ::   COEFD(:) !jgf48.4619 from Seizo (Lumped GWCE)
+      REAL(SZ),ALLOCATABLE,TARGET ::   COEFD(:) !jgf48.4619 from Seizo (Lumped GWCE)
+      REAL(SZ),ALLOCATABLE,TARGET ::   COEFDTempMem(:) !Added for VEW1D  08-11-2022 SB
+      REAL(SZ),POINTER ::   COEFDTemp(:) !Added for VEW1D  08-11-2022 SB
       INTEGER :: NBFR, NCOR
 C    kmd48.33bc - added variables for the levels of no motion and top temperature boundary condition
       REAL(SZ),ALLOCATABLE ::   LNM_BC1(:), LNM_BC2(:), LNM_BC(:) ! level of no motion
@@ -414,6 +416,10 @@ C.....for scalar transport
       
 !     The vertically-integrated momentum dispersion terms     
       REAL(SZ),ALLOCATABLE ::   VIDISPDXOH(:), VIDISPDYOH(:)
+
+C.....for VEW1D sb
+      INTEGER,ALLOCATABLE  :: flgNodesMultipliedByTotalArea(:)
+
 
       REAL(SZ) DT
 C                                
@@ -1211,6 +1217,10 @@ C    loadEleSlopeLim.eqv..true
       ALLOCATE (ESLCOUNT(MNP))
       ESLCOUNT = 0.d0
 
+C     Allocate an array for VEW1D
+      ALLOCATE (flgNodesMultipliedByTotalArea(MNP))
+      flgNodesMultipliedByTotalArea = 0
+      
 #ifdef CMPI
       ALLOCATE ( IDUMY(1), DUMY1(1), DUMY2(1) )
 #endif
@@ -1414,8 +1424,9 @@ C...
       USE SIZES, ONLY : MNP
       IMPLICIT NONE
 C     jgf48.4619: Array used in lumped GWCE (from Seizo)
-      ALLOCATE( COEFD(MNP) )
+      ALLOCATE( COEFD(MNP), COEFDTempMem(MNP) )  ! COEFDTemp is added for VEW1D  SB 08-11-2022
       coefd = -99999.d0
+      coefdtempmem = -99999.d0
       RETURN
       END SUBROUTINE ALLOC_MAIN11_LUMPED
 
@@ -2057,7 +2068,6 @@ C     available to different parts of ADCIRC.
             IF(idx.GT.0)uppercase(I:I)=cap(IDX:IDX)
           ENDDO
       END FUNCTION toUppercase
-
 
 C     ------------------------------------------------------------------
 C     ------------------------------------------------------------------

--- a/src/gwce.F
+++ b/src/gwce.F
@@ -232,27 +232,34 @@ C
      &   QN1, EN1, QN0, ElevDisc, QN2, EN0, iLump, BCFLAG_LNM, EN2,
      &   TKM, NPERSEG, NTIP, NNPERBC, IPERCONN, VIDispDXOH, Bd, Ad, Cs2,
      &   VIDispDYOH, IFSFM, IFNL_HDP, CGWCE_HDP, CAliDisp, H0, ALPHAL, windlim,
-     &   usingDynamicWaterLevelCorrection, dynamicWaterLevelCorrection1
+     &   usingDynamicWaterLevelCorrection, dynamicWaterLevelCorrection1,
+     &   COEFDTemp, COEFDTempMem  ! Added for VED1D  08-11-2022 SB
 #ifdef CMPI
      &    , dumy1, dumy2, rnp_global
 #endif
       USE MESH, ONLY : NE, NP, NM, DP, NNeigh, NeiTab, TotalArea, FDXE,
      &   Areas, NEIMAX, SFAC, nneighele, neitabele, FDYE,
      &   SWITCH_ELTAB_PERBC, SFacEle, SFMYEle, SFMXEle, SFCXEle,
-     &   SFCYEle, YCSFacEle, TANPHI, SFCT, TANPHIEle
+     &   SFCYEle, YCSFacEle, TANPHI, SFCT, TANPHIEle, LBArray_Pointer,
+     &   X, Y
       USE BOUNDARIES, ONLY : NETA, NFLUXF, NFLUXB, NFLUXGBC, NFLUXIB, 
-     &   NFLUXRBC, NOPE, NVEL, NBD, NBV, LBCODEI, BndLen2O3, NPEBC
+     &   NFLUXRBC, NOPE, NVEL, NBD, NBV, LBCODEI, BndLen2O3, NPEBC,
+     &   NBOU, NVELL, IBCONN, ISSUBMERGED64, NFLUXIB64_GBL  ! Added for VEW1D  08-11-2022 SB
       USE ITPACKV
       USE NodalAttributes, ONLY :
      &     LoadGeoidOffset, GeoidOffset, EVM, NOLIBF,
      &     TAU0VAR, HighResTimeVaryingTau0, FullDomainTimeVaryingTau0,
      &     CalculateTimeVaryingTau0, LoadAdvectionState, advectlocal,
+     &     LoadCondensedNodes, ListCondensedNodes, NListCondensedNodes, ! Added for VEW1D  08-11-2022 SB
+     &     NNodesListCondensedNodes, NCondensedNodes,                    !
 C... DW
      &     LoadAbsLayerSigma, absorblayer_sigma_eta,
      &     absorblayer_sigma_mnx, absorblayer_sigma_mny
       USE SPONGELAYER
 C... DW
-
+C... SB
+      USE VEW1D, ONLY : ROTATE_AT_CONDENSEDNODES_ALL
+C... SB
 #ifdef CMPI
       USE MESSENGER
 #endif
@@ -262,7 +269,7 @@ C... DW
 
       IMPLICIT NONE
 
-      INTEGER IE, JN, IJ, I, J                           !local loop counters
+      INTEGER IE, JN, IJ, I, J, K, L                     !local loop counters
       INTEGER IT
       INTEGER NM1, NM2, NM3, NMI1, NMI2, NMI3, NMJ1, NMJ2, NMJ3
       INTEGER NC1, NC2, NC3, NCEle, NCI, NCJ
@@ -321,6 +328,10 @@ C... DW
       INTEGER :: nbdj
       REAL(SZ) :: rff
       REAL(SZ) :: qforcei, qforcej
+C...... SB
+      REAL(SZ) :: SX, SY
+      INTEGER :: ROT_STATUS
+C...... SB
 C...... DW
       REAL(SZ):: SigmaAvg, Tau0Avg_S
       REAL(SZ):: SgN1_eta, SgN2_eta, SgN3_eta
@@ -341,7 +352,9 @@ C...... DW
       REAL(SZ) :: SPM1, SPM2, SPM3 
       LOGICAL :: ETA_SPONGE = .false., GWCE_SPONGE = .false.
       REAL(SZ) :: Ma2, Cfac = 1.0_SZ, CfacS0 = 1.0_SZ
-      
+      INTEGER :: NNBB1, NNBB2  ! Added for VEW1D  08-11-2022 SB
+      REAL(SZ):: fBuf          !
+
       IF ( LoadAbsLayerSigma ) THEN
          IF (NumNodesAbsLayer(1) > 0 ) ETA_SPONGE = .true.
          IF (SUM(NumNodesAbsLayer) > 0 ) GWCE_SPONGE = .true.
@@ -958,6 +971,17 @@ Corbitt 120322: Localized Advection
          T0N1=Tau0Var(NM1)
          T0N2=Tau0Var(NM2)
          T0N3=Tau0Var(NM3)
+C..... SB 2022-09-14
+C        Rorate the velocity and flux vectors at the condensed nodes
+C        so that they align with the stream direction
+         IF (LoadCondensedNodes) THEN
+            CALL ROTATE_AT_CONDENSEDNODES_ALL
+     &        (NM1,NM2,NM3,
+     &         U1N1,V1N1,U1N2,V1N2,U1N3,V1N3,
+     &         QX1N1,QY1N1,QX1N2,QY1N2,QX1N3,QY1N3,
+     &         ROT_STATUS)
+         ENDIF
+C..... SB
 C
 C.... DW: begin ! absorbing layer
 C 
@@ -1208,6 +1232,9 @@ C        WJP: Add on the contribution from spherical correction term
 C        from the momentum equation
          ! (tan \phi V_{lambda})/R + f
          CorifAvg = CorifAvg + IFNLCT*TANPHIAvg*U1Avg
+C
+C...... Eliminate Coriols at condensed nodes  10/17/2022 sb
+         IF (LoadCondensedNodes.AND.ROT_STATUS.EQ.0) CorifAvg = 0.D0
 C
 C...... DW absorbing layer
 C
@@ -1588,8 +1615,8 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
       IF((NFLUXF.EQ.1).OR.(NFLUXB.EQ.1).OR.(NFLUXIB.EQ.1)
      &     .OR.(NFLUXGBC.EQ.1).OR.(NFLUXRBC.EQ.1)) THEN
          NBDJ=NBV(1)
-         IF (LBCODEI(1).LE.29) QFORCEJ=(QN2(1)-QN0(1))/DT2 +
-     &        Tau0VAR(NBDJ)*QN1(1)
+         IF ((LBCODEI(1).LE.29).OR.(LBCODEI(1).EQ.64))    ! 64 is added for VEW  08-11-2022 SB
+     &        QFORCEJ=(QN2(1)-QN0(1))/DT2 + Tau0VAR(NBDJ)*QN1(1)
 
          IF (LBCODEI(1).EQ.30) THEN
             H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
@@ -1630,8 +1657,8 @@ C
             NBDJ=NBV(J)
             QFORCEI=QFORCEJ
 
-            IF(LBCODEI(J).LE.29) QFORCEJ=(QN2(J)-QN0(J))/DT2+
-     &           Tau0VAR(NBDJ)*QN1(J)
+            IF((LBCODEI(J).LE.29).OR.(LBCODEI(J).EQ.64))     ! 64 is added for VEW  08-11-2022 SB
+     &           QFORCEJ=(QN2(J)-QN0(J))/DT2 + Tau0VAR(NBDJ)*QN1(J)
             IF(LBCODEI(J).EQ.30) THEN
                H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
                CELERITY=SQRT(G*H1)
@@ -1727,6 +1754,118 @@ C... DW, periodic bcs
       if (subdomainOn.and.enforceBN.eq.2) call enforceEib() ! NCSU Subdomain
       if (subdomainOn.and.enforceBN.eq.2) call enforceGWCELVob() ! NCSU Subdomain
 
+C<<.. SECTION FOR VEW1D (=1D channel)   08-11-2022 SB
+C.... Nodal equations at IBTYPE=64 VEW boundary nodes and at condensed nodes are
+C.... summed up together in the following part. First, the value on the front side,
+C.... i.e., the floodplain side, is summed to the back side, i.e., the channel side.
+C.... Secondly, the values at the condensed nodes which are most likely on channel
+C.... beds are summed together. Notice that by this second step the nodes on channel
+C.... bed hold the sum of all the values on the floodplain side and the grouped 
+C.... condensed nodes. And then finally, the value on the backside, i.e. on the
+C.... channel bed, is copied to the front side, i.e., the floodplain side. Through
+C.... this procedure, the values at the floodplain nodes and (condensed) channel nodes
+C.... have the same values on both sides of the equations.
+C
+C.... Prep for the temporary LHS lumped array
+      IF(((NFLUXIB64_GBL.GT.0).AND.(ILump.NE.0)).OR.
+     &   (LoadCondensedNodes)) THEN
+         COEFDTemp => COEFDTempMem
+         COEFDTemp(:) = COEFD(:)
+      ELSE
+         COEFDTemp => COEFD
+      ENDIF
+C
+C     VEW: Sum front side values to back side
+      IF((NFLUXIB64_GBL.GT.0).AND.(ILump.NE.0)) THEN
+         I = 0                         
+         DO K = 1, NBOU
+            SELECT CASE(LBCODEI(I+1))
+                CASE(64)
+                    DO J = 1,NVELL(K)
+                        I = I + 1
+                        IF(ISSUBMERGED64(I).NE.0) THEN
+                           NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
+                           NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
+                           IF(NODECODE(NNBB1).NE.0.AND.NODECODE(NNBB2).NE.0) THEN
+                               COEFDTemp(NNBB2) =
+     &                           COEFD(NNBB1) + COEFD(NNBB2)
+                               GWCE_LV(NNBB2) =
+     &                           GWCE_LV(NNBB1) + GWCE_LV(NNBB2)
+                               ETA1(NNBB2) =
+     &                           ( ETA1(NNBB1) + ETA1(NNBB2) ) * 0.5D0
+                               GWCE_LV(NNBB1) = 0.D0  ! Set zero to avoid duplicated additions
+                               ETA1(NNBB1) = ETA1(NNBB2) ! Substitute here to make duplicated averaging ineffective
+                           ENDIF
+                        ENDIF
+                     ENDDO
+                     I = I + NVELL(K)
+                  CASE(4,24,5,25)
+                     I = I + NVELL(K)*2
+                  CASE DEFAULT
+                     I = I + NVELL(K)
+            END SELECT
+         ENDDO
+      ENDIF
+
+C.... CONDENSED NODES: Summing up the values at condensed nodes
+      IF((LoadCondensedNodes).AND.(ILump.NE.0)) THEN
+         DO K=1,NListCondensedNodes
+            I = ListCondensedNodes(K,1)
+            IF((NODECODE(I).NE.0)) THEN
+               ! 1) Sum them up
+               DO L=2,NNodesListCondensedNodes(K)
+                  J = ListCondensedNodes(K,L)
+                  COEFDTemp(I) = COEFDTemp(I) + COEFDTemp(J)
+                  GWCE_LV(I)   = GWCE_LV(I) + GWCE_LV(J)
+                  ETA1(I)      = ETA1(I) + ETA1(J)
+               ENDDO
+               ! 2) Distribute them
+               ETA1(I) = ETA1(I) / NNodesListCondensedNodes(K)
+               DO L=2,NNodesListCondensedNodes(K)
+                  J = ListCondensedNodes(K,L)
+                  COEFDTemp(J) = COEFDTemp(I)
+                  GWCE_LV(J)   = GWCE_LV(I)
+                  ETA1(J)      = ETA1(I)
+               ENDDO
+            ENDIF
+         ENDDO
+      ENDIF
+
+#ifdef CMPI
+      IF ((NFLUXIB64_GBL.GT.0.OR.LoadCondensedNodes)
+     &    .AND.(ILump.NE.0)) THEN
+         CALL UPDATER(COEFDTemp,GWCE_LV,DUMY1,2)
+      ENDIF
+#endif      
+      
+C     VEW: Copy values from back side to front side
+      IF((NFLUXIB64_GBL.GT.0).AND.(ILump.NE.0)) THEN
+         I = 0                         
+         DO K = 1, NBOU
+            SELECT CASE(LBCODEI(I+1))
+                CASE(64)
+                    DO J = 1,NVELL(K)
+                        I = I + 1
+                        IF(ISSUBMERGED64(I).NE.0) THEN
+                           NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
+                           NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
+                           IF(NODECODE(NNBB1).NE.0.AND.NODECODE(NNBB2).NE.0) THEN
+                              COEFDTemp(NNBB1) = COEFDTemp(NNBB2)
+                              GWCE_LV(NNBB1) = GWCE_LV(NNBB2)
+                              ETA1(NNBB1) = ETA1(NNBB2)
+                           ENDIF
+                        ENDIF
+                     ENDDO
+                     I = I + NVELL(K)
+                  CASE(4,24,5,25)
+                     I = I + NVELL(K)*2
+                  CASE DEFAULT
+                     I = I + NVELL(K)
+            END SELECT
+         ENDDO
+      ENDIF
+C..>>
+
       IF (ILump.eq.0) THEN ! default, fully consistent LHS
 C...  JCG ITERATIVE MATRIX SOLVER
          IPARM(1)=ITMAX
@@ -1738,10 +1877,10 @@ C...  JCG ITERATIVE MATRIX SOLVER
          END DO
       ELSE ! lumped LHS
          DO I = 1, NP
-            IF (COEFD(I).eq.0.0d0) THEN
+            IF (COEFDTemp(I).eq.0.0d0) THEN   ! COEFD --> COEFDTemp  08-11-2022 SB
                RDIAG = 0.0d0
             ELSE
-               RDIAG = 1.0d0 / COEFD(I)
+               RDIAG = 1.0d0 / COEFDTemp(I)   ! COEFD --> COEFDTemp  08-11-2022 SB
             ENDIF
             ETAS(I) = GWCE_LV(I) * RDIAG
          ENDDO
@@ -2743,8 +2882,9 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
       IF((NFLUXF.EQ.1).OR.(NFLUXB.EQ.1).OR.(NFLUXIB.EQ.1)
      &     .OR.(NFLUXGBC.EQ.1).OR.(NFLUXRBC.EQ.1)) THEN
          NBDJ=NBV(1)
-         IF(LBCODEI(1).LE.29) QFORCEJ=(QN2(1)-QN0(1))/DT2 +
-     &        Tau0VAR(NBDJ)*QN1(1)
+         IF((LBCODEI(1).LE.29).OR.(LBCODEI(1).EQ.64))     ! 64 is added for VEW  08-22-2022 SB
+     &        QFORCEJ=(QN2(1)-QN0(1))/DT2 +
+     &          Tau0VAR(NBDJ)*QN1(1)
 
          IF(LBCODEI(1).EQ.30) THEN
             H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
@@ -2768,8 +2908,8 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
             NBDJ=NBV(J)
             QFORCEI=QFORCEJ
 
-            IF(LBCODEI(J).LE.29) QFORCEJ=(QN2(J)-QN0(J))/DT2+
-     &           Tau0VAR(NBDJ)*QN1(J)
+            IF((LBCODEI(J).LE.29).OR.(LBCODEI(J).EQ.64))     ! 64 is added for VEW  08-22-2022 SB
+     &         QFORCEJ=(QN2(J)-QN0(J))/DT2+Tau0VAR(NBDJ)*QN1(J)
 
             IF(LBCODEI(J).EQ.30) THEN
                H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)

--- a/src/mesh.F
+++ b/src/mesh.F
@@ -237,7 +237,7 @@
              numSimpleFluxBoundaries = numSimpleFluxBoundaries + 1
          case(3,13,23)
              numExternalFluxBoundaries = numExternalFluxBoundaries + 1
-         case(4,24)
+         case(4,24,64)
              numInternalFluxBoundaries = numInternalFluxBoundaries + 1
              ! jgf51.52.24: added nvell(k) for boundaries with backside
              ! nodes, since these are to be included in nvel.
@@ -462,7 +462,7 @@
          ! paired node number, the barrier elevation above the Geoid and the
          ! coefficients of supercritical and subcritical flow for the nodes
          ! in the Kth boundary segment.
-         case(4,24)
+         case(4,24,64)
             internalFluxBoundaries(ifCount)%indexNum = k
             do j = 1, nvell(k)
                read(unit=iunit,fmt=*,err=10,end=20,iostat=ios)
@@ -1040,7 +1040,7 @@
                   numSimpleFluxBoundaries = numSimpleFluxBoundaries + 1
                case(3,13,23)
                   numExternalFluxBoundaries = numExternalFluxBoundaries + 1
-               case(4,24)
+               case(4,24,64)
                   numInternalFluxBoundaries = numInternalFluxBoundaries + 1
                case(5,25)
                   numInternalFluxBoundariesWithPipes = numInternalFluxBoundariesWithPipes + 1
@@ -1196,7 +1196,7 @@
                   end select
                end do
                efCount = efCount + 1
-            case(4,24)  ! internal barrier boundary (e.g., subgrid scale levee)
+            case(4,24,64)  ! internal barrier boundary (e.g., subgrid scale levee)
                internalFluxBoundaries(ifCount)%indexNum = fluxCount
                ! get the node numbers on the boundary
                call xdmfRetrieveSetValues(xdmfFortranObj, setIndex,
@@ -1366,7 +1366,7 @@
             barlancfspr(fluxCount,1:nvell(fluxCount)) =
      &               externalFluxBoundaries(efCount)%barlancfsp
             efCount = efCount + 1
-         case(4,24)  ! internal barrier boundary (e.g., subgrid scale levee)
+         case(4,24,64)  ! internal barrier boundary (e.g., subgrid scale levee)
             ! populate adcirc-native arrays
             nbvv(fluxCount,1:nvell(fluxCount)) =
      &             internalFluxBoundaries(ifCount)%nodes
@@ -1776,6 +1776,9 @@
       subroutine initializeBoundaries()
       use global, only : deg2rad, rad2deg, nbfr, c2ddi, pi, ifsprots
       use boundaries
+#ifdef CMPI
+      USE MESSENGER, ONLY : msg_imax  !sb msg_imax added 10/13/2022
+#endif
       implicit none
       integer  nprbi, nbvk
       integer i, j, k, n, ick, iprbi !local loop counters
@@ -1873,6 +1876,7 @@
       NFLUXB=0
       NFLUXIB=0
       NFLUXIBP=0
+      NFLUXIB64=0
       NFLUXRBC=0
       NFLUXGBC=0
       NVELEXT=0
@@ -1881,7 +1885,8 @@
       ! each segment and setting up boundary arrays
       NBOULOOP: DO K=1,NBOU
 !        write out flow boundary information to unit 16
-         IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24)) THEN
+         IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24).OR.
+     &      (IBTYPE(K).EQ.64)) THEN
             WRITE(16,28) K,NVELL(K),K,2*NVELL(K)
  28         FORMAT(///,5X,'TOTAL NUMBER OF PAIRS FOR FLOW BOUNDARY',
      &           ' SEGMENT',2X,i0,2X,'=',2X,i0,
@@ -1906,7 +1911,7 @@
      &           7X,'AND FREE TANGENTIAL SLIP',/)
          CASE(2)
             NFLUXF=1
-            WRITE(16,2342)
+            WRITE(16,2342) 
  2342       FORMAT(5X,'THIS SEGMENT IS AN EXTERNAL BOUNDARY WITH:',/,
      &           7X,'SPECIFIED NORMAL FLOW AS AN ESSENTIAL B.C.',/,
      &           7X,'AND FREE TANGENTIAL SLIP',/)
@@ -2114,6 +2119,24 @@
      &          7X,'The momentum equations are used to compute the',/,
      &          7X,'velocity field the same as for a nonboundary ',
      &          'node.',/)
+         CASE(64)
+           NFLUXIB=1
+           NFLUXIB64=1
+           WRITE(16,6533)
+ 6533      FORMAT(5X,'THIS SEGMENT IS AN VERTICAL ELEMENT WALL BOUNDARY:',/,
+     &            7X,'EACH NODE PAIR IS TREATED AS IF THEY ARE A SINGL',
+     &               'E NODE IF THE WATER HEIGHTS ON BOTH SIDES',/,
+     &            7X,'EXCEED THE BARRIER HEIGHTS.',/,
+     &            7X,'OTHERWISE, WITH CROSS BARRIER FLOW TREATED ',
+     &               ' AS A NATURAL NORMAL FLOW BOUNDARY CONDITION',/,
+     &            7X,'WHICH LEAVES/ENTERS THE DOMAIN ON ONE SIDE OF ',
+     &               ' THE BARRIER AND ENTERS/LEAVES THE DOMAIN ON THE',
+     &          /,7X,'CORRESPONDING OPPOSITE SIDE OF THE BARRIER ',/,
+     &            7X,'FLOW RATE AND DIRECTION ARE BASED ON BARRIER ',
+     &               ' HEIGHT, SURFACE WATER ELEVATION',/,
+     &            7X,'ON BOTH SIDES OF THE BARRIER, BARRIER COEFFICIEN',
+     &               'T AND THE APPROPRIATE BARRIER FLOW FORMULA',/,
+     &            7X,'FREE TANGENTIAL SLIP IS ALLOWED.',/)
          END SELECT
          !
          ! set the constants used in setting up the boundary arrays
@@ -2121,7 +2144,7 @@
          case(3,13,23)
             nprbi = 1
             npipe = 0
-         case(4,24)
+         case(4,24,64)
             nprbi = 2
             npipe = 0
          case(5,25)
@@ -2173,7 +2196,8 @@
             ENDIF
 
 !...        WRITE OUT ADDITIONAL HEADER FOR INTERNAL BARRIER BOUNDARIES
-            IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24)) THEN
+            IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24).OR.
+     &         (IBTYPE(K).EQ.64)) THEN
                IF(IPRBI.EQ.1) THEN
                   WRITE(16,1842)
  1842            FORMAT(/,5X,'FRONT FACE OF INTERNAL BARRIER BOUNDARY',/)
@@ -2499,7 +2523,8 @@
      &                       (LBCODEI(JGW).EQ.32).OR.
      &                       (LBCODEI(JGW).EQ.40).OR.
      &                       (LBCODEI(JGW).EQ.41).OR.
-     &                       (LBCODEI(JGW).EQ.52)) ME2GW(JME)=JGW
+     &                       (LBCODEI(JGW).EQ.52).OR.
+     &                       (LBCODEI(JGW).EQ.64)) ME2GW(JME)=JGW
                      ENDIF
                   ENDIF
                ENDIF
@@ -2524,7 +2549,8 @@
      &                    (LBCODEI(JGW).EQ.32).OR.
      &                    (LBCODEI(JGW).EQ.40).OR.
      &                    (LBCODEI(JGW).EQ.41).OR.
-     &                    (LBCODEI(JGW).EQ.52)) ME2GW(1)=JGW
+     &                    (LBCODEI(JGW).EQ.52).OR.
+     &                    (LBCODEI(JGW).EQ.64)) ME2GW(1)=JGW
                   ENDIF
                ENDIF
 
@@ -2536,7 +2562,8 @@
                ENDIF
 
 !...........   LOAD INTERNAL BARRIER BOUNDARY INFORMATION INTO THE CORRECT VECTORS
-               IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24)) THEN
+               IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24).OR.
+     &            (IBTYPE(K).EQ.64)) THEN
                   IBCONN(JGW)=IBCONNR(K,I)
                   BARINHT(JGW)=BARINHTR(K,I)
                   BARINCFSB(JGW)=BARINCFSBR(K,I)
@@ -2583,7 +2610,8 @@
                   ENDIF
                ENDIF
 !...........   CHECK INTERNAL BARRIER HEIGHTS AGAINST DEPTHS
-               IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24)) THEN
+               IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24).OR.
+     &            (IBTYPE(K).EQ.64)) THEN
                   IF(BARINHT(JGW).LT.-DP(NBV(JGW))) THEN
                      write(scratchMessage,8368)
      &                    JGW,NBV(JGW),BARINHT(JGW),DP(NBV(JGW))
@@ -2645,7 +2673,7 @@
 !...  ANY EXTERNAL BARRIER BOUNDARY. IF THIS DOES OCCUR, TAKE
 !...  APPROPRIATE ACTION
                IF((IBTYPE(K).EQ.4).OR.(IBTYPE(K).EQ.24).OR.
-     &              (IBTYPE(K).EQ.5)
+     &              (IBTYPE(K).EQ.64).OR.(IBTYPE(K).EQ.5)
      &              .OR.(IBTYPE(K).EQ.25)) THEN
                   DO ICK=1,NVELEXT
 !...  CHECK IF OVERLAP EXISTS
@@ -2702,7 +2730,8 @@
      &               '(NATURAL NO NORMAL FLOW WITH SLIP BOUNDARY) ')
                            LBCODEI(ICK)=20
                         ENDIF
-                        IF(((IBTYPE(K).EQ.24).AND.(LBCODEI(ICK).EQ.10))
+                        IF((((IBTYPE(K).EQ.24).OR.(IBTYPE(K).EQ.64))
+     &                       .AND.(LBCODEI(ICK).EQ.10))
      &                       .OR.((IBTYPE(K).EQ.25)
      &                       .AND.(LBCODEI(ICK).EQ.10))) THEN
                            WRITE(16,8570) JGW,ICK,ICK
@@ -2725,6 +2754,12 @@
             END DO NVELL_LOOP ! I = 1,NVELL(K)
          END DO  LOOPPRBI !IPRBI=1,NPRBI
       END DO NBOULOOP  ! K=1,NBOU
+
+Csb...10/13/2022 moved from an earlier section
+      IF (ALLOCATED(ISSUBMERGED64)) THEN
+         ISSUBMERGED64(:) = 0
+      ENDIF
+Csb...
 
 !...  ONCE ALL FLOW BOUNDARY NODES HAVE BEEN PROCESSED, CHECK TO MAKE
 !...  SURE THAT JGW LE MNVEL.  NOTE, JME MUST BE < JGW.
@@ -2817,7 +2852,8 @@
      &                4X,'SUB-CRIT. INT. BAR. COEF.',
      &                4X,'SUPER-CRIT. INT. BAR. COEF.',/)
          DO J=1,NVEL
-            IF((LBCODEI(J).EQ.4).OR.(LBCODEI(J).EQ.24)) THEN
+            IF((LBCODEI(J).EQ.4).OR.(LBCODEI(J).EQ.24).OR.
+     &         (LBCODEI(J).EQ.64)) THEN
                WRITE(16,2325) NBV(J),IBCONN(J),BARINHT(J),
      &                       BARINCFSB(J),BARINCFSP(J)
  2325         FORMAT(5X,i0,7X,i0,6X,F14.5,12X,F12.3,17X,F12.3)
@@ -2861,6 +2897,15 @@
             ENDIF
          END DO
       ENDIF
+
+!sb...
+#ifdef CMPI
+      nfluxib64_gbl = msg_imax(nfluxib64)
+#else
+      nfluxib64_gbl = nfluxib64
+#endif
+!sb...
+
 !jjwm001 - end add
       ! jgf51.11.18: Free memory associated with the reading of the
       ! levee and culvert parameters since it is no longer needed
@@ -5458,7 +5503,21 @@ C
         
         RETURN ; 
       END SUBROUTINE COMPUTE_CYLINPROJ_SFAC
-!.....
+
+!-----------------------------------------------------------------------
+      function findIBTYPEAtNode(I) RESULT(IBTYPE)
+!-----------------------------------------------------------------------
+      use boundaries,only : LBCODEI
+      implicit none
+      integer,intent(in) :: i
+      integer :: j,ibtype
+      ibtype = -1
+      j = lbarray_pointer(i)
+      if (j > 0) then
+         ibtype = lbcodei(j)
+      end if
+      end function findIBTYPEAtNode
+      
 !     ------------------------------------------------------------------
       end module mesh
 !     ------------------------------------------------------------------

--- a/src/messenger.F
+++ b/src/messenger.F
@@ -49,6 +49,7 @@ C  Message-Passing Array space
       INTEGER, ALLOCATABLE :: STAT_I1(:,:), STAT_I2(:,:)
       INTEGER, ALLOCATABLE :: REQ_R1(:), REQ_R2(:), REQ_R3(:)
       INTEGER, ALLOCATABLE :: STAT_R1(:,:), STAT_R2(:,:), STAT_R3(:,:)
+      INTEGER, ALLOCATABLE :: REQ_M4R(:), STAT_M4R(:,:) !sb 10/13/2022
       INTEGER, ALLOCATABLE :: REQ_R3D(:), STAT_R3D(:,:)
       INTEGER, ALLOCATABLE :: REQ_C3D(:), STAT_C3D(:,:)
       INTEGER, ALLOCATABLE :: INDX(:)
@@ -522,6 +523,8 @@ C
       ALLOCATE ( STAT_R1(MPI_STATUS_SIZE,RDIM),
      &           STAT_R2(MPI_STATUS_SIZE,RDIM),
      &           STAT_R3(MPI_STATUS_SIZE,RDIM) )
+      ALLOCATE ( REQ_M4R(RDIM) ) !sb 10/13/2022
+      ALLOCATE ( STAT_M4R(MPI_STATUS_SIZE,RDIM) ) !sb 10/13/2022
 
       IF (C3D) THEN
          ALLOCATE ( SENDBUF(2*MNP*MNFEN,NEIGHPROC) )
@@ -656,7 +659,7 @@ C---------------------------------------------------------------------
 C---------------------------------------------------------------------
 C     S U B R O U T I N E   U P D A T E R
 C---------------------------------------------------------------------
-C  Update 1, 2, or 3 Integer Arrays's Ghost Cells using asynchronous
+C  Update 1, 2, or 3 Real Arrays's Ghost Cells using asynchronous
 C  and persistent message-passing.
 C
 C  vjp  8/06/1999
@@ -824,6 +827,103 @@ cdebug     print *, myproc, tot,nfini,INDX(1),INDX(2)
       RETURN
 C--------------------------------------------------------------------- 
       END SUBROUTINE UPDATER
+C---------------------------------------------------------------------
+
+C---------------------------------------------------------------------
+C     S U B R O U T I N E   U P D A T E M A T 4 R
+C---------------------------------------------------------------------
+C  Update a 4-row real matrix's ghost cells using asynchronous
+C  and persistent message-passing.
+C
+C  sb  10/13/2022
+C---------------------------------------------------------------------
+      SUBROUTINE UPDATEM4R( M4R )
+#ifndef HAVE_MPI_MOD
+      include 'mpif.h'
+#endif
+      REAL(SZ), INTENT(INOUT) ::  M4R(:,:)
+      integer :: j  ! loop counter for neighboring subdomains
+      integer :: i  ! loop counter for nodes shared with a neighboring subdomain
+      integer :: nfini ! number of just-completed requests
+      integer :: n     ! loop counter for just-completed requests
+      integer :: tot   ! total number of completed requests
+      integer :: ncount ! num values passed to a particular subdomain neighbor
+      integer :: ir ! loop counter for rows
+C
+      call setMessageSource("updater")
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Enter.") 
+#endif
+C 
+      ! 
+      ! loop over neighboring subdomains
+      DO J=1,NEIGHPROC
+         NCOUNT = 0
+         DO IR=1,4
+            ! loop over nodes shared as ghost nodes with this neighboring subdomain
+            DO I=1,NNODSEND(J)
+                  NCOUNT = NCOUNT+1
+                  ! store the matrix values in the send buffer            
+                  SENDBUF(NCOUNT,J)=M4R(IR,ISENDLOC(I,J))
+            ENDDO
+         ENDDO
+      ENDDO
+      IF (NCOUNT > MNP) THEN
+         WRITE(*,'(A)') 
+     &     'INSUFFICIENT MEMORY ALLOCATION FOR SENDBUF. TERMINATING.'
+         CALL MSG_FINI()
+         STOP
+      ENDIF
+      !
+      ! receive and send data to each neighboring subdomain, populating
+      ! the request handler array
+      DO J=1,NEIGHPROC
+         CALL MPI_IRECV( RECVBUF(1,J), 4*NNODRECV(J),
+     &      REALTYPE,IPROC(J), TAG, COMM, REQ_M4R(J),IERR)
+         CALL MPI_ISEND( SENDBUF(1,J), 4*NNODSEND(J),
+     &      REALTYPE,IPROC(J), TAG, COMM, REQ_M4R(J+NEIGHPROC),IERR)
+      ENDDO
+
+      TOT = 0
+      ! keep looping until the total number of completed communications 
+      ! equals the total number that were requested
+      DO WHILE (TOT.LT.RDIM)
+         DO N=1, RDIM
+            INDX(N) = 0 ! zero out the array of just-completed requests
+         ENDDO
+         CALL MPI_WAITSOME( RDIM,REQ_M4R,NFINI,INDX,STAT_M4R,IERR )
+         ! add the number of just-completed requests to the total
+         TOT = TOT + NFINI
+         ! loop over the just-completed requests
+         DO N=1, NFINI
+            ! if the request has just completed (TODO: I don't see how
+            ! indx(n) can be greater than rdim
+            IF (INDX(N).GT.0.AND.INDX(N).LE.RDIM)  THEN
+               ! if the request that just completed is a receive
+               IF (INDX(N).LE.NEIGHPROC) THEN
+                  ! j = subdomain neighbor number that sent this data
+                  J = INDX(N)
+                  NCOUNT = 0
+                  DO IR=1,4
+                     DO I=1,NNODRECV(J)
+                        NCOUNT = NCOUNT+1
+                        ! update this subdomain's ghost value with the real 
+                        ! value from the other subdomain
+                        M4R(IR,IRECVLOC(I,J)) = RECVBUF(NCOUNT,J)
+                     ENDDO
+                  ENDDO
+               ENDIF
+            ENDIF
+         ENDDO
+      ENDDO
+ 
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Return.")
+#endif
+      call unsetMessageSource()
+      RETURN
+C--------------------------------------------------------------------- 
+      END SUBROUTINE UPDATEM4R
 C---------------------------------------------------------------------
 
 C..... DW:, for periodic bcs (this subroutine looks a bit ugly and probably does belongs here)
@@ -1034,6 +1134,36 @@ C---------------------------------------------------------------------
       END SUBROUTINE UPDATEC3D
 C---------------------------------------------------------------------
 
+C---------------------------------------------------------------------
+C     F U N C T I O N   M S G _ M A X
+C---------------------------------------------------------------------
+C  Find a maximum integer value
+C---------------------------------------------------------------------
+      function msg_imax( v ) result(vmax)
+#ifndef HAVE_MPI_MOD
+      include 'mpif.h'
+#endif
+      integer n, i
+      integer kount
+      integer v, vmax
+C
+      call setMessageSource("psdot")
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Enter.") 
+#endif
+C 
+      kount = 1
+      call MPI_ALLREDUCE( v, vmax, kount, MPI_INTEGER,
+     &     MPI_MAX, COMM, ierr)
+
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Return.")
+#endif
+      call unsetMessageSource()
+      return
+C---------------------------------------------------------------------      
+      end function msg_imax
+C---------------------------------------------------------------------
 
 C---------------------------------------------------------------------
 C     F U N C T I O N   P S D O T

--- a/src/momentum.F
+++ b/src/momentum.F
@@ -152,26 +152,41 @@ C*******************************************************************************
      &  VIDBCPDYOH, QN2, MOM_LV_X, MOM_LV_Y, TKM, NPERSEG, NNPERBC, 
      &  IPERCONN, VIDispDXOH, VIDispDYOH, IFSFM, adcirc_norm2, CAliDisp,
      &  usingDynamicWaterLevelCorrection, Cs2, Ad, Bd, G, windlim,
-     &  dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, H0
+     &  dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, H0,
+     &  flgNodesMultipliedByTotalArea, ilump
+#ifdef CMPI
+     &  , dumy1
+#endif
       USE MESH, ONLY : NE, NP, NM, DP, Areas, TotalArea,
      &     NNeigh, NeiTab, NeiTabEle, MJU, FDXE, FDYE,
-     &     SWITCH_ELTAB_PERBC, SFacEle, SFMYEle, SFMXEle, TANPHI 
+     &     SWITCH_ELTAB_PERBC, SFacEle, SFMYEle, SFMXEle, TANPHI,
+     &     X, Y
       USE BOUNDARIES, ONLY : NFLUXGBC, NVELME, ME2GW, NBV, LBCODEI,
+     &    NBOU, NVELL, IBCONN, ISSUBMERGED64, NFLUXIB, NFLUXIB64_GBL,
      &    CSII, SIII, NEleZNG, ZNGIF1, ZNGIF2, ZNGIF3                 
       USE NodalAttributes, ONLY: EVM,LoadAdvectionState,advectlocal,
      &     NOLIBF,
 C----- DW: begin !c absorbing layer
      &     LoadAbsLayerSigma, absorblayer_sigma_eta,
-     &     absorblayer_sigma_mnx, absorblayer_sigma_mny
+     &     absorblayer_sigma_mnx, absorblayer_sigma_mny,
 C----- END DW
+     &     LoadCondensedNodes, CondensedNodes, NCondensedNodes,
+     &     ListCondensedNodes, NListCondensedNodes,
+     &     NNodesListCondensedNodes
       USE SUBDOMAIN, ONLY : subdomainOn, enforceBN, enforceUVOB, 
      &                       enforceUVCB
       USE SPONGELAYER
       USE WIND, ONLY: PRBCKGRND_MH2O, windLimiter 
+C... SB
+      USE VEW1D, ONLY :
+     &     ROTATE_AT_CONDENSEDNODES_ALL,
+     &     ROTATEBACK_AT_CONDENSEDNODES_ALL,
+     &     REMOVE_NORMAL_AT_CONDENSEDNODES
+C... SB
 
       IMPLICIT NONE
 
-      INTEGER IE, I, J, N                           !local loop counters
+      INTEGER IE, I, J, N, K, L                       !local loop counters
       INTEGER  NM1, NM2, NM3
       INTEGER NC1, NC2, NC3, NCEle, NCI
       INTEGER NBDI
@@ -218,6 +233,19 @@ C..... DW
       REAL(SZ):: pr1_NM1, pr1_NM2, pr1_NM3
       REAL(SZ):: pr2_NM1, pr2_NM2, pr2_NM3
 C......DW
+C..... SB
+      INTEGER:: NNBB1, NNBB2
+      INTEGER:: NCIBC
+      INTEGER:: IA1, IA2, IB1, IB2
+      INTEGER:: ROT_STATUS
+      REAL(SZ):: fBUF1, fBUF2
+      REAL(SZ):: COEFIB64
+      REAL(SZ):: CS, SI, CSCS, CSSI, SISI ! cos, sin, cos*cos, cos*sin (=sin*cos), sin*sin
+      REAL(SZ):: SX, SY, LEN
+C.....
+C......SB For Elemental summation form
+      REAL(SZ):: TotalArea1, TotalArea2
+C......
       call setMessageSource("mom_eqs_new_nc")
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Enter.")
@@ -275,6 +303,17 @@ Corbitt 120322: Localized Advection
          QY1N1=QY1(NM1)
          QY1N2=QY1(NM2)
          QY1N3=QY1(NM3)
+C..... SB
+C        For condensed nodes 2022-09-14
+C        Remove the normal component of the load vector at the condensed nodes
+         IF (LoadCondensedNodes) THEN
+            CALL ROTATE_AT_CONDENSEDNODES_ALL
+     &        (NM1,NM2,NM3,
+     &         U1N1,V1N1,U1N2,V1N2,U1N3,V1N3,
+     &         QX1N1,QY1N1,QX1N2,QY1N2,QX1N3,QY1N3,
+     &         ROT_STATUS)
+         ENDIF
+C..... SB
          SFacAvg = SFacEle(IE)
 C..... BEG DW/WJP
          SFmxAvg= SFMXEle(IE) ; 
@@ -601,6 +640,19 @@ C...  LATERAL VISCOUS TERMS
 C...  STILL NEED TO DIVIDE BY TOTAL AREA AROUND A NODE
      &             )
 
+C... SB 2022-09-14
+C        For condensed nodes
+C        Remove the normal component of the load vector at the condensed nodes
+         IF (LoadCondensedNodes.AND.ROT_STATUS.EQ.0) THEN
+            CALL ROTATEBACK_AT_CONDENSEDNODES_ALL
+     &        (NM1,NM2,NM3,
+     &         TEMP_LV_A1,TEMP_LV_B1,
+     &         TEMP_LV_A2,TEMP_LV_B2,
+     &         TEMP_LV_A3,TEMP_LV_B3,
+     &         ROT_STATUS)
+         ENDIF
+Csb...
+
 C     Original (incorrect) area integration - for historical comparison
 
          IF (CME_AreaInt_Orig) THEN
@@ -716,6 +768,19 @@ C        WJP 05.28.2019: Add the Spherical coordinate correction term
 C        (refer; Kolar et al., 1994, doi:10.1080/00221689409498786)
 C        Equation (41) [refer also Eq. (37)]
          CorifA  = CORIF(I) + IFNLCT*TANPHI(I)*UU1(I)
+
+Csb...   For condensed nodes 2022-08-22
+C        Remove the normal component of the load vector at the condensed nodes
+         IF (LoadCondensedNodes) THEN
+            CALL REMOVE_NORMAL_AT_CONDENSEDNODES
+     &           (MOM_LV_X(I),MOM_LV_Y(I),I,ROT_STATUS)
+            IF (ROT_STATUS.EQ.0) THEN
+               CALL REMOVE_NORMAL_AT_CONDENSEDNODES
+     &           (WSX,WSY,I,ROT_STATUS)
+               CorifA = 0.D0    ! Coriolis force is removed here.
+            ENDIF
+         ENDIF
+Csb...
          VCOEFXY = DTO2*(TKM(3,I) - CorifA)
          VCOEFYX = DTO2*(TKM(3,I) + CorifA)
       
@@ -745,11 +810,10 @@ C...     DW, absorbing layers
 C...     DW
 
 C        WJP 02.24.2018 Get the lefthand side momentum 
-         AUV(1,I) = 1d0 + VCOEFXX*NCI
-         AUV(2,I) = 1d0 + VCOEFYY*NCI
-         AUV(3,I) = VCOEFXY*NCI
-         AUV(4,I) = VCOEFYX*NCI
-      
+        AUV(1,I) = 1d0 + VCOEFXX*NCI
+        AUV(2,I) = 1d0 + VCOEFYY*NCI
+        AUV(3,I) = VCOEFXY*NCI
+        AUV(4,I) = VCOEFYX*NCI
       END DO
 
 C...  Modify the momentum equations to impose velocity boundary
@@ -884,6 +948,189 @@ C.....DW
          ENDIF
 
       ENDDO
+
+C<<.. SECTION FOR VEW1D (=1D channel)   08-11-2022 SB
+C.... Nodal equations at IBTYPE=64 VEW boundary nodes and at condensed nodes are
+C.... summed up together in the following part. First, the value on the front side,
+C.... i.e., the floodplain side, is summed to the back side, i.e., the channel side.
+C.... Secondly, the values at the condensed nodes which are most likely on channel
+C.... beds are summed together. Notice that by this second step the nodes on channel
+C.... bed hold the sum of all the values on the floodplain side and the grouped 
+C.... condensed nodes. And then finally, the value on the backside, i.e. on the
+C.... channel bed, is copied to the front side, i.e., the floodplain side. Through
+C.... this procedure, the values at the floodplain nodes and (condensed) channel nodes
+C.... have the same values on both sides of the equations.
+C 
+C     
+
+C     VEW: Sum front side values to back side
+      IF((NFLUXIB64_GBL.GT.0).AND.(ILUMP.NE.0)) THEN
+         flgNodesMultipliedByTotalArea(:) = 0  ! Initialize flags for nodes multiplied by total areas
+
+         I = 0                         
+         DO K = 1, NBOU
+            SELECT CASE(LBCODEI(I+1))
+               CASE(64)
+               DO J = 1,NVELL(K)
+                  I = I + 1
+                  IF(ISSUBMERGED64(I).NE.0) THEN
+                     NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
+                     NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
+              
+                     IF(NODECODE(NNBB1).NE.0.AND.NODECODE(NNBB2).NE.0) THEN
+                        IF ((flgNodesMultipliedByTotalArea(NNBB1).eq.0).and.
+     &                      (TotalArea(NNBB1).ne.0.d0)) THEN
+                           IF (CME_AreaInt_Corr) THEN       !Correct area integration
+                              TotalArea1 = TotalArea(NNBB1)
+                           ENDIF
+                           IF (CME_AreaInt_Orig) THEN       !Original (incorrect) area integration
+                              TotalArea1 = MJU(NNBB1)
+                           ENDIF
+                        ELSE
+                           TotalArea1 = 1.D0
+                        ENDIF
+                        IF ((flgNodesMultipliedByTotalArea(NNBB2).eq.0).and.
+     &                      (TotalArea(NNBB2).ne.0.d0)) THEN
+                           IF (CME_AreaInt_Corr) THEN       !Correct area integration
+                              TotalArea2 = TotalArea(NNBB2)
+                           ENDIF
+                           IF (CME_AreaInt_Orig) THEN       !Original (incorrect) area integration
+                              TotalArea2 = MJU(NNBB2)
+                           ENDIF
+                        ELSE
+                           TotalArea2 = 1.D0
+                        ENDIF
+
+                        AUV(1,NNBB2) = TotalArea1*AUV(1,NNBB1) + TotalArea2*AUV(1,NNBB2)
+                        AUV(2,NNBB2) = TotalArea1*AUV(2,NNBB1) + TotalArea2*AUV(2,NNBB2)
+                        AUV(3,NNBB2) = TotalArea1*AUV(3,NNBB1) + TotalArea2*AUV(3,NNBB2)
+                        AUV(4,NNBB2) = TotalArea1*AUV(4,NNBB1) + TotalArea2*AUV(4,NNBB2)
+
+                        MOM_LV_X(NNBB2) =
+     &                       TotalArea1*MOM_LV_X(NNBB1) + TotalArea2*MOM_LV_X(NNBB2)
+                        MOM_LV_Y(NNBB2) =
+     &                       TotalArea1*MOM_LV_Y(NNBB1) + TotalArea2*MOM_LV_Y(NNBB2)
+
+                        AUV(1,NNBB1) = 0.D0    ! Set zero to avoid duplicated additions
+                        AUV(2,NNBB1) = 0.D0    !
+                        AUV(3,NNBB1) = 0.D0    !
+                        AUV(4,NNBB1) = 0.D0    !
+                        MOM_LV_X(NNBB1) = 0.D0 !
+                        MOM_LV_Y(NNBB1) = 0.D0 !
+                        
+                        flgNodesMultipliedByTotalArea(NNBB1) = 1
+                        flgNodesMultipliedByTotalArea(NNBB2) = 1
+                     ENDIF
+                  ENDIF
+               ENDDO
+               I = I + NVELL(K)
+               CASE(4,24,5,25)
+               I = I + NVELL(K)*2
+               CASE DEFAULT
+               I = I + NVELL(K)
+            END SELECT    
+         ENDDO 
+      ENDIF
+
+C.... CONDENSED NODES: Summing up the values at condensed nodes
+      IF((LoadCondensedNodes).AND.(ILump.NE.0)) THEN
+         DO K=1,NListCondensedNodes
+            I = ListCondensedNodes(K,1)
+            IF((NODECODE(I).NE.0)) THEN
+               ! 1) Mutiply LHS & RHS by total area at Node I
+               IF ((flgNodesMultipliedByTotalArea(I).eq.0).and.
+     &             (TotalArea(I).ne.0.d0)) THEN
+                  IF (CME_AreaInt_Corr) THEN       !Correct area integration
+                     TotalArea1 = TotalArea(I)
+                  ENDIF
+                  IF (CME_AreaInt_Orig) THEN       !Original (incorrect) area integration
+                     TotalArea1 = MJU(I)
+                  ENDIF
+               ELSE
+                  TotalArea1 = 1.D0
+               ENDIF
+               AUV(1,I) = TotalArea1*AUV(1,I)
+               AUV(2,I) = TotalArea1*AUV(2,I)
+               AUV(3,I) = TotalArea1*AUV(3,I)
+               AUV(4,I) = TotalArea1*AUV(4,I)
+               MOM_LV_X(I) = TotalArea1*MOM_LV_X(I)
+               MOM_LV_Y(I) = TotalArea1*MOM_LV_Y(I)
+
+               ! 2) Sum them up
+               DO L=2,NNodesListCondensedNodes(K)
+                  J = ListCondensedNodes(K,L)
+                  IF ((flgNodesMultipliedByTotalArea(J).eq.0).and.
+     &               (TotalArea(J).ne.0.d0)) THEN
+                     IF (CME_AreaInt_Corr) THEN       !Correct area integration
+                        TotalArea1 = TotalArea(J)
+                     ENDIF
+                     IF (CME_AreaInt_Orig) THEN       !Original (incorrect) area integration
+                        TotalArea1 = MJU(J)
+                     ENDIF
+                  ELSE
+                     TotalArea1 = 1.D0
+                  ENDIF
+                  AUV(1,I) = AUV(1,I) + TotalArea1*AUV(1,J)
+                  AUV(2,I) = AUV(2,I) + TotalArea1*AUV(2,J)
+                  AUV(3,I) = AUV(3,I) + TotalArea1*AUV(3,J)
+                  AUV(4,I) = AUV(4,I) + TotalArea1*AUV(4,J)
+                  MOM_LV_X(I) = MOM_LV_X(I) + TotalArea1*MOM_LV_X(J)
+                  MOM_LV_Y(I) = MOM_LV_Y(I) + TotalArea1*MOM_LV_Y(J)
+               ENDDO
+
+               ! 3) Distribute them
+               DO L=2,NNodesListCondensedNodes(K)
+                  J = ListCondensedNodes(K,L)
+                  AUV(1,J) = AUV(1,I)
+                  AUV(2,J) = AUV(2,I)
+                  AUV(3,J) = AUV(3,I)
+                  AUV(4,J) = AUV(4,I)
+                  MOM_LV_X(J) = MOM_LV_X(I)
+                  MOM_LV_Y(J) = MOM_LV_Y(I)
+               ENDDO
+            ENDIF
+         ENDDO
+      ENDIF
+
+#ifdef CMPI
+      IF ((NFLUXIB64_GBL.GT.0.OR.LoadCondensedNodes)
+     &    .AND.(ILump.NE.0)) THEN
+         CALL UPDATEM4R(AUV)
+         CALL UPDATER(MOM_LV_X,MOM_LV_Y,DUMY1,2)
+      ENDIF
+#endif            
+
+C     VEW: Copy values from back side to front side
+      IF((NFLUXIB64_GBL.GT.0).AND.(ILUMP.NE.0)) THEN
+         I = 0                         
+         DO K = 1, NBOU
+            SELECT CASE(LBCODEI(I+1))
+                CASE(64)
+                    DO J = 1,NVELL(K)
+                        I = I + 1
+                        IF(ISSUBMERGED64(I).NE.0) THEN
+                           NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
+                           NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
+                           IF(NODECODE(NNBB1).NE.0.AND.NODECODE(NNBB2).NE.0) THEN
+                              AUV(1,NNBB1) = AUV(1,NNBB2)
+                              AUV(2,NNBB1) = AUV(2,NNBB2)
+                              AUV(3,NNBB1) = AUV(3,NNBB2)
+                              AUV(4,NNBB1) = AUV(4,NNBB2)
+                              MOM_LV_X(NNBB1) = MOM_LV_X(NNBB2)
+                              MOM_LV_Y(NNBB1) = MOM_LV_Y(NNBB2)
+                           ENDIF
+                        ENDIF
+                     ENDDO
+                     I = I + NVELL(K)
+                  CASE(4,24,5,25)
+                     I = I + NVELL(K)*2
+                  CASE DEFAULT
+                     I = I + NVELL(K)
+            END SELECT    
+         ENDDO 
+      ENDIF
+
+
 C...
 C...  SOLVE FOR VELOCITY AT NEW LEVEL  (s+1)
 C...

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -77,6 +77,7 @@ C      River_et_WSE          "initial_river_elevation"
 C      IT_Fric               "internal_tide_friction"
 C      OverlandReductionFactor  "overland_reduction_factor"
 C      subgridBarrier        "subgrid_barrier"
+C      CondensedNodes        "condensed_nodes"
 C
 C-----------------------------------------------------------------------
       MODULE NodalAttributes
@@ -104,6 +105,17 @@ Corbitt 120321: Allow Advection to be Turned on Locally instead of Globally
       INTEGER              :: AdvectionStateNoOfVals
       REAL(SZ)             :: AdvectionStateDefVal
       REAL(SZ),ALLOCATABLE :: AdvectionState(:)
+Csb   Specify node groups for 1D condensation.
+      LOGICAL              :: LoadCondensedNodes
+      LOGICAL              :: FoundCondensedNodes
+      CHARACTER(LEN=80)    :: CondensedNodesUnits
+      INTEGER              :: CondensedNodesNoOfVals
+      INTEGER              :: CondensedNodesDefVal(4)
+      INTEGER,ALLOCATABLE  :: CondensedNodes(:,:)
+      INTEGER,ALLOCATABLE  :: NCondensedNodes(:)
+      INTEGER,ALLOCATABLE  :: ListCondensedNodes(:,:)
+      INTEGER              :: NListCondensedNodes
+      INTEGER,ALLOCATABLE  :: NNodesListCondensedNodes(:)
 C
 C     The following flags are .true. if the corresponding data are
 C     required for the run, according to the unit 15 control file
@@ -371,6 +383,11 @@ Corbitt 120321:
       FoundAdvectionState    = .FALSE.
       AdvectionStateNoOfVals = 1
       AdvectionStateDefVal   = 0.D0
+Csb
+      LoadCondensedNodes     = .False.
+      FoundCondensedNodes    = .FALSE.
+      CondensedNodesNoOfVals = 3
+      CondensedNodesDefVal   = 0
 C
       LoadTau0           = .False.
       LoadStartDry       = .False.
@@ -625,6 +642,9 @@ Casey 100210: Allow SWAN to handle wave refraction as a nodal attribute.
 Corbitt 120321: Allow advection to be turned on locally instead of globally
          CASE("advection_state")
             FoundAdvectionState = .TRUE.
+Csb
+         CASE("condensed_nodes")
+            FoundCondensedNodes = .TRUE.
          CASE("elemental_slope_limiter")
             FoundEleSlopeLim = .TRUE.
          CASE("initial_river_elevation")            
@@ -857,6 +877,7 @@ Casey 100210: Allow SWAN to handle wave refraction as a nodal attribute.
      &   ((LoadSwanWaveRefrac).and.(.not.FoundSwanWaveRefrac)).or.
 Corbitt 120321: Allow advection to be turned on locally instead of globally
      &   ((LoadAdvectionState).and.(.not.FoundAdvectionState)).or.
+     &   ((LoadCondensedNodes).and.(.not.FoundCondensedNodes)).or.
      &   ((LoadEleSlopeLim).and.(.not.FoundEleSlopeLim)).or.
      &   ((LoadRiver_et_WSE).and.(.not.FoundRiver_et_WSE)).or.     
      &   ((LoadIT_Fric).and.(.not.FoundIT_Fric)).or. 
@@ -901,6 +922,7 @@ Casey 100210: Allow SWAN to handle wave refraction as a nodal attribute.
       ALLOCATE(SwanWaveRefrac(NumOfNodes))
 Corbitt 120321: Allow advection to be turned on locally instead of globally
       ALLOCATE(AdvectionState(NumOfNodes))
+      ALLOCATE(CondensedNodes(NumOfNodes,CondensedNodesNoOfVals))
       ALLOCATE(River_et_WSE(NumOfNodes))  ! tcm 20140502 v51.27
       ALLOCATE(OverlandReductionFactor(NumOfNodes))
       ALLOCATE(elemental_slope_limiter_grad_max(NumOfNodes))
@@ -1026,6 +1048,8 @@ Casey 100210: Allow SWAN to handle wave refraction as a nodal attribute.
 Corbitt 120321: Allow advection to be turned on locally instead of globally
          CASE("advection_state")
             LoadAdvectionState = .True.
+         CASE("condensed_nodes")
+            LoadCondensedNodes = .True.
          CASE("elemental_slope_limiter")
             LoadEleSlopeLim = .TRUE.
          CASE("initial_river_elevation")  ! tcm 20140502 v51.27
@@ -1208,6 +1232,12 @@ Corbitt 120321: Allow advection to be turned on locally instead of globally
             READ(13,'(A80)') AdvectionStateUnits
             READ(13,*) AdvectionStateNoOfVals
             READ(13,*) AdvectionStateDefVal
+         CASE("condensed_nodes")
+            FoundCondensedNodes = .TRUE.
+            READ(13,'(A80)') CondensedNodesUnits
+            READ(13,*) CondensedNodesNoOfVals
+            READ(13,*) (CondensedNodesDefVal(j),
+     &                  j=1,CondensedNodesNoOfVals)
          CASE("elemental_slope_limiter")
             FoundEleSlopeLim = .TRUE.
             READ(13,'(A80)') EleSlopeLimUnits
@@ -1382,6 +1412,15 @@ Corbitt 120321: Allow Advection to be handled locally instead of globally.
          CASE("advection_state")
             IF (LoadAdvectionState) THEN
                CALL LoadAttrVec(AdvectionState,AdvectionStateDefVal,
+     &              NumNodesNotDefault, NScreen, MyProc, NAbOut)
+            ELSE
+               SkipDataSet = .TRUE.
+            ENDIF
+         CASE("condensed_nodes")
+            IF (LoadCondensedNodes) THEN
+               CALL LoadAttrMatNodeNo(CondensedNodes,
+     &              CondensedNodesNoOfVals,
+     &              CondensedNodesDefVal,
      &              NumNodesNotDefault, NScreen, MyProc, NAbOut)
             ELSE
                SkipDataSet = .TRUE.
@@ -1608,6 +1647,73 @@ C
       RETURN
 C     ----------------------------------------------------------------
       END SUBROUTINE LoadAttrMat
+C     ----------------------------------------------------------------
+
+
+
+C     ----------------------------------------------------------------
+C         S U B R O U T I N E     L O A D  A T T R  M A T  N O D E  N O
+C     ----------------------------------------------------------------
+C
+C     Subroutine to load a single set of nodal attributes from
+C     the Nodal Attributes File (unit 13) if there is more than one
+C     value per node.
+C
+C     Added for integer node no attributes. Based on LoadAttrMat. SB
+C
+C     ----------------------------------------------------------------
+      SUBROUTINE LoadAttrMatNodeNo(AttributeData, NumCol, Default,
+     &     NumNodesNotDef, NScreen, MyProc, NAbOut, NodesNotDef )
+      USE MESH,ONLY:node_dict,find
+      IMPLICIT NONE
+      INTEGER, intent(in) :: NumCol  ! number of columns in the matrix
+      INTEGER, intent(out),
+     &     dimension(NumOfNodes,NumCol) :: AttributeData
+      INTEGER, intent(in), dimension(NumCol) :: Default ! default values
+      INTEGER, intent(in) :: NumNodesNotDef  ! number of nodes spec. in file
+      INTEGER, intent(in) :: NScreen ! 1 for debug info to screen (unit 6)
+      INTEGER, intent(in) :: MyProc  ! in parallel, only MyProc=0 i/o to screen
+      INTEGER, intent(in) :: NAbOut  ! 1 to abbrev. output to unit 16
+      INTEGER             :: TempAttData(NumCol) 
+      INTEGER             :: NodeNum ! node label listed in the file
+      INTEGER             :: DictNode ! node position in array
+C------ DW
+      INTEGER, optional::  NodesNotDef(:)
+C------
+C
+C     Set all nodes to user-specified default values.
+      IF (NABOUT.EQ.0) WRITE(16,1001)
+      DO i=1, NumOfNodes
+         DO j=1, NumCol
+            AttributeData(i,j)=Default(j)
+         END DO
+      END DO
+C
+      IF (NABOUT.EQ.0) WRITE(16,1005)
+      IF (NABOUT.EQ.0) WRITE(16,*) NumCol,ubound(AttributeData),NumNodesNotDef
+      DO i=1, NumNodesNotDef
+         READ(13,*) NodeNum, (TempAttData(j),j=1,NumCol)
+         DictNode = find(node_dict,NodeNum)
+         DO j=1,NumCol
+            TempAttData(j) = find(node_dict,TempAttData(j))
+         END DO
+         IF ( present(NodesNotDef) ) THEN
+            NodesNotDef(i) = DictNode 
+         END IF
+         AttributeData(DictNode,:) = TempAttData(:)
+         IF (NABOUT.EQ.0) WRITE(16,1010) NodeNum,
+     &        (AttributeData(DictNode,j),j=1,NumCol)
+      END DO
+C
+ 1001 FORMAT(/,10X,'Set all nodes to the default values of ',/,
+     &     99I11,/)
+ 1005 FORMAT(/,10X,'Now setting the following nodes to these values:',
+     &     /,10X,'NODE',5X,'DATA',5X/)
+ 1010 FORMAT(7X,I8,6X,12(1X,I11))
+C
+      RETURN
+C     ----------------------------------------------------------------
+      END SUBROUTINE LoadAttrMatNODENO
 C     ----------------------------------------------------------------
 
 
@@ -2082,6 +2188,7 @@ C
       REAL(SZ) BALPHA! BALPHA(2) is constriction fraction
       REAL(SZ) BDELX ! BDELX(3) is effective delx
       REAL(SZ) MLDrat ! MLD ratio to depth
+      REAL(SZ) HT, WCH, ManN
 
 
       !...Reset the friction to original values
@@ -2102,29 +2209,40 @@ C
 C     Step 0. Convert Manning's N to Cd, if necessary.
       IF (LoadManningsN) THEN
          DO I=1, NP
+            HT = DP(I)+IFNLFA*ETA2(I)
             IF(LoadSubgridBarrier)THEN
                 IF(subgridBarrierOvertopping(I).AND.
      &             SubgridBarrierNoOfVals.EQ.2)THEN
                     FRIC(I)=g*subgridBarrier(I,2)**2.d0
-     &                   /( ( DP(I)+IFNLFA*ETA2(I) )**(1.d0/3.d0) ) 
+     &                   /( ( HT )**(1.d0/3.d0) ) 
                     IF(FRIC(I).LT.BFCdLLimit) THEN
                        FRIC(I) = BFCdLLimit
                     ENDIF
                 ELSE
                     IF (ManningsN(I).le.0d0) cycle ! Can use Cd where man <= 0
                     FRIC(I)=g*ManningsN(I)**2.d0
-     &                   /( ( DP(I)+IFNLFA*ETA2(I) )**(1.d0/3.d0) ) ! sb46.28sb02
+     &                   /( ( HT )**(1.d0/3.d0) ) ! sb46.28sb02
                     IF(FRIC(I).LT.BFCdLLimit) THEN
                        FRIC(I) = BFCdLLimit
                     ENDIF
                 ENDIF
             ELSE
                 IF (ManningsN(I).le.0d0) cycle ! Can use Cd where man <= 0
-                FRIC(I)=g*ManningsN(I)**2.d0
-     &               /( ( DP(I)+IFNLFA*ETA2(I) )**(1.d0/3.d0) ) ! sb46.28sb02
-                !sb46.28sb02  Lower limit is applied here.
-                IF(FRIC(I).LT.BFCdLLimit) THEN
-                   FRIC(I) = BFCdLLimit
+                IF (ManningsN(I).gt.1.d0) THEN
+                   WCH = floor(ManningsN(I))
+                   ManN = ManningsN(I) - WCH
+                   FRIC(I)=g*((1.D0+2.D0*HT/WCH)**(2.D0/3.D0)*ManN)**2.d0
+     &               /( HT**(1.d0/3.d0) )
+                   IF(FRIC(I).LT.BFCdLLimit) THEN
+                      FRIC(I) = BFCdLLimit
+                   ENDIF
+                ELSE
+                   FRIC(I)=g*ManningsN(I)**2.d0
+     &               /( ( HT )**(1.d0/3.d0) ) ! sb46.28sb02
+                   !sb46.28sb02  Lower limit is applied here.
+                   IF(FRIC(I).LT.BFCdLLimit) THEN
+                      FRIC(I) = BFCdLLimit
+                   ENDIF
                 ENDIF
             ENDIF
          ENDDO
@@ -2803,6 +2921,105 @@ C     ----------------------------------------------------------------
       END SUBROUTINE na_terminate
 C     ----------------------------------------------------------------
 
+
+C     ----------------------------------------------------------------
+C        S U B R O U T I N E   P R E P  C O N D E N S E D   N O D E S
+C     ----------------------------------------------------------------
+C     Parepare list of condensed nodes
+C     ----------------------------------------------------------------
+      SUBROUTINE PrepCondensedNodes()
+C     ----------------------------------------------------------------
+      USE SIZES,ONLY : SZ,MNVEL
+      USE MESH,ONLY : NP,LBArray_Pointer,X,Y
+      USE BOUNDARIES,ONLY : CSIICN,SIIICN
+      IMPLICIT NONE
+      INTEGER :: I,J,K,II,I1,I2,J1,J2
+      INTEGER :: JMAX
+      REAL(SZ) :: X1,Y1,X2,Y2,DX,DY,LEN
+      LOGICAL :: ON_THE_SAME_BOUNDARY
+
+      IF (.NOT.LoadCondensedNodes) RETURN
+
+      NListCondensedNodes = 0
+      JMAX = 0
+      DO I=1,NP
+         IF(CondensedNodes(I,1).NE.0) THEN
+            NListCondensedNodes = NListCondensedNodes + 1
+            DO J=1,CondensedNodesNoOfVals
+               IF(CondensedNodes(I,J).EQ.0) EXIT
+               IF(JMAX.LT.J) JMAX = J
+            ENDDO
+         ENDIF
+      ENDDO
+
+      ALLOCATE(NCondensedNodes(NumOfNodes))
+      ALLOCATE(ListCondensedNodes(NListCondensedNodes,JMAX+1))
+      ALLOCATE(NNodesListCondensedNodes(NListCondensedNodes))
+
+      NCondensedNodes(:) = 0
+
+      K = 0
+      DO I=1,NP
+         IF(CondensedNodes(I,1).GT.0) THEN
+            K = K + 1
+            ListCondensedNodes(K,1) = I
+            DO J=1,CondensedNodesNoOfVals
+               IF(CondensedNodes(I,J).LE.0) EXIT
+               II = CondensedNodes(I,J)
+               NCondensedNodes(I) = J+1
+               ListCondensedNodes(K,J+1) = II
+               NNodesListCondensedNodes(K) = J+1
+               CondensedNodes(II,1) = -I ! To tell that node II is one of condensed nodes
+            ENDDO
+            DO J=1,CondensedNodesNoOfVals
+               IF(CondensedNodes(I,J).LE.0) EXIT
+               II = CondensedNodes(I,J)
+               NCondensedNodes(II) = NCondensedNodes(I)
+            ENDDO
+         ENDIF
+      ENDDO
+
+      ALLOCATE(CSIICN(MNVEL),SIIICN(MNVEL))
+      CSIICN = 0.D0
+      SIIICN = 0.D0
+
+      DO I=1,NP
+         IF((CondensedNodes(I,1) > 0).AND.
+     &      (NCondensedNodes(I).EQ.2)) THEN
+            I1 = I
+            I2 = CondensedNodes(I,1)
+
+            J1 = LBArray_Pointer(I1)
+            J2 = LBArray_Pointer(I2)
+            IF(J1<1.OR.J2<1) CYCLE
+            IF(J1.EQ.(J2+1).OR.
+     &         J1.EQ.(J2-1)) THEN ! Whether Nodes J1 and J2 are on the same boundary.
+               ON_THE_SAME_BOUNDARY = .TRUE.
+            ELSE
+               ON_THE_SAME_BOUNDARY = .FALSE.
+            END IF
+            IF(ON_THE_SAME_BOUNDARY) CYCLE
+
+            X1 = X(I1)
+            Y1 = Y(I1)
+            X2 = X(I2)
+            Y2 = Y(I2)
+            DX = X1 - X2
+            DY = Y1 - Y2
+            LEN = SQRT(DX*DX + DY*DY)
+            DX = DX/LEN
+            DY = DY/LEN
+
+            CSIICN(J1) = DX
+            SIIICN(J1) = DY
+
+            CSIICN(J2) = DX
+            SIIICN(J2) = DY
+         END IF
+      END DO
+
+      END SUBROUTINE PrepCondensedNodes
+C     ----------------------------------------------------------------
 
 C-----------------------------------------------------------------------
       END MODULE NodalAttributes

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -114,6 +114,7 @@ C-----------------------------------------------------------------------
      &     NoLiBF, NWP, Tau0, HBreak, FTheta, FGamma, Tau, CF,
      &     InitNAModule, ReadNodalAttr, InitNodalAttr, ESLM, ESLC,
      &     Tau0FullDomainMin, Tau0FullDomainMax, Z0b_var,
+     &     PrepCondensedNodes,   ! SB
 C ....DW
      &     LoadAbsLayerSigma, FoundAbsLayerSigma 
       USE SPONGELAYER, ONLY: SpongeLayerRelatedPrep, FLAGSPONGEELEM
@@ -264,7 +265,7 @@ C...
 4312  FORMAT(/,'**** W A R N I N G ****',/
             ' You are running ADCIRC in SINGLE PRECISION! ',/
             ' It is always recommended that you run ADCIRC in ',/
-            ' DOUBLE PRECISION ONLY.'
+            ' DOUBLE PRECISION ONLY.')
 #else
       WRITE(16,*) '      - CODE SETUP TO RUN WITH 8 byte REALS'
 #endif
@@ -2947,7 +2948,7 @@ C     the beginning of this subroutine.)
 C     jgf51.12.13: Adjust node table based on ics, nolifa, h0,
 C     slam0, sfea0. Check for sufficient precision. Compute neighbor table.
       call initializeMesh()
-            
+
 C   For Sponge layer
       IF ( LoadAbsLayerSigma .AND. FoundAbsLayerSigma ) THEN
          CALL FLAGSPONGEELEM()
@@ -4741,8 +4742,17 @@ c     CALL READ_INPUT_3DDSS(STATIM,NT)
 C     RJWW jgf46.00 Initialize nodal attributes, now that grid has been read
 C     in from unit 14 file.
 C     RJW IOOS move until after ZOB definition
-      CALL InitNodalAttr(DP, NP, G, NScreen, ScreenUnit, MyProc, NAbOut, Z0B)
+      CALL InitNodalAttr
+     &  (DP, NP, G, NScreen, ScreenUnit, MyProc, NAbOut, Z0B)
 CS
+C...  SB
+C     Preparation of condensed nodes  SB
+      call PrepCondensedNodes()
+      
+C     Recompute a & b coefficients            
+      CALL RecomputeFDXEFDYEAtCondensedNodes()
+      
+C...  SB END
 
 C...  INITIALIZE NIBNODECODE(I)
       DO I=1,NP
@@ -4975,7 +4985,138 @@ c******************************************************************************
       END SUBROUTINE READ_INPUT
 c******************************************************************************
 
+c******************************************************************************
+      SUBROUTINE RecomputeFDXEFDYEAtCondensedNodes()
+c******************************************************************************
+      USE SIZES
+      USE Mesh,ONLY : NE,NM,X,Y,FDXE,FDYE,AREAS
+      USE NodalAttributes, ONLY : LoadCondensedNodes
+      IMPLICIT NONE
+      INTEGER :: NM1,NM2,NM3
+      INTEGER :: IE
+      INTEGER :: STATUS
+      REAL(SZ) :: x1,y1,x2,y2,x3,y3
+      REAL(SZ) x2mx1,x3mx2,x1mx3,y2my1,y3my2,y1my3
 
+      if (.not.LoadCondensedNodes) RETURN
+      
+      do ie=1,NE
+         nm1 = nm(ie,1)
+         nm2 = nm(ie,2)
+         nm3 = nm(ie,3)
+
+         call get_new_xy(nm1,nm2,nm3,x1,y1,x2,y2,x3,y3,status)
+
+         if (status.ne.0) then
+            cycle
+         endif
+
+         X2mX1 = (X2 - X1);
+         X3mX2 = (X3 - X2);
+         X1mX3 = (X1 - X3);
+         Y2mY1 = (Y2 - Y1);
+         Y3mY2 = (Y3 - Y2);
+         Y1mY3 = (Y1 - Y3);
+
+!.....   For later use for FDX1, FDY1 in gwce, momentum 
+         FDXE(1,IE) = -Y3mY2 ; !b1
+         FDXE(2,IE) = -Y1mY3 ; !b2
+         FDXE(3,IE) = -Y2mY1 ; !b3
+         FDYE(1,IE) =  X3mX2 ; !a1
+         FDYE(2,IE) =  X1mX3 ; !a2
+         FDYE(3,IE) =  X2mX1 ; !a3
+
+!.....   compute and store 2 x element areas
+         AREAS(IE)=(X1mX3)*(-Y3mY2)+(X3mX2)*(Y1mY3)
+      end do
+
+      RETURN
+
+      CONTAINS
+         SUBROUTINE GET_New_XY
+     &              (NM1,NM2,NM3,X1,Y1,X2,Y2,X3,Y3,STATUS)
+         USE MESH, ONLY : X,Y,findIBTYPEAtNode
+         USE NodalAttributes, ONLY : NCondensedNodes,CondensedNodes
+         USE VEW1D, ONLY : GET_STREAMDIRECTION_AT_ELEMENT
+
+         IMPLICIT NONE
+
+         INTEGER,INTENT(IN) :: NM1,NM2,NM3
+         REAL(SZ),INTENT(OUT) :: X1,Y1,X2,Y2,X3,Y3
+         INTEGER,INTENT(OUT) :: STATUS
+         REAL(SZ) :: XX,YY
+         REAL(SZ) :: SX,SY,NX,NY,CAX,CAY,CBX,CBY,DX,DY,LEN
+         INTEGER :: IA1,IA2,IB1,IB2
+         INTEGER :: IBTYPE_A1,IBTYPE_A2,IBTYPE_B1
+         LOGICAL :: ON_BOUNDARY
+
+         CALL GET_STREAMDIRECTION_AT_ELEMENT
+     &        (NM1,NM2,NM3,IA1,IA2,IB1,IB2,
+     &         CAX,CAY,CBX,CBY,SX,SY,STATUS)
+
+         IF (STATUS.NE.0) RETURN
+
+         NX = -SY
+         NY = SX
+
+         XX = X(IA1)
+         YY = Y(IA1)
+         DX = XX - CAX
+         DY = YY - CAY
+         LEN = DX*NX + DY*NY
+         XX = CAX + LEN * NX
+         YY = CAY + LEN * NY
+         IF (IA1.EQ.NM1) THEN
+            X1 = XX
+            Y1 = YY
+         ELSE IF (IA1.EQ.NM2) THEN
+            X2 = XX
+            Y2 = YY
+         ELSE
+            X3 = XX
+            Y3 = YY
+         END IF
+
+         XX = X(IA2)
+         YY = Y(IA2)
+         DX = XX - CAX
+         DY = YY - CAY
+         LEN = DX*NX + DY*NY
+         XX = CAX + LEN * NX
+         YY = CAY + LEN * NY
+         IF (IA2.EQ.NM1) THEN
+            X1 = XX
+            Y1 = YY
+         ELSE IF (IA2.EQ.NM2) THEN
+            X2 = XX
+            Y2 = YY
+         ELSE
+            X3 = XX
+            Y3 = YY
+         END IF
+
+         XX = X(IB1)
+         YY = Y(IB1)
+         DX = XX - CBX
+         DY = YY - CBY
+         LEN = DX*NX + DY*NY
+         XX = CBX + LEN * NX
+         YY = CBY + LEN * NY
+         IF (IB1.EQ.NM1) THEN
+            X1 = XX
+            Y1 = YY
+         ELSE IF (IB1.EQ.NM2) THEN
+            X2 = XX
+            Y2 = YY
+         ELSE
+            X3 = XX
+            Y3 = YY
+         END IF
+
+         RETURN
+         END SUBROUTINE GET_New_XY
+
+      END SUBROUTINE RecomputeFDXEFDYEAtCondensedNodes
 
 c******************************************************************************
 C   Subroutine to read in 3D portion of fort.15 file                          *

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -181,6 +181,7 @@ C....... DW
       LOGICAL, SAVE:: FIRST_ENTER = .TRUE. 
       INTEGER:: NBDI, istep
 C.......
+      LOGICAL ISFRONT
 
       call setMessageSource("timestep")
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)
@@ -988,6 +989,17 @@ C                     ACROSS A WEIR
                         I = I + 1
                         CALL COMPUTE_INTERNAL_BOUNDARY_FLUX(I,J,K,
      &                      TIMELOC,QN2(I))
+                    ENDDO
+                CASE(64)
+                    DO J = 1,NVELL(K)*2
+                        I = I + 1
+                        IF(J.LE.NVELL(K)) THEN
+                           ISFRONT = .TRUE.
+                        ELSE
+                           ISFRONT = .FALSE.
+                        ENDIF
+                        CALL COMPUTE_INTERNAL_BOUNDARY64_FLUX(I,J,K,
+     &                      TIMELOC,QN2(I),ISFRONT)
                     ENDDO
                 CASE DEFAULT
                     I = I + NVELL(K)

--- a/src/vew1d.F
+++ b/src/vew1d.F
@@ -1,0 +1,408 @@
+C*******************************************************************
+C
+C  MODULE VEW1D
+C
+C  This module declares subroutines for vertical element walls and 
+C  1D condensation
+C
+C  2022-09-21: Created by SB
+C
+C*******************************************************************
+      module vew1d
+      implicit none
+
+      contains
+
+      !-------------------------------------------------------------
+      SUBROUTINE GET_STREAMDIRECTION_AT_ELEMENT
+     &           (NM1,NM2,NM3,IA1,IA2,IB1,IB2,
+     &            CAX,CAY,CBX,CBY,SX,SY,STATUS)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      USE MESH,ONLY : X,Y,findIBTYPEAtNode
+      USE NodalAttributes,ONLY : NCondensedNodes,CondensedNodes
+
+      IMPLICIT NONE
+
+      INTEGER,INTENT(IN) :: NM1,NM2,NM3
+      INTEGER,INTENT(OUT) :: IA1,IA2,IB1,IB2
+      REAL(SZ),INTENT(OUT) :: CAX,CAY,CBX,CBY,SX,SY
+      INTEGER,INTENT(OUT) :: STATUS
+      INTEGER :: IBTYPE_A1,IBTYPE_A2,IBTYPE_B1
+      REAL(SZ) :: LEN
+      LOGICAL :: ON_BOUNDARY
+
+      STATUS = 0
+
+      if (NCondensedNodes(nm1) < 2.or.
+     &    NCondensedNodes(nm2) < 2.or.
+     &    NCondensedNodes(nm3) < 2) then
+         status = -1
+         return
+      end if
+
+      IF(CondensedNodePairFound(NM1,NM2)) THEN
+         IA1 = NM1
+         IA2 = NM2
+         IB1 = NM3 
+      ELSE IF(CondensedNodePairFound(NM2,NM1)) THEN
+         IA1 = NM2
+         IA2 = NM1
+         IB1 = NM3 
+      ELSE IF(CondensedNodePairFound(NM2,NM3)) THEN
+         IA1 = NM2
+         IA2 = NM3
+         IB1 = NM1
+      ELSE IF(CondensedNodePairFound(NM3,NM2)) THEN
+         IA1 = NM3
+         IA2 = NM2
+         IB1 = NM1
+      ELSE IF(CondensedNodePairFound(NM3,NM1)) THEN
+         IA1 = NM3
+         IA2 = NM1
+         IB1 = NM2
+      ELSE IF(CondensedNodePairFound(NM1,NM3)) THEN
+         IA1 = NM1
+         IA2 = NM3
+         IB1 = NM2
+      ELSE
+         status = -1
+         return !when condensed node pair not found
+      ENDIF
+      IB2 = FIND_IB2(IB1,IA1,IA2)
+      IF(IB2 < 1) THEN
+         status = -1
+         return !when condensed node pair not found
+      ENDIF
+      IF(CondensedNodes(IB2,1).EQ.0) THEN
+         status = -1
+         return !when condensed node pair not found
+      ENDIF
+
+      ibtype_a1 = findIBTYPEAtNode(ia1)
+      ibtype_a2 = findIBTYPEAtNode(ia2)
+      ibtype_b1 = findIBTYPEAtNode(ib1)
+
+      on_boundary = .false.
+      if ((ibtype_a1.eq.20.and.ibtype_b1.eq.20).or.
+     &    (ibtype_a2.eq.20.and.ibtype_b1.eq.20).or.
+     &    (ibtype_a1.eq.64.and.ibtype_b1.eq.64).or.
+     &    (ibtype_a2.eq.64.and.ibtype_b1.eq.64)) then
+         on_boundary = .true.
+      end if
+
+      if (.not.on_boundary) then
+         status = -1
+         return
+      end if
+
+      CAX = 0.5*(X(IA1)+X(IA2))
+      CAY = 0.5*(Y(IA1)+Y(IA2)) 
+      CBX = 0.5*(X(IB1)+X(IB2))
+      CBY = 0.5*(Y(IB1)+Y(IB2)) 
+      SX = CAX - CBX
+      SY = CAY - CBY
+      LEN = SQRT(SX*SX+SY*SY)
+      SX = SX/LEN
+      SY = SY/LEN
+
+      RETURN
+      END SUBROUTINE GET_STREAMDIRECTION_AT_ELEMENT
+
+      !-------------------------------------------------------------
+      SUBROUTINE ROTATE_AT_CONDENSEDNODES(VECX,VECY,IND,SX,SY)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      USE GLOBAL,ONLY : NODECODE
+      USE NodalAttributes,ONLY : LoadCondensedNodes,NCondensedNodes
+      USE Mesh,ONLY : LBArray_Pointer
+      USE BOUNDARIES,ONLY : LBCODEI,NBV,IBCONN,ISSUBMERGED64
+      IMPLICIT NONE
+
+      REAL(SZ),INTENT(INOUT) :: VECX, VECY
+      REAL(SZ),INTENT(IN) :: SX,SY
+      INTEGER,INTENT(IN) :: IND
+      REAL(SZ) :: CS,SI,CSCS,CSSI,SISI,fBUF1,fBUF2,VLEN,P
+      INTEGER :: IBND,NNBB1,NNBB2
+      LOGICAL :: DO_ROTATE
+      
+      IF(.NOT.LoadCondensedNodes) RETURN
+      IF(.NOT.NCondensedNodes(IND).GE.2) RETURN
+
+      IBND = LBArray_Pointer(IND)
+      IF (IBND.LE.0) RETURN
+
+      ! Rotate the vector if there is no bank top
+      ! side, i.e., along land boundaries, or along not-submerged
+      ! vertical element walls 
+      DO_ROTATE = .false.
+      IF(LBCODEI(IBND).EQ.20) THEN
+         DO_ROTATE = .true.
+      ELSE IF(LBCODEI(IBND).EQ.64) THEN
+         NNBB1=NBV(IBND)
+         NNBB2=IBCONN(IBND)
+         IF ((ISSUBMERGED64(IBND).EQ.0).OR.
+     &       (NODECODE(NNBB1).EQ.0.OR.NODECODE(NNBB2).EQ.0)) THEN
+            DO_ROTATE = .true.
+         ENDIF
+      END IF
+      IF(.NOT.DO_ROTATE) RETURN
+
+      CS = SX
+      SI = SY
+
+      VLEN = SQRT(VECX*VECX + VECY*VECY)
+
+      P = VECX*CS + VECY*SI
+
+      VECX = VLEN*CS*SIGN(1.D0,P)
+      VECY = VLEN*SI*SIGN(1.D0,P)
+
+      RETURN
+      END SUBROUTINE ROTATE_AT_CONDENSEDNODES
+
+      !-------------------------------------------------------------
+      SUBROUTINE ROTATEBACK_AT_CONDENSEDNODES(VECX,VECY,IND)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      USE GLOBAL,ONLY : NODECODE
+      USE NodalAttributes,ONLY : LoadCondensedNodes,NCondensedNodes
+      USE Mesh,ONLY : LBArray_Pointer
+      USE BOUNDARIES,ONLY : CSIICN,SIIICN,LBCODEI,NBV,IBCONN,
+     &                      ISSUBMERGED64
+      IMPLICIT NONE
+
+      REAL(SZ),INTENT(INOUT) :: VECX, VECY
+      INTEGER,INTENT(IN) :: IND
+      REAL(SZ) CS,SI,CSCS,CSSI,SISI,fBUF1,fBUF2,VLEN,P
+      INTEGER :: IBND,NNBB1,NNBB2
+      LOGICAL :: DO_ROTATE
+      
+      IF(.NOT.LoadCondensedNodes) RETURN
+      IF(NCondensedNodes(IND).NE.2) RETURN
+
+      IBND = LBArray_Pointer(IND)
+      IF (IBND.LE.0) RETURN
+
+      ! Rotate back the vector if there is no bank top
+      ! side, i.e., along land boundaries, or along not-submerged
+      ! vertical element walls 
+      DO_ROTATE = .false.
+      IF(LBCODEI(IBND).EQ.20) THEN
+         DO_ROTATE = .true.
+      ELSE IF(LBCODEI(IBND).EQ.64) THEN
+         NNBB1=NBV(IBND)
+         NNBB2=IBCONN(IBND)
+         IF ((ISSUBMERGED64(IBND).EQ.0).OR.
+     &       (NODECODE(NNBB1).EQ.0.OR.NODECODE(NNBB2).EQ.0)) THEN
+            DO_ROTATE = .true.
+         ENDIF
+      END IF
+      IF(.NOT.DO_ROTATE) RETURN
+
+      VLEN = SQRT(VECX*VECX+VECY*VECY)
+      CS = -SIIICN(IBND)
+      SI = CSIICN(IBND)
+      P = VECX*CS + VECY*SI
+      VECX = VLEN*CS*SIGN(1.D0,P)
+      VECY = VLEN*SI*SIGN(1.D0,P)
+
+      RETURN
+      END SUBROUTINE ROTATEBACK_AT_CONDENSEDNODES
+C
+      !-------------------------------------------------------------
+      SUBROUTINE ROTATE_AT_CONDENSEDNODES_ALL
+     &           (NM1,NM2,NM3,
+     &            U1N1,V1N1,U1N2,V1N2,U1N3,V1N3,
+     &            QX1N1,QY1N1,QX1N2,QY1N2,QX1N3,QY1N3,
+     &            STATUS)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      IMPLICIT NONE
+
+      INTEGER,INTENT(IN) :: NM1,NM2,NM3
+      REAL(SZ),INTENT(INOUT) :: 
+     &     U1N1,V1N1,U1N2,V1N2,U1N3,V1N3,
+     &     QX1N1,QY1N1,QX1N2,QY1N2,QX1N3,QY1N3
+      INTEGER,INTENT(OUT) :: STATUS
+      REAL(SZ) :: CAX,CAY,CBX,CBY,SX,SY
+      INTEGER :: IA1,IA2,IB1,IB2
+
+      CALL GET_STREAMDIRECTION_AT_ELEMENT
+     &     (NM1,NM2,NM3,IA1,IA2,IB1,IB2,
+     &      CAX,CAY,CBX,CBY,SX,SY,STATUS)
+
+      IF (STATUS.NE.0) RETURN
+
+      CALL ROTATE_AT_CONDENSEDNODES(U1N1,V1N1,NM1,SX,SY)
+      CALL ROTATE_AT_CONDENSEDNODES(QX1N1,QY1N1,NM1,SX,SY)
+
+      CALL ROTATE_AT_CONDENSEDNODES(U1N2,V1N2,NM2,SX,SY)
+      CALL ROTATE_AT_CONDENSEDNODES(QX1N2,QY1N2,NM2,SX,SY)
+
+      CALL ROTATE_AT_CONDENSEDNODES(U1N3,V1N3,NM3,SX,SY)
+      CALL ROTATE_AT_CONDENSEDNODES(QX1N3,QY1N3,NM3,SX,SY)
+
+      RETURN
+      END SUBROUTINE ROTATE_AT_CONDENSEDNODES_ALL
+C
+      !-------------------------------------------------------------
+      SUBROUTINE ROTATEBACK_AT_CONDENSEDNODES_ALL
+     &           (NM1,NM2,NM3,TEMP_LV_A1,TEMP_LV_B1,
+     &            TEMP_LV_A2,TEMP_LV_B2,TEMP_LV_A3,TEMP_LV_B3,
+     &            STATUS)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      IMPLICIT NONE
+
+      INTEGER,INTENT(IN) :: NM1,NM2,NM3
+      REAL(SZ),INTENT(INOUT) :: 
+     &     TEMP_LV_A1,TEMP_LV_B1,TEMP_LV_A2,TEMP_LV_B2,
+     &     TEMP_LV_A3,TEMP_LV_B3
+      INTEGER,INTENT(OUT) :: STATUS
+      REAL(SZ) :: CAX,CAY,CBX,CBY,SX,SY
+      INTEGER :: IA1,IA2,IB1,IB2
+
+      CALL GET_STREAMDIRECTION_AT_ELEMENT
+     &     (NM1,NM2,NM3,IA1,IA2,IB1,IB2,
+     &      CAX,CAY,CBX,CBY,SX,SY,STATUS)
+
+      IF (STATUS.NE.0) RETURN
+
+      CALL ROTATEBACK_AT_CONDENSEDNODES(TEMP_LV_A1,TEMP_LV_B1,NM1)
+      CALL ROTATEBACK_AT_CONDENSEDNODES(TEMP_LV_A2,TEMP_LV_B2,NM2)
+      CALL ROTATEBACK_AT_CONDENSEDNODES(TEMP_LV_A3,TEMP_LV_B3,NM3)
+
+      RETURN
+      END SUBROUTINE ROTATEBACK_AT_CONDENSEDNODES_ALL
+C
+      !-------------------------------------------------------------
+      SUBROUTINE REMOVE_NORMAL_AT_CONDENSEDNODES
+     &           (VECX,VECY,IND,STATUS)
+      !-------------------------------------------------------------
+      USE SIZES,ONLY : SZ
+      USE GLOBAL,ONLY : NODECODE
+      USE NodalAttributes,ONLY : LoadCondensedNodes,NCondensedNodes
+      USE Mesh,ONLY : LBArray_Pointer
+      USE BOUNDARIES,ONLY : CSIICN,SIIICN,LBCODEI,NBV,IBCONN,
+     &                      ISSUBMERGED64
+      
+      IMPLICIT NONE
+
+      REAL(SZ),INTENT(INOUT) :: VECX, VECY
+      INTEGER,INTENT(IN) :: IND
+      INTEGER,INTENT(OUT) :: STATUS
+      REAL(SZ) CS,SI,CSCS,CSSI,SISI,fBUF1,fBUF2,LEN
+      INTEGER :: IBND,NNBB1,NNBB2
+      LOGICAL :: DO_ROTATE
+      
+      STATUS = -1
+
+      IF(.NOT.LoadCondensedNodes) RETURN
+      IF(NCondensedNodes(IND).NE.2) RETURN
+
+      IBND = LBArray_Pointer(IND)
+      IF (IBND.LE.0) RETURN
+
+      ! Remove the normal component if there is no bank top
+      ! side, i.e., along land boundaries, or along not-submerged
+      ! vertical element walls 
+      DO_ROTATE = .false.
+      IF(LBCODEI(IBND).EQ.20) THEN
+         DO_ROTATE = .true.
+      ELSE IF(LBCODEI(IBND).EQ.64) THEN
+         NNBB1=NBV(IBND)
+         NNBB2=IBCONN(IBND)
+         IF ((ISSUBMERGED64(IBND).EQ.0).OR.
+     &       (NODECODE(NNBB1).EQ.0.OR.NODECODE(NNBB2).EQ.0)) THEN
+            DO_ROTATE = .true.
+         ENDIF
+      END IF
+
+      IF(.NOT.DO_ROTATE) RETURN  
+
+      CS = -SIIICN(IBND)
+      SI = CSIICN(IBND)
+      CSCS = CS*CS
+      CSSI = CS*SI
+      SISI = SI*SI
+
+      fBUF1 = VECX*CSCS + VECY*CSSI
+      fBUF2 = VECX*CSSI + VECY*SISI
+
+      VECX = fBUF1
+      VECY = fBUF2
+
+      STATUS = 0
+
+      RETURN
+      END SUBROUTINE REMOVE_NORMAL_AT_CONDENSEDNODES
+      
+      FUNCTION CondensedNodePairFound(N1,N2)
+      USE NodalAttributes, ONLY : NCondensedNodes,CondensedNodes,
+     &                            CondensedNodesNoOfVals
+      IMPLICIT NONE
+      INTEGER :: N1,N2
+      LOGICAL :: CondensedNodePairFound
+      INTEGER :: I,N
+
+      CondensedNodePairFound = .false.
+      IF (CondensedNodes(N1,1) < 0) THEN
+         N = ABS(CondensedNodes(N1,1))
+      ELSE
+         N = N1
+      END IF
+      DO I=1,CondensedNodesNoOfVals
+         IF (CondensedNodes(N,I).EQ.N2) THEN
+            CondensedNodePairFound = .true.
+            EXIT
+         END IF
+      END DO
+      
+      END FUNCTION CondensedNodePairFound
+
+      FUNCTION FIND_IB2(N1,N2,N3)
+      USE MESH,ONLY : NNEIGHELE,NEITABELE,NM
+      IMPLICIT NONE
+      INTEGER :: FIND_IB2,N1,N2,N3
+      INTEGER :: nnm1,nnm2,nnm3,tmp
+      INTEGER :: I,IE
+      LOGICAL :: FOUND
+
+      find_ib2 = -1
+      found = .false.
+
+      do i=1,nneighele(n1)
+         ie = neitabele(n1,i)
+         nnm1 = nm(ie,1)
+         nnm2 = nm(ie,2)
+         nnm3 = nm(ie,3)
+         if (nnm1.eq.n1) then
+            continue ! do nothing
+         else if (nnm2.eq.n1) then
+            tmp = nnm1
+            nnm1 = nnm2
+            nnm2 = nnm3
+            nnm3 = tmp
+         else if (nnm3.eq.n1) then
+            tmp = nnm1
+            nnm1 = nnm3
+            nnm3 = nnm2
+            nnm2 = tmp
+         else
+            STOP('Error')
+         end if
+         if ((nnm2.eq.n2.and.nnm3.eq.n3).or.
+     &       (nnm2.eq.n3.and.nnm3.eq.n2)) cycle
+         if (nnm2.eq.n2.or.nnm2.eq.n3) then
+            find_ib2 = nnm3
+            found = .true.
+         else if (nnm3.eq.n2.or.nnm3.eq.n3) then
+            find_ib2 = nnm2
+            found = .true.
+         end if
+         if (found) exit
+      end do
+      END FUNCTION FIND_IB2
+
+      end module vew1d

--- a/src/weir_boundary.F
+++ b/src/weir_boundary.F
@@ -6,7 +6,7 @@ C              zcobell@thewaterinstitute.org
 C              (225)421-2761
 C
 C   CONTAINS THE NEW ROUTINES FOR THE SPECIFICATION OF TIME VARYING WEIRS AND
-C   LAND BOUNDARY CONDITIONS. ALL TYPE 3,13,23,4,24,5,25 BOUNDARY CONDITIONS
+C   LAND BOUNDARY CONDITIONS. ALL TYPE 3,13,23,4,24,64,5,25 BOUNDARY CONDITIONS
 C   HAVE THEIR ELEVATION VALUES SET USING THIS ROUNTINE. ALSO, WEIR OVERTOPPING
 C   IS COMPUTED HERE USING EITHER THE ORIGINAL IMPLEMENTATION (JJW) OR THE
 C   STANDARD FORMULATION (SHINTARO BUNYA, CHECKS FOR WET EDGE)
@@ -29,6 +29,8 @@ C-----------------------------------------------------------------------
             REAL(SZ),ALLOCATABLE     :: BARLANHT1(:)   !...External Barrier elevation at previous timestep
             REAL(SZ),ALLOCATABLE     :: BARLANHT2(:)   !...External Barrier elevation at current timestep
             REAL(SZ), PARAMETER      :: BARMIN=0.04D0
+            REAL(SZ), PARAMETER      :: BARMIN64=0.04D0
+            REAL(SZ), PARAMETER      :: SUBMIN64=0.04D0
 
             !...Averaging information in time for boundaries. 
             !   This was previously zeroed out in the code, but the
@@ -304,7 +306,7 @@ C...............COUNT THE NUMBER OF WEIR STYLE BOUNDARIES
                 NWEIR = 0
                 DO I = 1,NVEL
                     SELECT CASE(LBCODEI(I))
-                        CASE(3,13,23,4,24,5,25)
+                        CASE(3,13,23,4,24,64,5,25)
                             NWEIR = NWEIR + 1
                     END SELECT
                 ENDDO
@@ -314,7 +316,7 @@ C...............CONSTRUCT ARRAYS OF X,Y FOR BOUNDARY NODE LOCATIONS
                 IDX = 0
                 DO I = 1,NVEL
                     SELECT CASE(LBCODEI(I))
-                        CASE(3,13,23,4,24,5,25)
+                        CASE(3,13,23,4,24,64,5,25)
                             IDX = IDX + 1
                             BAR_LOCATIONS(1,IDX) = X(NBV(I))
                             BAR_LOCATIONS(2,IDX) = Y(NBV(I))
@@ -638,7 +640,7 @@ C...............COMPUTE THE NEW BOUNDARY HEIGHT
                             BAR_DZ = BARLANHT(MYIDX) - 
      &                               BARHT_FINAL(MYIDX)
                             BAR_START = BARLANHT(MYIDX)
-                        CASE(4,24,5,25)
+                        CASE(4,24,64,5,25)
                             BAR_DZ = BARINHT(MYIDX) - BARHT_FINAL(MYIDX)
                             BAR_START = BARINHT(MYIDX)
                         CASE DEFAULT
@@ -872,7 +874,7 @@ C                   VALUES BASED UPON MESH GEOMETRY.
                             SELECT CASE(LBCODEI(MYIDX))
                                 CASE(3,13,23)
                                     BARHT_FINAL(MYIDX) = -DP(NNBB1)
-                                CASE(4,14,24,5,25)
+                                CASE(4,14,24,64,5,25)
                                     NNBB2 = IBCONN(MYIDX)
                                     BARHT_FINAL(MYIDX) = 
      &                                 MIN(-DP(NNBB1),-DP(NNBB2))
@@ -885,7 +887,7 @@ C                   VALUES BASED UPON MESH GEOMETRY.
      &                                  BARLANHT2(MYIDX) + 
      &                                  BAR_SCHEDULE(MYIDX)%
      &                                  SECTION(MYSEC)%BARHT_DELTA
-                                CASE(4,14,24,5,25)
+                                CASE(4,14,24,64,5,25)
                                     BARHT_FINAL(MYIDX) = 
      &                                  BARINHT2(MYIDX) + 
      &                                  BAR_SCHEDULE(MYIDX)%
@@ -900,7 +902,7 @@ C                   VALUES BASED UPON MESH GEOMETRY.
      &                                  BARLANHT2(MYIDX) - 
      &                                  BAR_SCHEDULE(MYIDX)%
      &                                  SECTION(MYSEC)%BARHT_DELTA
-                                CASE(4,14,24,5,25)
+                                CASE(4,14,24,64,5,25)
                                     BARHT_FINAL(MYIDX) = 
      &                                  BARINHT2(MYIDX) - 
      &                                  BAR_SCHEDULE(MYIDX)%
@@ -912,7 +914,7 @@ C                   VALUES BASED UPON MESH GEOMETRY.
                             SELECT CASE(LBCODEI(MYIDX))
                                 CASE(3,13,23)
                                     BARHT_FINAL(MYIDX) = BARLANHT(MYIDX)
-                                CASE(4,14,24,5,25)
+                                CASE(4,14,24,64,5,25)
                                     BARHT_FINAL(MYIDX) = BARINHT(MYIDX)
                             END SELECT
                         CASE DEFAULT
@@ -1300,7 +1302,7 @@ C...........................A ONE SIDED STYLE WEIR, WE DONT NEED X2 AND Y2
                                 BAR_SCHEDULE(IDX)%OFFSET = OFFSET   
                             ENDIF
 
-                        CASE(4,24,5,25)
+                        CASE(4,24,64,5,25)
 C...........................A TWO SIDED STYLE WEIR, WE NEED X2 AND Y2
                             CALL FIND_BOUNDARY_NODES(X2,Y2,IDX2)
                             IF(IDX2.EQ.-1)THEN
@@ -2107,6 +2109,201 @@ C..................INWARD SUPERCRITICAL FLOW -> CASE 6
                RETURN
 C-----------------------------------------------------------------------
             END SUBROUTINE COMPUTE_INTERNAL_BOUNDARY_FLUX
+C-----------------------------------------------------------------------
+
+C-----------------------------------------------------------------------
+C     S U B R O U T I N E 
+C       C O M P U T E _ I N T E R N A L _ B O U N D A R Y 6 4 _ F L U X
+C-----------------------------------------------------------------------
+C     THIS SUBROUTINE CONTAINS THE CALCULATIONS OF OVERTOPPING FLUX
+C     PASSED BETWEEN THE THE WEIR PAIR NODES. THIS IS THE VERSION OF
+C     THE CODE THAT CHECKS IF THE WEIR HAS A WET EDGE BEFORE PASSING
+C     FLUX OVER THE WEIR.
+C     THIS IS A SUBROUTINE THAT WORKS WITH IBTYPE=64. THIS RETURNS ZERO
+C     WHEN A WEIR IS SUBMERGED ON BOTH SIDES. SB
+C-----------------------------------------------------------------------
+            SUBROUTINE COMPUTE_INTERNAL_BOUNDARY64_FLUX(
+     &          BARRIER_INDEX,BOUNDARYNODE,BOUNDARY,TIMELOC,FLUX,
+     &          ISFRONT)
+
+                USE BOUNDARIES,ONLY:BARINCFSB,BARINCFSP,
+     &              NVELL,IBCONN,BARINHT,ISSUBMERGED64,NBV
+                USE GLOBAL,ONLY:NIBNODECODE,TVW,USE_TVW,NODECODE,H0
+                USE MESH,ONLY:LBArray_Pointer,MNEI,NEITAB,NNEIGH,DP
+                IMPLICIT NONE
+                INTEGER,INTENT(IN),TARGET   :: BARRIER_INDEX
+                INTEGER,INTENT(IN),TARGET   :: BOUNDARY
+                INTEGER,INTENT(IN),TARGET   :: BOUNDARYNODE
+                REAL(SZ),INTENT(IN)         :: TIMELOC
+                REAL(SZ),INTENT(OUT)        :: FLUX
+                LOGICAL,INTENT(IN)          :: ISFRONT
+
+                INTEGER                     :: NNBB1,NNBB2
+                INTEGER                     :: NNBB1WN,NNBB2WN
+                INTEGER                     :: FLOWDIR
+                INTEGER,POINTER             :: I,J,K
+                REAL(SZ)                    :: RBARWL1,RBARWL2,RBARWLL
+                REAL(SZ)                    :: RBARWL1F,RBARWL2F
+
+                CALL setMessageSource("COMPUTE_INTERNAL_BOUNDARY_FLUX")
+#if defined(WEIR_TRACE) || defined(ALL_TRACE) 
+                CALL allMessage(DEBUG,"Enter")
+#endif                
+
+C...............SIMPLIFY VARIABLES
+                I => BARRIER_INDEX
+                J => BOUNDARYNODE
+                K => BOUNDARY
+
+                NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
+                NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
+                NNBB1WN = 0      ! COUNT NUMBER OF WET NEIGHBORS
+                NNBB2WN = 0      ! COUNT NUMBER OF WET NEIGHBORS
+                FLOWDIR = 0      ! DIRECTION OF FLOW
+
+C...............CHECK TO SEE IF THERE IS A WET EDGE
+                IF( (J.EQ.1).OR.(J.EQ.NVELL(K)+1) )THEN
+                    NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
+                    NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
+                ELSE
+                    IF( J.EQ.NVELL(K).OR.(J.EQ.NVELL(K)*2) ) THEN
+                        NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
+                        NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
+                    ELSE
+                        NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
+                        NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
+                        NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
+                        NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
+                    ENDIF
+               ENDIF
+
+C..............CHECK TO SEE IF THE BARRIER ELEVATION NEEDS UPDATING
+               IF(INT_TVW)THEN
+                   IF(BAR_DEG(I))THEN
+                       CALL COMPUTE_BARRIER_HEIGHT(I,TIMELOC,BARINHT1(I)
+     &                  ,BARINHT2(I))
+                   ENDIF
+                   TVW(NNBB1) = BARINHT2(I)-BARINHT(I)
+               ENDIF
+
+C..............GET WATER LEVEL ABOVE WEIR ON EACH SIDE TO COMPUTE HEAD
+C              DEFINE COMPILER FLAG -DAVERAGEWEIRFLOW TO USE BARAVGWT,
+C              WHICH GENERALLY IS SET TO ZERO, AND IS HARD CODED
+C              TO ZERO HERE. READ_INPUT.F CONTAINS THE SPECIFICATION OF 
+C              BARAVGWT. WITH BARAVGWT SET TO ZERO, THERE IS NO NEED FOR
+C              IBSTART EITHER.
+#if AVERAGEWEIRFLOW
+               IF(IBSTART.EQ.0)THEN
+                  RBARWL1AVG(I)=ETA2(NNBB1)-BARINHT2(I)
+                  RBARWL2AVG(I)=ETA2(NNBB2)-BARINHT2(I)
+                  IBSTART=1
+               ELSE
+                  RBARWL1AVG(I)=(ETA2(NNBB1)-BARINHT2(I)+BARAVGWT
+     &                 *RBARWL1)/(1.D0+BARAVGWT)
+                  RBARWL2AVG(I)=(ETA2(NNBB2)-BARINHT2(I)+BARAVGWT
+     &                 *RBARWL2)/(1.D0+BARAVGWT)
+               ENDIF
+               RBARWL1=RBARWL1AVG(I)
+               RBARWL2=RBARWL2AVG(I)
+#else               
+C..............ZC - STREAMLINE THE PROCESS SINCE BARAVGWT IS ZERO BY DEFAULT
+               RBARWL1=ETA2(NNBB1)-BARINHT2(I)
+               RBARWL2=ETA2(NNBB2)-BARINHT2(I)
+#endif               
+C..............RBARWL on the lower ground side SB
+               IF(DP(NNBB1).GE.DP(NNBB2)) THEN
+                    RBARWLL = RBARWL1
+               ELSE
+                    RBARWLL = RBARWL2
+               ENDIF
+
+               RBARWL1F=2.D0*RBARWL1/3.D0
+               RBARWL2F=2.D0*RBARWL2/3.D0
+               FLUX=0.D0
+               ISSUBMERGED64(I) = 0
+               ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
+
+               IF(RBARWLL.GE.BARMIN64) THEN
+C...............THIS IS THE MAJOR DIFFERENCE OF IBTYPE=64 FROM IBTYPE=24.
+C               WATER LEVEL ON BOTH SIDES OF BARRIER ABOVE BARRIER -> CASE 0
+                  FLUX = 0.D0
+                  ISSUBMERGED64(I) = 1
+                  ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 1
+               ELSEIF((RBARWL1.LT.BARMIN64).AND.(RBARWL2.LT.BARMIN64)) THEN
+C...............WATER LEVEL ON BOTH SIDES OF BARRIER BELOW BARRIER -> CASE 1
+                  FLUX=0.D0
+               ELSEIF(ABS(RBARWL1-RBARWL2).LT.0.01D0) THEN
+C...............WATER LEVEL EQUAL ON BOTH SIDES OF BARRIER
+C................TO WITHIN TOLERANCE BARMIN -> CASE 2
+                  FLUX=0.D0
+               ELSEIF((RBARWL1.GT.RBARWL2).AND.(RBARWL1.GT.BARMIN64)) THEN
+C...............WATER LEVEL GREATER ON THIS SIDE OF THE BARRIER AND IS SUCH
+C................THAT OVERTOPPING IS OCCURING
+C................THUS THIS SIDE IS THE SOURCE SIDE OF THE FLOW ACROSS THE BARRIER
+C................NOTE THAT WE DO NOT FORCE THE SOURCE SIDE OF THE BARRIER TO
+C................REMAIN WET. ALSO WE CHECK TO SEE IF THE SOURCE SIDE OF THE
+C................BARRIER HAS BEEN DRIED. IF IT HAS WE SHUT DOWN THE FLOW ACROSS
+C................THE BARRIER
+C................ALSO WE CHECK TO SEE IF THE SOURCE SIDE OF THE BARRIER HAS AT
+C................LEAST ONE WET EDGE. IF NOT, WE SHUT DOWN THE FLOW ACROSS
+C................THE BARRIER. shintaro v46.28.sb05.05 11/01/2006
+                  IF(RBARWL2.GT.RBARWL1F) THEN
+C..................OUTWARD SUBCRITICAL FLOW -> CASE 3
+                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0) THEN
+                        FLUX=0.0D0
+                     ELSE
+                        FLUX=-RampIntFlux*RBARWL2*BARINCFSB(I)*
+     &                     (2.D0*G*(RBARWL1-RBARWL2))**0.5D0
+                    ENDIF
+                  ELSE
+C..................OUTWARD SUPERCRITICAL FLOW -> CASE 4
+                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0) THEN
+                        FLUX=0.0D0
+                     ELSE
+                        FLUX=-RampIntFlux*BARINCFSP(I)*RBARWL1F*
+     &                    (RBARWL1F*G)**0.5D0
+                     ENDIF
+                  ENDIF
+               ELSEIF((RBARWL2.GT.RBARWL1).AND.(RBARWL2.GT.BARMIN64)) THEN
+C...............WATER LEVEL LOWER ON THIS SIDE OF BARRIER AND IS SUCH
+C................THAT OVERTOPPING IS OCCURING
+C................THUS THIS IS THE RECEIVING SIDE OF THE FLOW ACROSS THE BARRIER
+C................NOTE THAT WE DO FORCE THE RECEIVING SIDE OF THE BARRIER TO
+C................REMAIN WET WHEN THERE IS FLOW ACROSS THE BARRIER.
+C................ALSO WE CHECK TO SEE IF THE SOURCE SIDE OF THE
+C................BARRIER HAS BEEN DRIED. IF IT HAS, WE SHUT DOWN THE FLOW ACROSS
+C................THE BARRIER
+C................ALSO WE CHECK TO SEE IF THE SOURCE SIDE OF THE BARRIER HAS AT
+C................LEAST ONE WET EDGE. IF NOT, WE SHUT DOWN THE FLOW ACROSS
+C................THE BARRIER. shintaro v46.28.sb05.05 11/01/2006
+                  IF(RBARWL1.GT.RBARWL2F) THEN
+C..................INWARD SUBCRITICAL FLOW -> CASE 5
+                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0) THEN
+                        FLUX=0.0D0
+                     ELSE
+                        FLUX=RampIntFlux*RBARWL1*BARINCFSB(I)*
+     &                     (2.0D0*G*(RBARWL2-RBARWL1))**0.5D0
+                     ENDIF
+                  ELSE
+C..................INWARD SUPERCRITICAL FLOW -> CASE 6
+                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0) THEN
+                        FLUX=0.0D0
+                     ELSE
+                        FLUX=RampIntFlux*BARINCFSP(I)*RBARWL2F*
+     &                     (RBARWL2F*G)**0.5D0
+                     ENDIF
+                  ENDIF
+               ELSE
+                  FLUX=0
+               ENDIF
+               
+#if defined(WEIR_TRACE) || defined(ALL_TRACE) 
+               CALL allMessage(DEBUG,"Return")
+#endif
+               CALL unsetMessageSource()
+               RETURN
+C-----------------------------------------------------------------------
+            END SUBROUTINE COMPUTE_INTERNAL_BOUNDARY64_FLUX
 C-----------------------------------------------------------------------
 
 C-----------------------------------------------------------------------

--- a/src/wetdry.F
+++ b/src/wetdry.F
@@ -122,17 +122,23 @@ CWET...
       subroutine computeWettingAndDrying(it)
       use sizes, only : sz, mne, mnp
       use nodalattributes,only: loadSubgridBarrier
-      use global, only : noff, nodecode, nnodecode, eta2, tk, nolifa,
+      use global, only : noff, nodecode, nnodecode, eta1, eta2, tk,
+     &    nolifa,
      &    bsx1, bsy1, btime_end, C2DDI, C3D, g, h0, ifnlfa, nddt, dtdp,
      &    nibnodecode, ilump, ncchange, tkm, directvelWD, useHF
 #ifdef CMPI
      &    ,idumy,dumy1,dumy2
       use messenger
 #endif
-      use mesh, only : ne, np, nm, dp, mju, totalArea, nm, x, y, areas
+      use mesh, only : ne, np, nm, dp, mju, totalArea, nm, x, y, areas,
+     &   LBArray_Pointer, nneighele, neitabele
       use nodalattributes, only : BFCdLLimit, fgamma, ftheta, fric,
      &   manningsn, hbreak, ifhybf, ifnlbf, iflinbf, loadManningsN,
-     &   loadZ0B_var, z0b_var, loadSubgridBarrier
+     &   loadZ0B_var, z0b_var, loadSubgridBarrier,
+     &   loadCondensedNodes,
+     &   ListCondensedNodes, NListCondensedNodes,
+     &   NNodesListCondensedNodes
+      USE BOUNDARIES, ONLY : IBCONN, ISSUBMERGED64, NFLUXIB64_GBL
       use global_3dvs, only : a, b, islip, kp, z0b, sigma, evtot, q
       use subdomain, only : subdomainOn, enforceBN, enforceWDcb, enforceWDob
       implicit none
@@ -156,9 +162,13 @@ CWET...
       real(sz) :: tk_tmp(np),tmp1(np),tmp2(np),tmp3(np)
       integer :: tk_cnt(np)
       integer :: nbnctot
-      integer :: i,j,k,kk
+      integer :: i,j,k,kk,l
       integer :: ie          
       real(sz) :: tknf !dmw 202207, added for "new" formula for vel 
+      integer :: nnc
+      integer :: nnbb2
+      integer :: nwetele
+  
       if (nolifa.ne.2) then
          return ! wetting and drying is not active 
       endif
@@ -196,13 +206,35 @@ CWET...
                   NNODECODE(I)=0
                   NODECODE(I)=0
                   NCCHANGE=NCCHANGE+1 !NCCHANGE=0 set near beginning of GWCE
-C                  ENDIF
                ENDIF
             ENDIF
          ENDDO
 CWET...
 CWET...END WET/DRY SECTION - PART 1
 CWET...
+
+C.....
+C.....Nodal Wetting Criteria for the ibtype=64 weir boundary
+C.....Check the node if it is along the ibtype=64 weir boundary and if the weir is
+C.....submerged. If it is the case, set the nnodecode to 1.   SB
+C.....
+         IF (NFLUXIB64_GBL.GT.0) THEN
+            DO I=1,NP
+               IF(LBArray_Pointer(I).GT.0) THEN
+                  J = LBArray_Pointer(I)
+                  IF((ISSUBMERGED64(J).GT.0).AND.(NODECODE(I).EQ.0)) THEN
+                     NNBB2=IBCONN(J)
+                     ETA2(I) = ETA2(NNBB2)
+                     HTOT=DP(I)+ETA2(I)
+                     IF(HTOT.GT.HOFF) THEN
+                        NNODECODE(I)=1
+                        NODECODE(I)=1
+                        NCCHANGE=NCCHANGE+1 !NCCHANGE=0 set near beginning of GWCE
+                     ENDIF
+                  ENDIF
+               ENDIF
+            ENDDO
+         ENDIF
 
 cjjwC     Use Message-Passing to update nodecode and nnodecode at ghost nodes
 cjjw#ifdef CMPI
@@ -1046,6 +1078,61 @@ CWET...
 CWET...
 CWET...END WET/DRY SECTION  - PART 3
 CWET...
+
+C.....
+C.....Nodal Drying Criteria for the ibtype=64 weir boundary
+C.....Check the node if it is along the ibtype=64 weir boundary and if the weir is
+C.....submerged. If it is the case and the node does not belong to at least 
+C.....one wet element, set the nnodecode back to 0.   SB
+C.....
+         IF (NFLUXIB64_GBL.GT.0) THEN
+            DO I=1,NP
+               IF(LBArray_Pointer(I).GT.0) THEN
+                  J = LBArray_Pointer(I)
+                  IF((ISSUBMERGED64(J).GT.0).AND.(NNODECODE(I).EQ.1)) THEN
+                     NNBB2=IBCONN(J)
+                     NWetEle = 0
+                     DO K=1,NNeighEle(I)
+                        IE = NeiTabEle(I,K)
+                        NCTOT = NNODECODE(NM(IE,1)) + 
+     &                          NNODECODE(NM(IE,2)) + NNODECODE(NM(IE,3))
+                        IF (NCTOT.EQ.3) THEN
+                           NWetEle = NWetEle + 1
+                        ENDIF
+                     ENDDO
+                     IF (NWetEle.EQ.0) THEN
+                        NNODECODE(I) = 0
+                     ENDIF
+                  ENDIF
+               ENDIF
+            ENDDO
+         ENDIF
+
+C.....
+C..... Section for condensed nodes
+C..... Setting the same nodecode value at grouped condensed nodes   SB
+C.....
+      IF(LoadCondensedNodes) THEN
+         DO K=1,NListCondensedNodes
+            I = ListCondensedNodes(K,1)
+            ! 0) DEFAULT VALUE
+            NNC = NNODECODE(I)
+            ! 1) FIND UPDATED VALUE 
+            DO L=2,NNodesListCondensedNodes(K)
+               J = ListCondensedNodes(K,L)
+               IF(NNODECODE(J).NE.NODECODE(J)) THEN
+                  NNC = NNODECODE(J)
+                  EXIT ! EXiT THE LOOP IF AN UPDATED NODECODE IS FOUND
+               ENDIF
+            ENDDO
+            ! 2) DISTRIBUTE IT
+            NNODECODE(I) = NNC
+            DO L=2,NNodesListCondensedNodes(K)
+               J = ListCondensedNodes(K,L)
+               NNODECODE(J) = NNC
+            ENDDO
+         ENDDO
+      ENDIF
 
 CWET...
 CWET...START WET/DRY SECTION PART 4 - NODAL DRYING LOOP D2

--- a/work/cmplrflags.mk
+++ b/work/cmplrflags.mk
@@ -177,7 +177,12 @@ ifeq ($(compiler),gfortran)
         FFLAGS2 := $(FFLAGS2) -I/usr/lib64/gfortran/modules
         FFLAGS3 := $(FFLAGS3) -I/usr/lib64/gfortran/modules
      endif
-     FLIBS      := $(FLIBS) -lnetcdff
+     ifeq ($(MACHINENAME),wsl2-ubuntu)
+        NETCDFHOME := /usr
+        FFLAGS1 := $(FFLAGS1) -I/usr/include
+        FFLAGS2 := $(FFLAGS2) -I/usr/include
+        FFLAGS3 := $(FFLAGS3) -I/usr/include
+     endif
   endif
   IMODS 	:=  -I
   CC		:= gcc

--- a/work/makefile
+++ b/work/makefile
@@ -356,6 +356,7 @@ ADC_MSRC   =  version.F sizes.F global.F
 POST_MSRC  =  post_global.F
 HARM_MSRC  =  harm.F
 VORT_MSRC  =  vortex.F
+VW1D_MSRC  =  vew1d.F
 
 ifeq ($(NETCDF),enable)
 WIND_MSRC  =  wind.F owiwind.F rs2.F owi_ice.F owiwind_netcdf.F
@@ -398,6 +399,7 @@ SOLV_MOBJ:= $(patsubst %.F, $(O_DIR)%.o, $(SOLV_MSRC) )
 ADC_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(ADC_MSRC)  )
 HARM_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(HARM_MSRC)  )
 VORT_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(VORT_MSRC)  )
+VW1D_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(VW1D_MSRC)  )
 WIND_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(WIND_MSRC)  )
 NA_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(NA_MSRC)  )
 NC_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(NC_MSRC)  )
@@ -417,7 +419,7 @@ BC3D_MOBJ :=  $(patsubst %.F, $(O_DIR)%.o, $(BC3D_MSRC) )
 
 METIS_SRC  =  metis.F
 PREP_SRC   =  adcprep.F decomp.F prep_weir.F read_global.F prep.F interp.F machdep.F
-ADC_SRC    =  adcirc.F weir_boundary.F wetdry.F read_input.F cstart.F hstart.F gwce.F momentum.F timestep.F vsmy.F transport.F
+ADC_SRC    =  adcirc.F weir_boundary.F wetdry.F read_input.F cstart.F hstart.F gwce.F momentum.F vew1d.F timestep.F vsmy.F transport.F
 POST_SRC   =  adcpost.F post.F compare.F diffmerge.F machdep.F
 P15_SRC    =  p15.F
 OWI_SRC    =  owi22.F
@@ -756,8 +758,8 @@ else
 $(O_DIR)nodalattr.o   :  nodalattr.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)mesh.o $(O_DIR)hashtable.o
 endif
 
-$(O_DIR)gwce.o        :  gwce.F $(O_DIR)itpackv.o $(O_DIR)nodalattr.o $(O_DIR)sponge_layer.o $(O_DIR)subdomain.o $(O_DIR)momentum.o
-$(O_DIR)momentum.o    :  momentum.F $(O_DIR)subdomain.o
+$(O_DIR)gwce.o        :  gwce.F $(O_DIR)itpackv.o $(O_DIR)nodalattr.o $(O_DIR)vew1d.o $(O_DIR)sponge_layer.o $(O_DIR)subdomain.o $(O_DIR)momentum.o
+$(O_DIR)momentum.o    :  momentum.F $(O_DIR)vew1d.o $(O_DIR)subdomain.o
 $(O_DIR)wetdry.o      :  wetdry.F $(O_DIR)subdomain.o
 $(O_DIR)messenger.o   :  messenger.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)global_3dvs.o
 #!st3 100711: Added globalio.o to writer.F for HSWRITER MODULE


### PR DESCRIPTION
A sequence of commits to add the IBTYPE=64 weir boundary (=vertical element wall) and nodal attribute "condensed_nodes" (1D condensation). Vertical element walls (=VEWs) are used to model jumps in the bottom depth representation and condensed_nodes are used to model quasi-1D computational nodes. They are used together to model quasi-1D channels.