### PR TITLE
MDAL "long_name" compatibility for netcdf vector component outputs

### DIFF
--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -1195,7 +1195,7 @@ C
                select case(abs(nws))
                   case(1,2)
                     iret = nf90_put_att(sta%ncid, sta%u_station_data_id,
-     &                      'long_name', 'station e/w wind stress')
+     &                      'long_name', 'station wind stress u-component')
                     CALL check_err(iret)
                     iret = nf90_put_att(sta%ncid, sta%u_station_data_id,
      &                     'standard_name',
@@ -1204,7 +1204,7 @@ C
                     iret = nf90_put_att(sta%ncid, sta%u_station_data_id,
      &                     'positive', 'east')
                     iret = nf90_put_att(sta%ncid, sta%v_station_data_id,
-     &                     'long_name', 'station n/s wind stress')
+     &                     'long_name', 'station wind stress v-component')
                     CALL check_err(iret)
                     iret = nf90_put_att(sta%ncid, sta%v_station_data_id,
      &                    'standard_name',
@@ -1215,7 +1215,7 @@ C
                     CALL check_err(iret)
                   case default
                     iret = nf90_put_att(sta%ncid, sta%u_station_data_id,
-     &                     'long_name', 'station e/w wind velocity')
+     &                     'long_name', 'station wind speed at 10m u-component')
                     CALL check_err(iret)
                     iret = nf90_put_att(sta%ncid, sta%u_station_data_id,
      &                     'standard_name',
@@ -1225,7 +1225,7 @@ C
      &                     'positive', 'east')
                     iret = nf90_put_att(sta%ncid, sta%v_station_data_id,
      &                     'long_name',
-     &                     'station n/s wind velocity')
+     &                     'station wind speed at 10m v-component')
                     CALL check_err(iret)
                     iret = nf90_put_att(sta%ncid, sta%v_station_data_id,
      &                     'standard_name', 'station_northward_wind')
@@ -2404,7 +2404,7 @@ C
                   case(1,2)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'long_name',
-     &                       'e/w wind stress')
+     &                       'wind stress u-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'standard_name',
@@ -2415,7 +2415,7 @@ C
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                       'long_name',
-     &                       'n/s wind stress')
+     &                       'wind stress v-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                      'standard_name',
@@ -2426,7 +2426,7 @@ C
                      CALL check_err(iret)
                   case default
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
-     &               'long_name', 'e/w wind velocity')
+     &               'long_name', 'wind speed at 10m u-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'standard_name', 'eastward_wind')
@@ -2435,7 +2435,7 @@ C
      &                     'positive', 'east')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
-     &                     'long_name', 'n/s wind velocity')
+     &                     'long_name', 'wind speed at 10m v-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                       'standard_name', 'northward_wind')
@@ -3073,7 +3073,7 @@ C
                   case(1,2)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'long_name',
-     &                       'e/w wind stress')
+     &                       'wind stress u-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'standard_name',
@@ -3084,7 +3084,7 @@ C
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                       'long_name',
-     &                       'n/s wind stress')
+     &                       'wind stress v-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                      'standard_name',
@@ -3095,7 +3095,7 @@ C
                      CALL check_err(iret)
                   case default
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
-     &               'long_name', 'e/w wind velocity')
+     &               'long_name', 'wind speed at 10m u-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%u_nodal_data_id,
      &                      'standard_name', 'eastward_wind')
@@ -3104,7 +3104,7 @@ C
      &                     'positive', 'east')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
-     &                     'long_name', 'n/s wind velocity')
+     &                     'long_name', 'wind speed at 10m v-component')
                      CALL check_err(iret)
                      iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id,
      &                       'standard_name', 'northward_wind')
@@ -5452,7 +5452,7 @@ C     U V E L
       CALL check_err(iret)
       if (ics.ne.1) then
          iret = nf90_put_att(hs%ncid, hs%vel%u_nodal_data_id,
-     &          'long_name', 'vertically averaged e/w velocity')
+     &          'long_name', 'vertically averaged water velocity u-component')
          CALL check_err(iret)
          iret = nf90_put_att(hs%ncid, hs%vel%u_nodal_data_id,
      &          'positive', 'east')
@@ -5483,13 +5483,13 @@ C     V V E L
       CALL check_err(iret)
       if (ics.ne.1) then
          iret = nf90_put_att(hs%ncid, hs%vel%v_nodal_data_id,
-     &           'long_name', 'vertically averaged n/s velocity')
+     &           'long_name', 'vertically averaged water velocity v-component')
          CALL check_err(iret)
          iret = nf90_put_att(hs%ncid, hs%vel%v_nodal_data_id,
      &           'positive', 'north')
       else
          iret = nf90_put_att(hs%ncid, hs%vel%v_nodal_data_id,
-     &       'long_name','vertically averaged velocity in y-direction')
+     &       'long_name','vertically averaged water velocity in y-direction')
          CALL check_err(iret)
          iret = nf90_put_att(hs%ncid, hs%vel%v_nodal_data_id,
      &  'positive', '90 degrees counterclockwise from x water velocity')


### PR DESCRIPTION
From @acrosby (#359)

This commit changes the following in **src/netcdfio.F**:
* all "n/s" and "e/w" `long_name` netcdf attributes to MDAL vector logic compatible "{u,v}-component" names
* "velocity" output for 2D depth-average currents include "water velocity" in the `long_name` now

Does not change:
* `standard_name`s
*  x-direction/y-direction `long_name`s (except for the case of adding "water" to the depth-avg current attrs)

TLDR: Modifications to vector output `long_name`s to make them more MDAL (mesh data abstraction layer) library compatible for QGIS and other GIS systems, without changing anything related to the CF or UGRID encoding standards.