### PR TITLE
Adding compiler and cmake warnings for deprecated flags

### DIFF
--- a/cmake/options_select.cmake
+++ b/cmake/options_select.cmake
@@ -2,15 +2,15 @@
 option(PRECISION_8BYTE "Use 8-byte real numbers instead of 4-byte." ON)
 mark_as_advanced(PRECISION_8BYTE)
 
-# ##############################################################################
+# ######################################################################################################################
 # ...Output format options
 option(ENABLE_OUTPUT_NETCDF "Turn on netCDF output options" OFF)
 if(ENABLE_OUTPUT_NETCDF)
   option(ENABLE_OUTPUT_XDMF "Turn on XDMF output options" OFF)
 endif(ENABLE_OUTPUT_NETCDF)
-# ##############################################################################
+# ######################################################################################################################
 
-# ##############################################################################
+# ######################################################################################################################
 # ...Executables
 option(BUILD_ADCIRC "Build the serial ADCIRC executable" OFF)
 
@@ -23,14 +23,11 @@ endif(PERL_FOUND)
 if(MPI_FOUND)
   option(BUILD_ADCPREP "Build the MPI parallel ADCIRC preprocessor" OFF)
   option(BUILD_PADCIRC "Build the MPI parallel ADCIRC executable" OFF)
-  option(BUILD_LIBADCIRC_STATIC "Build the static library version of ADCIRC"
-         OFF)
-  option(BUILD_LIBADCIRC_SHARED "Build the shared library version of ADCIRC"
-         OFF)
+  option(BUILD_LIBADCIRC_STATIC "Build the static library version of ADCIRC" OFF)
+  option(BUILD_LIBADCIRC_SHARED "Build the shared library version of ADCIRC" OFF)
   if(PERL_FOUND)
     option(BUILD_PADCSWAN "Build the MPI parallel SWAN+ADCIRC executable" OFF)
-    option(BUILD_PUNSWAN "Build the MPI parallel unstructured SWAN executable"
-           OFF)
+    option(BUILD_PUNSWAN "Build the MPI parallel unstructured SWAN executable" OFF)
     mark_as_advanced(BUILD_PUNSWAN)
   endif(PERL_FOUND)
 endif(MPI_FOUND)
@@ -39,40 +36,64 @@ option(BUILD_ASWIP "Build ASWIP (ASymmetric Wind Input Preprocessor)")
 option(BUILD_UTILITIES "Build the ADCIRC utility programs" OFF)
 option(ENABLE_GRIB2 "Use GRIB2API static libraries." OFF)
 option(ENABLE_DATETIME "Use DATETIME static libraries." OFF)
-# ##############################################################################
+# ######################################################################################################################
 
-# ##############################################################################
+# ######################################################################################################################
 # ...No need to show CXX compilers on main screen
-mark_as_advanced(CLEAR CMAKE_CXX_COMPILER CMAKE_C_COMPILER
-                 CMAKE_Fortran_COMPILER)
-mark_as_advanced(CLEAR CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE
-                 CMAKE_Fortran_FLAGS_RELEASE)
-mark_as_advanced(CLEAR CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG
-                 CMAKE_Fortran_FLAGS_DEBUG)
-# ##############################################################################
+mark_as_advanced(
+  CLEAR
+  CMAKE_CXX_COMPILER
+  CMAKE_C_COMPILER
+  CMAKE_Fortran_COMPILER)
+mark_as_advanced(
+  CLEAR
+  CMAKE_CXX_FLAGS_RELEASE
+  CMAKE_C_FLAGS_RELEASE
+  CMAKE_Fortran_FLAGS_RELEASE)
+mark_as_advanced(
+  CLEAR
+  CMAKE_CXX_FLAGS_DEBUG
+  CMAKE_C_FLAGS_DEBUG
+  CMAKE_Fortran_FLAGS_DEBUG)
+# ######################################################################################################################
 
