### PR TITLE
Fix for tropical cyclones in southern hemisphere with parametric vortex models

### DIFF
--- a/src/wind.F
+++ b/src/wind.F
@@ -5096,8 +5096,11 @@ C     Compute the distances based on haversine formula for distance along a sphe
 C     Compute coriolis
          coriolis = 2.0d0 * omega * sin(YCOOR(I)*DEG2RAD)
 C     Compute pressure field
-         PRESS(I)=(cpress+(centralPressureDeficit)*
-     &        EXP(-(RMW*1000.d0/RAD(I))**B)) / (RHOWAT0*G)
+!P.V 11/04/2022 to account for Southern Hemisphere
+!         PRESS(I)=(cpress+(centralPressureDeficit)*
+!     &        EXP(-(RMW*1000.d0/RAD(I))**B)) / (RHOWAT0*G)
+         PRESS(I)=cpress+(centralPressureDeficit)*
+     &        EXP(-(RMW*1000.d0/RAD(I))**B)
 C     Compute velocity field with absolute around 
 C     CORIOLIS for the Southern Hempisphere
          V_r(I) = sqrt(
@@ -5117,8 +5120,18 @@ C     Apply mutliplier for Storm2 in LPFS ensemble.
          V_r(I) = V_r(I) * WindMultiplier
 C
 C     Find the velocity components.
+!P.V 11/04/2022 to account for Southern Hemisphere
+        !WVNX(I)=-V_r(I)*SIN(THETA(I))
+        !WVNY(I)= V_r(I)*COS(THETA(I))
+        ! Find the wind velocity components (caution to SH/NH)
+        if(lat.lt.0.d0) then ! SH
+         WVNX(I)= V_r(I)*SIN(THETA(I))
+         WVNY(I)=-V_r(I)*COS(THETA(I))
+        else ! NH
          WVNX(I)=-V_r(I)*SIN(THETA(I))
          WVNY(I)= V_r(I)*COS(THETA(I))
+        endif
+ 
 C
 C     jgf46.19 Convert wind velocity from top of atmospheric boundary
 C     layer (which is what the Holland curve fit produces) to wind
@@ -5143,6 +5156,17 @@ C            WVNX(I)=0.0d0
 C            WVNY(I)=0.0d0
 C         ENDIF
 C
+!P.V 11/04/2022
+        PRESS(I) = max(0.85d5,min(1.1e5,PRESS(I))) !Typhoon Tip 870 hPa ... 12-oct-1979
+        WVNX(I)  = max(-200.d0,min(200.d0,WVNX(I)))
+        WVNY(I)  = max(-200.d0,min(200.d0,WVNY(I)))
+        !-------------------------------------------
+        ! Convert atmospheric pressure (Pascals) to
+        ! atmospheric pressure-induced water surface
+        ! elevation (meters).
+        !-------------------------------------------
+        PRESS(I) = PRESS(I) / (RHOWAT0*G)
+
       END DO
 #if defined(WIND_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")
@@ -6787,7 +6811,9 @@ C     we are running off the end of the data.
      &                         wtratio*(cHollBs2(:)-cHollBs1(:))
       cVmwBL   =  cVmwBL1(:) +
      &                         wtratio*(cVmwBL2(:)-cVmwBL1(:))
-      corio = 2.0d0 * omega * SIN(deg2rad*cLat)
+      !P.V 11/04/2022
+      !Using absolute value for coriolis for Southern Hemisphere
+      corio = ABS(2.0d0 * omega * SIN(deg2rad*cLat))
 
 !Jie debug GAHM
 !         WRITE(16,700) 'Temporal interpolation:',
@@ -6880,6 +6906,13 @@ C     we are running off the end of the data.
          CALL uvpr(dist(i),aziangle(i),crmaxw(i),crmaxwTrue(i),
      &        cHollBs(i),cVmwBL(i),cPhiFactor(i),stormMotionU,
      &        stormMotionV,geofactor,wvnx(i),wvny(i),press(i))
+
+
+         !P.V 11/04/2022
+         press(i) = max(0.85d5,min(1.1e5,press(i)))  ! Typhoon Tip 870 hPa ... 12-oct-1979
+         wvnx(i)  = max(-200.d0,min(200.d0,wvnx(i)))
+         wvny(i)  = max(-200.d0,min(200.d0,wvny(i)))
+
          !-------------------------------------------
          ! Convert atmospheric pressure (Pascals) to
          ! atmospheric pressure-induced water surface

--- a/wind/vortex.F
+++ b/wind/vortex.F
@@ -162,7 +162,8 @@
       cLon = lon
       Vmax = vm
       ! evaluate basic physical params
-      corio = 2.0d0 * omega * SIN(deg2rad*cLat)
+!P.V 11/04/2022 use absolute coriolis to account for Southern Hemisphere
+      corio = ABS(2.0d0 * omega * SIN(deg2rad*cLat))
       B = (Vmax*kt2ms)**2 * RhoAir * EXP(1.d0)
      &             / ((Pn - Pc) * mb2pa)
       B = MAX( MIN(B,2.5d0), 1.0d0) ! limit B to range 1.0->2.5
@@ -186,7 +187,8 @@
       cLon = lon
       Vmax = vm
       ! evaluate basic physical params
-      corio = 2.0d0 * omega * SIN(deg2rad*cLat)
+!P.V 11/04/2022 use absolute coriolis to account for Southern Hemisphere
+      corio = ABS(2.0d0 * omega * SIN(deg2rad*cLat))
       B = (Vmax*kt2ms)**2 * RhoAir * EXP(1.d0)
      &             / ((Pn - Pc) * mb2pa)
       Phi=1.d0
@@ -221,7 +223,8 @@
       cLat = lat
       cLon = lon
       ! evaluate basic physical params
-      corio = 2.0d0 * omega * SIN(deg2rad*cLat)
+!P.V 11/04/2022 use absolute coriolis to account for Southern Hemisphere
+      corio = ABS(2.0d0 * omega * SIN(deg2rad*cLat))      
       END SUBROUTINE setVortex
 
 
@@ -699,8 +702,15 @@
       ! now reduce the wind speed to the surface
       speed = speed * windReduction
 
-      u = -speed * COS(deg2rad*angle)
-      v =  speed * SIN(deg2rad*angle)
+!P.V 11/04/2022 to account for Southern Hemisphere
+      ! Caution with SH/NH
+      if(cLat.lt.0.d0) then
+      u =  speed * COS(DEG2RAD * angle)
+      v = -speed * SIN(DEG2RAD * angle)
+      else
+      u = -speed * COS(DEG2RAD * angle)
+      v =  speed * SIN(DEG2RAD * angle)
+      endif
       !
       ! Alter wind direction by adding a frictional inflow angle
       CALL rotate(u,v, fang(dist,rmx), cLat, uf,vf)
@@ -840,8 +850,15 @@
       ! now reduce the wind speed to the surface
       speed = speed * windReduction
 
-      u = -speed * COS(deg2rad*iangle)
-      v =  speed * SIN(deg2rad*iangle)
+!P.V 11/05/2022 to account for Southern Hemisphere
+      ! Caution with SH/NH
+      if(cLat.lt.0.d0) then ! SH
+        u =  speed * COS(deg2rad*iangle)
+        v = -speed * SIN(deg2rad*iangle)
+      else
+        u = -speed * COS(deg2rad*iangle)
+        v =  speed * SIN(deg2rad*iangle)
+      endif
       !
       ! Alter wind direction by adding a frictional inflow angle
       CALL rotate(u,v, fang(idist,irmx_true), cLat, uf,vf)


### PR DESCRIPTION
This PR adds the missing -DHAVE_MPI_MOD for intel compilers and fixes HollandB/GAHM modules for southern hemisphere parametric winds (tested)