### PR TITLE
fixing wind dir bug from copy/paste error in owiwind_netcdf.F for NWS13

### DIFF
--- a/src/owiwind_netcdf.F
+++ b/src/owiwind_netcdf.F
@@ -832,8 +832,8 @@
                 sWdir = 0.
               ELSE
                 sWdir = ATAN2(UU(iV),VV(iV))
-                UU(IV) = -Wind(IV)*SIN(sWDir)
-                VV(IV) = -Wind(IV)*COS(sWDir)
+                UU(IV) = Wind(IV)*SIN(sWDir)
+                VV(IV) = Wind(IV)*COS(sWDir)
               ENDIF
               ! Casey 200528
               PRN2(IV) = PP(IV)


### PR DESCRIPTION
A section in "src/owiwind_netcdf.F" that scaled interpolated U/V by the WS was copied from internal code that was using meteorological (from-which) convention for direction, causing a bug in wind direction in the v55 NWS13 wind field inputs. This fix corrects vector scaling code so that U/V and directions are correctly to-which within the fortran.