-# ##############################################################################
+# ######################################################################################################################
 # ...Library paths
 if(ENABLE_OUTPUT_XDMF)
-  if(NOT ${XDMFHOME} STREQUAL "")
+  if(NOT
+     ${XDMFHOME}
+     STREQUAL
+     "")
     set(XDMFHOME
         ${XDMFHOME}
         CACHE STRING "XDMF home path containing lib and include")
-  elseif(NOT $ENV{XDMFHOME} STREQUAL "")
+  elseif(
+    NOT
+    $ENV{XDMFHOME}
+    STREQUAL
+    "")
     set(XDMFHOME
         $ENV{XDMFHOME}
         CACHE STRING "XDMF home path containing lib and include")
-  else(NOT ${XDMFHOME} STREQUAL "")
+  else(
+    NOT
+    ${XDMFHOME}
+    STREQUAL
+    "")
     set(XDMFHOME
         "XDMF-NOTFOUND"
         CACHE STRING "XDMF home path containing lib and include")
-  endif(NOT ${XDMFHOME} STREQUAL "")
+  endif(
+    NOT
+    ${XDMFHOME}
+    STREQUAL
+    "")
 else(ENABLE_OUTPUT_XDMF)
   unset(XDMFHOME CACHE)
 endif(ENABLE_OUTPUT_XDMF)
-# ##############################################################################
+# ######################################################################################################################
 
