### PR TITLE
Fixing issue where some nodal attributes were not skipped when necessary

### DIFF
--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -1456,12 +1456,16 @@ C 09232016 WP : Spatially varying linear internal tide friction
      &              OverlandReductionFactorDefaultValue,
      &              NumNodesNotDefault,nScreen,MyProc,
      &              NAbOut)
+            ELSE
+              SkipDataSet = .True.
             ENDIF
          CASE("subgrid_barrier")
              IF(LoadSubgridBarrier)THEN
                  CALL LoadAttrMat(SubgridBarrier,SubgridBarrierNoOfVals,
      &              subgridBarrierDefaultValue,NumNodesNotDefault,
      &              nScreen,MyProc,NAbOut)
+             ELSE
+               SkipDataSet = .True.
              ENDIF
 C          WP
 !------- DW ---- Absorbing layer -----------


### PR DESCRIPTION
If a fort.13 had certain attributes but they were not used in the fort.15, this could trigger a failed reading of the fort.13 file at startup of a simulation