-# ##############################################################################
+# ######################################################################################################################
 # ...Additional flags
 set(ADDITIONAL_FLAGS_ADCIRC
     ""
@@ -91,78 +112,58 @@ set(ADDITIONAL_FLAGS_ASWIP
 set(ADDITIONAL_FLAGS_UTLIITIES
     ""
     CACHE STRING "Additional flags for utility programs")
-# ##############################################################################
+# ######################################################################################################################
 
-# ##############################################################################
+# ######################################################################################################################
 # ...Options enabled via compiler flags within the code
 option(ENABLE_WARN_ELEV_DEBUG "Enable writing of the fort.69 debug file" OFF)
+if(ENABLE_WARN_ELEV_DEBUG)
+  message(
+    WARNING
+      "The compile time enabled fort.69 file is deprecated and the user should use the &warnElevControl namelist instead. This option will be removed in a future release."
+  )
+endif()
 
 option(IBM "Format code for IBM based architectures" OFF)
 option(SGI "Format code for SGI based architectures" OFF)
 option(SUN "Format code for SUN based architectures" OFF)
 option(CRAY "Format code for CRAY based architectures" OFF)
 option(CRAYX1 "Format code for CRAYX1 based architectures" OFF)
-mark_as_advanced(IBM SGI SUN CRAY CRAYX1)
+mark_as_advanced(
+  IBM
+  SGI
+  SUN
+  CRAY
+  CRAYX1)
 
 option(DEBUG_FULL_STACK "Write the detailed stack trace during debugging" OFF)
-option(DEBUG_FLUSH_MESSAGES "Do not allow caching of screen printed messages"
-       OFF)
+option(DEBUG_FLUSH_MESSAGES "Do not allow caching of screen printed messages" OFF)
 option(DEBUG_LOG_LEVEL "Force debug log level for screen messages" OFF)
-option(DEBUG_ALL_TRACE
-       "Write all tracing debug information to screen output during debugging"
-       OFF)
-option(DEBUG_GLOBALIO_TRACE
-       "Write tracing debug information from the GLOBALIO module" OFF)
-option(DEBUG_WRITER_TRACE
-       "Write tracing debug information for writer processors" OFF)
-option(DEBUG_WRITE_OUTPUT_TRACE
-       "Write tracing debug information for the write output module" OFF)
-option(DEBUG_WIND_TRACE "Write tracing debug information for the wind module"
-       OFF)
-option(DEBUG_WEIR_TRACE "Write tracing debug information for the weir module"
-       OFF)
-option(DEBUG_TVW_TRACE
-       "Write tracing debug information for the time varying weir module" OFF)
-option(DEBUG_VSMY_TRACE
-       "Write tracing debug information for the 3D momentum equation module"
-       OFF)
-option(DEBUG_TIMESTEP_TRACE
-       "Write the tracing debug information for the timestepping module" OFF)
-option(DEBUG_SUBPREP_TRACE
-       "Write the tracing debug information for the subdomain prep module" OFF)
-option(DEBUG_SUBDOMAIN_TRACE
-       "Write the tracing debug information for the subdomain module" OFF)
-option(DEBUG_READ_INPUT_TRACE
-       "Write the tracing debug information for the read_input module" OFF)
-option(DEBUG_OWIWIND_TRACE
-       "Write the tracing debug information for the OWI wind module" OFF)
-option(DEBUG_NODALATTR_TRACE
-       "Write the tracing debug information for the nodal attributes module"
-       OFF)
-option(DEBUG_NETCDF_TRACE
-       "Write the tracing debug information for the netCDF modle" OFF)
-option(
-  DEBUG_MESSENGER_TRACE
-  "Write the tracing debug information for the message passing (MPI) module"
-  OFF)
-option(DEBUG_MESH_TRACE
-       "Write the tracing debug information for the mesh module" OFF)
-option(DEBUG_HOTSTART_TRACE
-       "Write the tracing debug information for the hotstart module" OFF)
-option(DEBUG_GLOBAL_TRACE
-       "Write the tracing debug information for the global module" OFF)
-option(DEBUG_HARM_TRACE
-       "Write the tracing debug information for the harmonics module" OFF)
-option(DEBUG_COLDSTART_TRACE
-       "Write the tracing debug information for the coldstart module" OFF)
-option(DEBUG_COUPLE2SWAN_TRACE
-       "Write the tracing debug information for the couple2swan module" OFF)
-option(DEBUG_ADCIRC_TRACE
-       "Write the tracing debug information for the main ADCIRC module" OFF)
-option(DEBUG_HOLLAND
-       "Write the debugging information for the symmetric Holland model" OFF)
-option(DEBUG_NWS14 "Write the debugging information for NWS=14 interpolation"
-       OFF)
+option(DEBUG_ALL_TRACE "Write all tracing debug information to screen output during debugging" OFF)
+option(DEBUG_GLOBALIO_TRACE "Write tracing debug information from the GLOBALIO module" OFF)
+option(DEBUG_WRITER_TRACE "Write tracing debug information for writer processors" OFF)
+option(DEBUG_WRITE_OUTPUT_TRACE "Write tracing debug information for the write output module" OFF)
+option(DEBUG_WIND_TRACE "Write tracing debug information for the wind module" OFF)
+option(DEBUG_WEIR_TRACE "Write tracing debug information for the weir module" OFF)
+option(DEBUG_TVW_TRACE "Write tracing debug information for the time varying weir module" OFF)
+option(DEBUG_VSMY_TRACE "Write tracing debug information for the 3D momentum equation module" OFF)
+option(DEBUG_TIMESTEP_TRACE "Write the tracing debug information for the timestepping module" OFF)
+option(DEBUG_SUBPREP_TRACE "Write the tracing debug information for the subdomain prep module" OFF)
+option(DEBUG_SUBDOMAIN_TRACE "Write the tracing debug information for the subdomain module" OFF)
+option(DEBUG_READ_INPUT_TRACE "Write the tracing debug information for the read_input module" OFF)
+option(DEBUG_OWIWIND_TRACE "Write the tracing debug information for the OWI wind module" OFF)
+option(DEBUG_NODALATTR_TRACE "Write the tracing debug information for the nodal attributes module" OFF)
+option(DEBUG_NETCDF_TRACE "Write the tracing debug information for the netCDF modle" OFF)
+option(DEBUG_MESSENGER_TRACE "Write the tracing debug information for the message passing (MPI) module" OFF)
+option(DEBUG_MESH_TRACE "Write the tracing debug information for the mesh module" OFF)
+option(DEBUG_HOTSTART_TRACE "Write the tracing debug information for the hotstart module" OFF)
+option(DEBUG_GLOBAL_TRACE "Write the tracing debug information for the global module" OFF)
+option(DEBUG_HARM_TRACE "Write the tracing debug information for the harmonics module" OFF)
+option(DEBUG_COLDSTART_TRACE "Write the tracing debug information for the coldstart module" OFF)
+option(DEBUG_COUPLE2SWAN_TRACE "Write the tracing debug information for the couple2swan module" OFF)
+option(DEBUG_ADCIRC_TRACE "Write the tracing debug information for the main ADCIRC module" OFF)
+option(DEBUG_HOLLAND "Write the debugging information for the symmetric Holland model" OFF)
+option(DEBUG_NWS14 "Write the debugging information for NWS=14 interpolation" OFF)
 mark_as_advanced(
   DEBUG_GLOBALIO_TRACE
   DEBUG_WRITER_TRACE
@@ -190,15 +191,18 @@ mark_as_advanced(
   DEBUG_NWS14
   IBM)
 
-option(
-  ENABLE_POWELL
-  "Force Powell wind drag to be enabled. Warning: Overrides any other options specified at run time."
-  OFF)
+option(ENABLE_POWELL
+       "Force Powell wind drag to be enabled. Warning: Overrides any other options specified at run time." OFF)
 mark_as_advanced(ENABLE_POWELL)
+if(ENABLE_POWELL)
+  message(
+    WARNING
+      "The compile time enabled Powell wind drag forcing is deprecated and users should switch to the &metControl namelist. This feature will be removed in a future release"
+  )
+endif()
 
 option(VECTOR_COMPUTER "Assume the system is a vector computer" OFF)
 mark_as_advanced(VECTOR_COMPUTER)
 
-option(ADCIRC_NOF2008
-       "The fortran compiler being used does not have F2008 intrinsics" OFF)
+option(ADCIRC_NOF2008 "The fortran compiler being used does not have F2008 intrinsics" OFF)
 mark_as_advanced(ADCIRC_NOF2008)

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -710,6 +710,7 @@ C
 #else
 C     jgf46.10 Add user-controllable warning, output, and stop criteria
 C     for elevations. 
+#warning The -DDEBUG_WARN_ELEV flag will be removed in a future release. Please begin using the &warnElevControl namelist to avoid future issues 
       READ(15,*) NFOVER, WarnElev, iWarnElevDump, WarnElevDumpLimit,
      &  ErrorElev
 #endif

--- a/src/wind.F
+++ b/src/wind.F
@@ -117,6 +117,8 @@ C
 #else
       ! jgf50.32 Provide backward compatibility with hardcoded POWELL
       ! support.
+#warning The flag -DPOWELL is deprecated and will be removed in a future release. Please use the &metcontrol name list functionality to avoid issues
+      
       CHARACTER(len=10) :: DragLawString = 'Powell'
       INTEGER :: dragLawType = DRAGLAW_POWELL
 #endif


### PR DESCRIPTION
Based on some recent listserv traffic, it seems prudent to start throwing warnings when behavioral flags are thrown at the code to ensure compatibility between input files. This change ensures that the input files the model uses generate results with the same assumptions and different builds do not change physics or input file formats.

Flags being deprecated:
`-DPOWELL` - Enable the Powell wind drag formulation. Users should switch to using the `&metControl` namelist.

`-DWARN_ELEV_DEBUG` - Enable writing of the fort.69 file. Users should switch to using the `&warnElevControl` namelist.

The code uses the `#warning` compiler directive to alert the user during the build and the cmake build system will also throw a warning alerting users to deprecation at configuration time