### PR TITLE
Fixes for NOAA Version of Code -- Velcheck and store H1 and H2 to fix Subgrid Barriers

### DIFF
--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -377,7 +377,7 @@ C******************************************************************************
       SUBROUTINE ADCIRC_Run(NTIME_STP)
       USE SIZES, ONLY : mnproc, mnwproc, mnwproh, myproc
       USE GLOBAL, ONLY : iTime, DEBUG, INFO, setMessageSource, allMessage,
-     &   unsetMessageSource, statim, dtdp, screenunit, logMessage
+     &   unsetMessageSource, statim, dtdp, screenunit, logMessage, earlyterminate
 #ifdef CMPI
       USE WRITER, ONLY : writer_main, writer_pause, sendLabelInfoToWriters
       USE HSWRITER, ONLY : hswriter_main, hswriter_pause
@@ -432,10 +432,15 @@ C             to then call the SWAN time-stepping subroutine.
           CALL PADCSWAN_RUN(ITIME)
         ENDIF
 #endif
+        if ( earlyterminate.ne.0 ) then 
+           call writeOutput2D(ITIME_END,TimeLoc) 
+           exit
+        else
         !...WRITE OUTPUT
         !   zc - moved this here so that output occurs after
         !        the SWAN time step has been completed.
-        CALL writeOutput2D(ITIME,TimeLoc) ! =>see write_output.F
+            CALL writeOutput2D(ITIME,TimeLoc) ! =>see write_output.F
+        endif
 100   CONTINUE
 C
       IF (PRESENT(NTIME_STP)) THEN

--- a/src/global.F
+++ b/src/global.F
@@ -33,7 +33,9 @@ C... v49.48 tcm -- added for coupling with STWAVE (NRS=4)
       REAL(8)  :: STARTWAVE   ! Start of Wave Service
       REAL(8)  :: ENDWAVE     ! End of Wave Service
       LOGICAL  :: CPL2STWAVE = .FALSE.  !Coupled to STWAVE (NRS=4)
-      LOGICAL  :: Flag_ElevError = .FALSE.  
+      LOGICAL  :: Flag_ElevError = .FALSE. 
+C     DMW 202401 Check for velocity exceeding error level
+      LOGICAL  :: Flag_VelError = .FALSE.     
 
 C
 C... v50.xx sm -- added for coupling with NOUPC Cap
@@ -60,6 +62,10 @@ C     jgf46.10 user-controlled warning, dump and error levels on elevations
       REAL(8) ErrorElev      ! ADCIRC terminates if this elev is exceeded
       INTEGER :: screenUnit = 6 ! jgf46.19 I/O unit where screen output is sent
       INTEGER :: Terminate_LocalProc = 0 ! zc - allow a single processor to initiate code shutdown
+C     DMW 202401 Check for velocity exceeding error level as well as NaNs
+      REAL(8) ErrorVel      ! ADCIRC terminates if this vel is exceeded
+      INTEGER :: earlyterminate = 0
+      INTEGER :: IT_foundNaN
 C
 C     Variables related to hotstarting.
       type HOTSTART_t

--- a/src/global.F
+++ b/src/global.F
@@ -65,7 +65,7 @@ C     jgf46.10 user-controlled warning, dump and error levels on elevations
 C     DMW 202401 Check for velocity exceeding error level as well as NaNs
       REAL(8) ErrorVel      ! ADCIRC terminates if this vel is exceeded
       INTEGER :: earlyterminate = 0
-      INTEGER :: IT_foundNaN
+      INTEGER :: IT_foundNaN = 0
 C
 C     Variables related to hotstarting.
       type HOTSTART_t
@@ -210,7 +210,7 @@ c.
 #endif
       !jgf50.44: Added variable to record the time that the min or max
       ! has occurred
-      REAL(8),ALLOCATABLE, TARGET ::  ETA1(:), ETA2(:), UU2(:), VV2(:)
+      REAL(8),ALLOCATABLE, TARGET ::  ETA1(:), ETA2(:), UU2(:), VV2(:), H1(:), H2(:) ! DMW202401 Added variables for tracking flow depths
       REAL(8),ALLOCATABLE, TARGET ::  ETAMAX(:) ! v46.50 sb 11/11/2006
       REAL(8),ALLOCATABLE, TARGET ::  UMAX(:) ! v46.50 sb 11/11/2006
       REAL(8),ALLOCATABLE, TARGET ::  ET00(:), UU00(:), VV00(:)
@@ -1153,6 +1153,10 @@ C- DMW
       ALLOCATE ( ETA1(MNP),ETA2(MNP))
       eta1(:) = -99999.d0
       eta2(:) = -99999.d0
+C.....DMW202401 Added variables for tracking flow depths
+      ALLOCATE ( H1(MNP),H2(MNP))
+      h1(:) = -99999.d0
+      h2(:) = -99999.d0
       ALLOCATE ( CORIF(MNP))
       corif(:) = -99999.d0      
       ALLOCATE ( NODECODE(MNP))

--- a/src/gwce.F
+++ b/src/gwce.F
@@ -220,7 +220,7 @@ C
 #endif
       USE SIZES, ONLY : myproc
       USE GLOBAL, ONLY : GWCE_LV, COEF, COEFD, OBCCOEF, ETAS, ETA1, ETA2,
-     &   ESBIN1, ESBIN2, C2DDI, C3D, CBaroclinic, CGWCE_Advec_C1,
+     &   ESBIN1, ESBIN2, C2DDI, C3D, CBaroclinic, CGWCE_Advec_C1, H1, H2,
      &   CGWCE_Advec_C2, CGWCE_Advec_NC, CGWCE_LS_2PartQ, CGWCE_LS_2PartSQ,
      &   CGWCE_LS_2PartV, CGWCE_LS_2PartSV, CGWCE_LS_KGQ, CPRECOR,
      &   CSmag_Eh, Smag_Comp_Flag, CTIP, DT, FluxSettlingIT, IFNLCAT,
@@ -295,7 +295,7 @@ C... SB
       REAL(8) EVMEle, EVMSmag
       REAL(8) GA00DPAvgOAreaIE4
       REAL(8) GHAvg, GHAvgOAreaIE2, GOAreaIE4
-      REAL(8) H1N1, H1N2, H1N3, HAvg, H1, H2
+      REAL(8) H1N1, H1N2, H1N3, HAvg
       REAL(8) H2OTotalArea
       REAL(8) LSXXGradA, LSXYGradA, LSYXGradA, LSYYGradA
       REAL(8) LSXXEle, LSXYEle, LSYXEle, LSYYEle
@@ -797,8 +797,8 @@ C........ END DW:
 
          DO I=1,NP
             IF(TotalArea(I).NE.0.) THEN
-               H2=DP(I)+IFNLFA*ETA2(I)
-               H2OTotalArea=H2/TotalArea(I)
+C..............DMW202401 Use saved H2
+               H2OTotalArea=H2(I)/TotalArea(I)
                IF (CGWCE_LS_2PartV) THEN          !nonsymmetric
                   LSXX(I)=H2OTotalArea*LSXX(I)
                   LSXY(I)=H2OTotalArea*LSXY(I)
@@ -963,9 +963,10 @@ Corbitt 120322: Localized Advection
          QY1N1=QY1(NM1)
          QY1N2=QY1(NM2)
          QY1N3=QY1(NM3)
-         H1N1=DP(NM1)+IFNLFA*E1N1
-         H1N2=DP(NM2)+IFNLFA*E1N2
-         H1N3=DP(NM3)+IFNLFA*E1N3
+C........DMW202401 Use saved H2
+         H1N1=H2(NM1)
+         H1N2=H2(NM2)
+         H1N3=H2(NM3)
          EVMN1=EVM(NM1)
          EVMN2=EVM(NM2)
          EVMN3=EVM(NM3)
@@ -1217,13 +1218,13 @@ C        Ali et al. formula
             Ma2    = G*DPavg/Cs2
             CfacS0 = (1.0D0 - 0.25D0*Ma2 - Ad*DPavgS0**Bd)**2D0
          endif
-         ! DMW 2022/06 Apply slope limiting to gravity
+         ! DMW 202206 Apply slope limiting to gravity
          GDPAvgOAreaIE4 = ALPHAL(IE)*G*DPAvg*Cfac/AreaIE4
-         ! DMW 2022/06 Apply slope limiting to gravity
+         ! DMW 202206 Apply slope limiting to gravity
          GDPAvgOAreaIE4_S0 = ALPHAL(IE)*G*DPAvgS0*CfacS0/AreaIE4
 C....  END DW & WJP
          HAvg=(H1N1+H1N2+H1N3)/3.d0
-         ! DMW 2022/06 Apply slope limiting to gravity
+         ! DMW 202206 Apply slope limiting to gravity
          GHAvg=ALPHAL(IE)*G*HAvg
          GHAvgOAreaIE2=GHAvg/AreaIE2
          BSXAvg=(BSXN1+BSXN2+BSXN3)/3.d0
@@ -1503,6 +1504,8 @@ ckmd  Need to save z(s-1) and etas(s-1) for the corrector loop
             Eta0(I)=Eta1(I)
          END IF
          Eta1(I)=Eta2(I)
+C........DMW202401 Add update for flow depth at previous timestep, H1
+         H1(I) = H2(I)
          Eta2(I)=0.0d0
       END DO
 
@@ -1621,14 +1624,14 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
      &        QFORCEJ=(QN2(1)-QN0(1))/DT2 + Tau0VAR(NBDJ)*QN1(1)
 
          IF (LBCODEI(1).EQ.30) THEN
-            H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-            CELERITY=SQRT(G*H1)
+C...........DMW202401 Use saved H1
+            CELERITY=SQRT(G*H1(NBDJ))
             QFORCEJ=-CELERITY*ETAS(NBDJ)/DT - Tau0VAR(NBDJ)*QN1(1)
          ENDIF
 
          IF (LBCODEI(1).EQ.32) THEN
-            H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-            CELERITY=SQRT(G*H1)
+C...........DMW202401 Use saved H1
+            CELERITY=SQRT(G*H1(NBDJ))
 !C DW, Below is an original scheme and is correct 
 !C            QFORCEJ=(QN1(1)-QN0(1))/DT
 !C     &           -CELERITY*(ETAS(NBDJ)-(EN1(1)-EN0(1)))/DT
@@ -1647,8 +1650,8 @@ C     jgf46.21 Added IBTYPE=52.
          IF(LBCODEI(1).EQ.52) THEN
             QFORCEJ=(QN2(1)-QN0(1))/DT2 + Tau0VAR(NBDJ)*QN1(1)
             IF (IT.GT.FluxSettlingIT) THEN
-               HH1=DP(NBDJ)+IFNLFA*Eta1(NBDJ)
-               Celerity=SQRT(G*HH1)
+C..............DMW202401 Use saved H1
+               Celerity=SQRT(G*H1(NBDJ))
                QforceJ=QforceJ - Celerity*(EtaS(NBDJ)/DT
      &              + Tau0Var(NBDJ)*(Eta1(NBDJ)-ElevDisc(1)))
             ENDIF
@@ -1662,14 +1665,14 @@ C
             IF((LBCODEI(J).LE.29).OR.(LBCODEI(J).EQ.64))     ! 64 is added for VEW  08-11-2022 SB
      &           QFORCEJ=(QN2(J)-QN0(J))/DT2 + Tau0VAR(NBDJ)*QN1(J)
             IF(LBCODEI(J).EQ.30) THEN
-               H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-               CELERITY=SQRT(G*H1)
+C..............DMW202401 Use saved H1
+               CELERITY=SQRT(G*H1(NBDJ))
                QFORCEJ=-CELERITY*ETAS(NBDJ)/DT - Tau0VAR(NBDJ)*QN1(J)
             ENDIF
 
             IF(LBCODEI(J).EQ.32) THEN
-               H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-               CELERITY=SQRT(G*H1)
+C..............DMW202401 Use saved H1
+               CELERITY=SQRT(G*H1(NBDJ))
 !C DW, This is an original formula and is definitely correct (1st order in time)
 !C                QFORCEJ=(QN1(J)-QN0(J))/DT
 !C     &              -CELERITY*(ETAS(NBDJ)-(EN1(J)-EN0(J)))/DT
@@ -1688,8 +1691,8 @@ C     jgf46.21 Added IBTYPE=52
             IF(LBCODEI(J).EQ.52) THEN
                QFORCEJ=(QN2(J)-QN0(J))/DT2 + Tau0VAR(NBDJ)*QN1(J)
                IF (IT.GT.FluxSettlingIT) THEN
-                  HH1=DP(NBDJ)+IFNLFA*Eta1(NBDJ)
-                  Celerity=SQRT(G*HH1)
+C.................DMW202401 Use saved H1
+                  Celerity=SQRT(G*H1(NBDJ))
                   QforceJ=QforceJ - Celerity*(EtaS(NBDJ)/DT
      &                 + Tau0Var(NBDJ)*(Eta1(NBDJ)-ElevDisc(J)))
                ENDIF
@@ -2003,7 +2006,7 @@ C*******************************************************************************
 C
       USE SIZES
       USE GLOBAL, ONLY : GWCE_LV, COEF, COEFD, OBCCOEF, ETAS, ETA1, ETA2,
-     &   ESBIN1, ESBIN2, C2DDI, C3D, CBaroclinic, CGWCE_Advec_C1,
+     &   ESBIN1, ESBIN2, C2DDI, C3D, CBaroclinic, CGWCE_Advec_C1, H1, H2,
      &   CGWCE_Advec_C2, CGWCE_Advec_NC, CGWCE_LS_2PartQ, CGWCE_LS_2PartSQ,
      &   CGWCE_LS_2PartV, CGWCE_LS_2PartSV, CGWCE_LS_KGQ, CPRECOR,
      &   CSmag_Eh, Smag_Comp_Flag, CTIP, DT, FluxSettlingIT, IFNLCAT,
@@ -2055,7 +2058,7 @@ C
       REAL(8) EVMN1, EVMN2, EVMN3, EVMXGrad, EVMYGrad, EVMAvgODT
       REAL(8) EVMEle, EVMSmag
       REAL(8) GHAvg, GHAvgOAreaIE2, GOAreaIE4
-      REAL(8) H1N1, H1N2, H1N3, H2N1, H2N2, H2N3, HAvg, H1, H2
+      REAL(8) H1N1, H1N2, H1N3, H2N1, H2N2, H2N3, HAvg
       REAL(8) H2OTotalArea
       REAL(8) LSXXGradA, LSXYGradA, LSYXGradA, LSYYGradA
       REAL(8) LSXXEle, LSXYEle, LSYXEle, LSYYEle
@@ -2228,8 +2231,8 @@ C...  Compute the Lateral Stress Field using the 2 Part velocity approach (nonsy
 
          DO I=1,NP
             IF(TotalArea(I).NE.0.) THEN
-               H2=DP(I)+IFNLFA*ETA2(I)
-               H2OTotalArea=H2/TotalArea(I)
+C..............DMW202401 Use saved H2
+               H2OTotalArea=H2(I)/TotalArea(I)
                IF (CGWCE_LS_2PartV) THEN          !nonsymmetric
                   LSXX(I)=H2OTotalArea*LSXX(I)
                   LSXY(I)=H2OTotalArea*LSXY(I)
@@ -2350,14 +2353,13 @@ ckmd
             UV1=SQRT(UU1(I)*UU1(I)+VV1(I)*VV1(I))
             UV2=SQRT(UU2(I)*UU2(I)+VV2(I)*VV2(I))
             H00=DP(I)+IFNLFA*ETA0(I)
-            H1=DP(I)+IFNLFA*ETA1(I)
-            H2=DP(I)+IFNLFA*ETA2(I)
+C...........DMW202401 Use saved H1 and H2           
             TK0(I)=FRIC(I)*(IFLINBF + (UV0/H00)*(IFNLBF + IFHYBF*
      &           (1+(HBREAK/H00)**FTHETA)**(FGAMMA/FTHETA)))
-            TK(I)=FRIC(I)*(IFLINBF + (UV1/H1)*(IFNLBF + IFHYBF*
-     &           (1+(HBREAK/H1)**FTHETA)**(FGAMMA/FTHETA)))
-            TK2(I)=FRIC(I)*(IFLINBF + (UV2/H2)*(IFNLBF + IFHYBF*
-     &           (1+(HBREAK/H2)**FTHETA)**(FGAMMA/FTHETA)))
+            TK(I)=FRIC(I)*(IFLINBF + (UV1/H1(I))*(IFNLBF + IFHYBF*
+     &           (1+(HBREAK/H1(I))**FTHETA)**(FGAMMA/FTHETA)))
+            TK2(I)=FRIC(I)*(IFLINBF + (UV2/H2(I))*(IFNLBF + IFHYBF*
+     &           (1+(HBREAK/H2(I))**FTHETA)**(FGAMMA/FTHETA)))
        END DO
 
 ckmd      Added in the time weights
@@ -2449,12 +2451,13 @@ Corbitt 120322: Localized Advection
          H0N1=DP(NM1)+IFNLFA*E0N1
          H0N2=DP(NM2)+IFNLFA*E0N2
          H0N3=DP(NM3)+IFNLFA*E0N3
-         H1N1=DP(NM1)+IFNLFA*E1N1
-         H1N2=DP(NM2)+IFNLFA*E1N2
-         H1N3=DP(NM3)+IFNLFA*E1N3
-         H2N1=DP(NM1)+IFNLFA*E2N1
-         H2N2=DP(NM2)+IFNLFA*E2N2
-         H2N3=DP(NM3)+IFNLFA*E2N3
+C........DMW202401 Use saved H1 and H2
+         H1N1=H1(NM1)
+         H1N2=H1(NM2)
+         H1N3=H1(NM3)
+         H2N1=H2(NM1)
+         H2N2=H2(NM2)
+         H2N3=H2(NM3)
          EVMN1=EVM(NM1)
          EVMN2=EVM(NM2)
          EVMN3=EVM(NM3)
@@ -2890,14 +2893,14 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
      &          Tau0VAR(NBDJ)*QN1(1)
 
          IF(LBCODEI(1).EQ.30) THEN
-            H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-            CELERITY=SQRT(G*H1)
+C...........DMW202401 Use saved H1
+            CELERITY=SQRT(G*H1(NBDJ))
             QFORCEJ=-CELERITY*ETAS(NBDJ)/DT - Tau0VAR(NBDJ)*QN1(1)
             ENDIF
 
          IF(LBCODEI(1).EQ.32) THEN
-            H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-            CELERITY=SQRT(G*H1)
+C...........DMW202401 Use saved H1
+            CELERITY=SQRT(G*H1(NBDJ))
             QFORCEJ=(QN1(1)-QN0(1))/DT
      &           -CELERITY*(ETAS(NBDJ)-(EN1(1)-EN0(1)))/DT
      &           +TAU0VAR(NBDJ)*(QN1(1)-CELERITY*(ETA1(NBDJ)-EN1(1)))
@@ -2915,14 +2918,14 @@ C...Note 3, Eta1 is the latest computed elevation (it was updated above).
      &         QFORCEJ=(QN2(J)-QN0(J))/DT2+Tau0VAR(NBDJ)*QN1(J)
 
             IF(LBCODEI(J).EQ.30) THEN
-               H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-               CELERITY=SQRT(G*H1)
+C..............DMW202401 Use saved H1
+               CELERITY=SQRT(G*H1(NBDJ))
                QFORCEJ=-CELERITY*ETAS(NBDJ)/DT - Tau0VAR(NBDJ)*QN1(J)
                ENDIF
 
             IF(LBCODEI(J).EQ.32) THEN
-               H1=DP(NBDJ)+IFNLFA*ETA1(NBDJ)
-               CELERITY=SQRT(G*H1)
+C..............DMW202401 Use saved H1
+               CELERITY=SQRT(G*H1(NBDJ))
                QFORCEJ=(QN1(J)-QN0(J))/DT
      &              -CELERITY*(ETAS(NBDJ)-(EN1(J)-EN0(J)))/DT
      &              +TAU0VAR(NBDJ)*(QN1(J)-CELERITY*(ETA1(NBDJ)-EN1(J)))

--- a/src/hstart.F
+++ b/src/hstart.F
@@ -101,7 +101,6 @@ C     Addition for netCDF by MCF 5/18/08 modified by jgf49.28
 C   kmd48.33bc - add variable for timestep change
       INTEGER NTHS
       REAL(8) ArgT, ArgTP, ArgSAlt
-      REAL(8) H2
       REAL(8) CCSFEA
       REAL(8) QTRatio
       REAL(8) SAltMul, S2SFEA
@@ -752,9 +751,10 @@ C     kmd48.33bc - added time and time step to be passed to the hotstart file
 C
       DO I=1, NP
          ETAS(I)=ETA2(I)-ETA1(I)
-         H2=DP(I)+IFNLFA*ETA2(I)
-         QX2(I)=UU2(I)*H2
-         QY2(I)=VV2(I)*H2
+C........DMW202401 Added global variable H2
+         H2(I)=DP(I)+IFNLFA*ETA2(I)
+         QX2(I)=UU2(I)*H2(I)
+         QY2(I)=VV2(I)*H2(I)
       END DO
 C     jgf46.08 Fine grained ramp functions
 C     jgf46.21 Split flux into internal and external, added support

--- a/src/messenger.F
+++ b/src/messenger.F
@@ -10,7 +10,7 @@ C
      &    SIG_TERM, FLOAT_TYPE, REALTYPE, DBLETYPE,
      &    DEBUG, ECHO, INFO, WARNING, ERROR, CPL2STWAVE,Flag_ElevError,
      &    screenMessage, logMessage, allMessage, setMessageSource,
-     &    unsetMessageSource, scratchMessage     
+     &    unsetMessageSource, scratchMessage,Flag_VelError
      
       USE MPI
       IMPLICIT NONE
@@ -239,6 +239,10 @@ C
       ! Note: mpi_comm_world is defined in mpich.f
       IF (CPL2STWAVE.eqv..true.) then
          IF (Flag_ElevError.eqv..true.) then
+            call mpi_abort(mpi_comm_world,myproc,ierr)
+         endif
+C        DMW 202401 Check for velocity exceeding error level
+         IF (Flag_VelError.eqv..true.) then
             call mpi_abort(mpi_comm_world,myproc,ierr)
          endif
       endif
@@ -1447,6 +1451,37 @@ C
       call unsetMessageSource()
 C------------------------------------------------------------------------------
       END SUBROUTINE WarnElevSum
+C------------------------------------------------------------------------------
+
+C------------------------------------------------------------------------------
+C               S U B R O U T I N E   E A R L Y T E R M S U M
+C------------------------------------------------------------------------------
+C     DMW 202401 If a NaN was detected in the velocity soln in one subdomain,
+C     that information is propagated to the other subdomains so that the
+C     solns can be output for debugging before exiting the model.
+C------------------------------------------------------------------------------
+      SUBROUTINE EarlyTermSum( earlyterminate )
+      INTEGER earlyterminate !=1 if this subdomain has detected a NaN in the velocity soln and 20 timesteps have passed since then
+      INTEGER SumEarlyterminate !sum total of all flags from all subdomains
+      INTEGER kount       ! to avoid compiler bug on certain platforms
+C
+      call setMessageSource("earlytermsum")
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Enter.") 
+#endif
+C 
+      SumEarlyterminate = 0
+      kount=1
+      call MPI_ALLREDUCE( earlyterminate, SumEarlyterminate, kount,
+     &     MPI_INTEGER, MPI_SUM, COMM, ierr)
+      earlyterminate = SumEarlyterminate
+C
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Return.")
+#endif
+      call unsetMessageSource()
+C------------------------------------------------------------------------------
+      END SUBROUTINE EarlyTermSum
 C------------------------------------------------------------------------------
 
 

--- a/src/momentum.F
+++ b/src/momentum.F
@@ -153,7 +153,7 @@ C*******************************************************************************
      &  IPERCONN, VIDispDXOH, VIDispDYOH, IFSFM, adcirc_norm2, CAliDisp,
      &  usingDynamicWaterLevelCorrection, windlim,
      &  dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, H0,
-     &  flgNodesMultipliedByTotalArea, ilump
+     &  flgNodesMultipliedByTotalArea, ilump, H1, H2
 #ifdef CMPI
      &  , dumy1
 #endif
@@ -201,8 +201,8 @@ C... SB
       REAL(8) DU1DX, DU1DY, DV1DX, DV1DY
       REAL(8) DU1DXA, DU1DYA, DV1DXA, DV1DYA
       REAL(8) EVMH1N1, EVMH1N2, EVMH1N3, EVMEle, EVMSmag
-      REAL(8) H1, H1N1, H1N2, H1N3, H1Avg
-      REAL(8) H2, H2N1, H2N2, H2N3, H2Avg
+      REAL(8) H1N1, H1N2, H1N3, H1Avg
+      REAL(8) H2N1, H2N2, H2N3, H2Avg
       REAL(8) LSXXN1, LSXXN2, LSXXN3
       REAL(8) LSXYN1, LSXYN2, LSXYN3
       REAL(8) LSYXN1, LSYXN2, LSYXN3
@@ -292,12 +292,13 @@ Corbitt 120322: Localized Advection
          V1N1=VV1(NM1)
          V1N2=VV1(NM2)
          V1N3=VV1(NM3)
-         H1N1=DP(NM1)+IFNLFA*ETA1(NM1)
-         H1N2=DP(NM2)+IFNLFA*ETA1(NM2)
-         H1N3=DP(NM3)+IFNLFA*ETA1(NM3)
-         H2N1=DP(NM1)+IFNLFA*ETA2(NM1)
-         H2N2=DP(NM2)+IFNLFA*ETA2(NM2)
-         H2N3=DP(NM3)+IFNLFA*ETA2(NM3)
+C........DMW202401 Use saved H1 and H2
+         H1N1=H1(NM1)
+         H1N2=H1(NM2)
+         H1N3=H1(NM3)
+         H2N1=H2(NM1)
+         H2N2=H2(NM2)
+         H2N3=H2(NM3)
          QX1N1=QX1(NM1)
          QX1N2=QX1(NM2)
          QX1N3=QX1(NM3)
@@ -734,15 +735,14 @@ C      DispY=0.D0
                MOM_LV_Y(I)=MOM_LV_Y(I)/MJU(I)
             ENDIF
          ENDIF
-         H1=DP(I)+IFNLFA*ETA1(I)
-         H2=DP(I)+IFNLFA*ETA2(I)
+C........DMW202401 Use saved H1 and H2
          IF((NWS.NE.0).OR.(NRS.NE.0)) THEN
-            WSX=DTO2*IFWIND*(WSX1(I)/H1+WSX2(I)/H2)
-            WSY=DTO2*IFWIND*(WSY1(I)/H1+WSY2(I)/H2)
+            WSX=DTO2*IFWIND*(WSX1(I)/H1(I)+WSX2(I)/H2(I))
+            WSY=DTO2*IFWIND*(WSY1(I)/H1(I)+WSY2(I)/H2(I))
             
 C.....      DMW 202207 tail off wind forcing in very shallow water
             IF (WINDLIM.eqv..true.) THEN
-               CALL windLimiter(H2,fwind)
+               CALL windLimiter(H2(I),fwind)
                WSX = fwind*WSX
                WSY = fwind*WSY
             ENDIF
@@ -825,15 +825,15 @@ C...  AUV12=-AUV21)
       DO J=1,NVELME
          I=ME2GW(J)
          NBDI=NBV(I)
-         H2=DP(NBDI)+IFNLFA*ETA2(NBDI)
          NCI=NODECODE(NBDI)
 
 C      Specified essential normal flow and free tangential slip
+C........DMW202401 Use saved H2
 
          IF((LBCODEI(I).GE.0).AND.(LBCODEI(I).LE.9)) THEN
-            VelNorm=-QN2(I)/H2
+            VelNorm=-QN2(I)/H2(I)
             IF (abs(adcirc_norm2(TKM(:,NBDI))-sqrt(2d0)*TK(NBDI))
-     &          .lt.epsilon(H2)) THEN
+     &          .lt.epsilon(H2(I))) THEN
             ! WJP 03.6.2018 In the case of the symmetric matrix..
             ! Should be equivalent to the non-symmetric formula below
             ! but for consistency when testing using this formula helps
@@ -862,7 +862,8 @@ C      Specified essential normal flow and free tangential slip
 C     Specified essential normal flow and no tangential slip
 
          IF (LBCODEI(I).GE.10.AND.LBCODEI(I).LE.19) THEN
-            VelNorm=-QN2(I)/H2
+C...........DMW202401 Use saved H2
+            VelNorm=-QN2(I)/H2(I)
             VelTan=0.D0
             MOM_LV_X(NBDI)=VelTan*NCI !Tangential Eqn RHS
             MOM_LV_Y(NBDI)=VelNorm*NCI !Normal Eqn RHS
@@ -1193,9 +1194,9 @@ C...
 C...  Compute fluxes
 
       DO I=1,NP
-         H2 = DP(I)+IFNLFA*ETA2(I)
-         QX2(I) = UU2(I)*H2
-         QY2(I) = VV2(I)*H2
+C........DMW202401 Use saved H2
+         QX2(I) = UU2(I)*H2(I)
+         QY2(I) = VV2(I)*H2(I)
       ENDDO
 
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)
@@ -1258,7 +1259,7 @@ C
      & CME_AREAINT_ORIG, CME_AREAINT_CORR, ETA1, ETA2, QX1, QY1, UU1,
      & VV1, IFNLFA, CSMAG_EH, SMAG_COMP_FLAG, SMAG_UPPER_LIM, NOFF, 
      & SMAG_LOWER_LIM, NODECODE, VIDISPDXOH, VIDISPDYOH, IFSFM, 
-     & CBaroclinic, CAliDisp, windlim
+     & CBaroclinic, CAliDisp, windlim, H1, H2
       USE MESH, ONLY : NE, NP, NM, DP, X, Y, AREAS, TotalArea, MJU,
      &   NEITAB, NEITABELE, NNEIGH, FDXE, FDYE,
      &   SFacEle, SFMYEle, SFMXEle, TANPHI   
@@ -1285,8 +1286,8 @@ C
       REAL(8) DQX1DX2A, DQX1DY2A, DQY1DX2A, DQY1DY2A
       REAL(8) DU1QX1DXA, DV1QX1DYA, DU1QY1DXA, DV1QY1DYA
       REAL(8) EVMH1N1, EVMH1N2, EVMH1N3, EVMEle, EVMSmag
-      REAL(8) H1, H1N1, H1N2, H1N3, H1Avg, GH1Avg
-      REAL(8) H2, H2N1, H2N2, H2N3, H2Avg, GH2Avg
+      REAL(8) H1N1, H1N2, H1N3, H1Avg, GH1Avg
+      REAL(8) H2N1, H2N2, H2N3, H2Avg, GH2Avg
       REAL(8) LSXXN1, LSXXN2, LSXXN3
       REAL(8) LSXYN1, LSXYN2, LSXYN3
       REAL(8) LSYXN1, LSYXN2, LSYXN3
@@ -1343,12 +1344,13 @@ Corbitt 120322: Localized Advection
          V1N1=VV1(NM1)
          V1N2=VV1(NM2)
          V1N3=VV1(NM3)
-         H1N1=DP(NM1)+IFNLFA*ETA1(NM1)
-         H1N2=DP(NM2)+IFNLFA*ETA1(NM2)
-         H1N3=DP(NM3)+IFNLFA*ETA1(NM3)
-         H2N1=DP(NM1)+IFNLFA*ETA2(NM1)
-         H2N2=DP(NM2)+IFNLFA*ETA2(NM2)
-         H2N3=DP(NM3)+IFNLFA*ETA2(NM3)
+C........DMW202401 Use saved H1 and H2
+         H1N1=H1(NM1)
+         H1N2=H1(NM2)
+         H1N3=H1(NM3)
+         H2N1=H2(NM1)
+         H2N2=H2(NM2)
+         H2N3=H2(NM3)
          QX1N1=QX1(NM1)
          QX1N2=QX1(NM2)
          QX1N3=QX1(NM3)
@@ -1744,19 +1746,18 @@ C...  and adding in the lumped terms, bottom friction and boundary conditions
                MOM_LV_Y(I)=MOM_LV_Y(I)/MJU(I)
             ENDIF
          ENDIF
-         H1=DP(I)+IFNLFA*ETA1(I)
-         H2=DP(I)+IFNLFA*ETA2(I)
+
          IF (NWS.NE.0.OR.NRS.NE.0) THEN
             WSX=DTO2*IFWIND*(WSX1(I)+WSX2(I))
             WSY=DTO2*IFWIND*(WSY1(I)+WSY2(I))
             
-C.....      DMW 202207 tail off wind forcing in very shallow water
+C...........DMW 202207 tail off wind forcing in very shallow water
             IF (WINDLIM.eqv..true.) THEN
-               CALL windLimiter(H2,fwind)
+C..............DMW202401 Use saved H2
+               CALL windLimiter(H2(I),fwind)
                WSX = fwind*WSX
                WSY = fwind*WSY
             ENDIF
-C.....      DMW
             
          ENDIF
          VCOEFXX = DTO2*TKM(1,I) 
@@ -1953,10 +1954,10 @@ C...
 C...  Compute velocities
 
       DO I=1,NP
-         H2=DP(I)+IFNLFA*ETA2(I)
-         IF(H2.NE.0.) THEN
-            UU2(I)=QX2(I)/H2
-            VV2(I)=QY2(I)/H2
+C........DMW202401 Use saved H2
+         IF(H2(I).NE.0.) THEN
+            UU2(I)=QX2(I)/H2(I)
+            VV2(I)=QY2(I)/H2(I)
             ELSE
             WRITE(16,*) ''
             WRITE(16,*) ''
@@ -2017,7 +2018,7 @@ C
      & CME_AREAINT_ORIG, CME_AREAINT_CORR, ETA1, ETA2, QX1, QY1, UU1,
      & VV1, IFNLFA, CSMAG_EH, SMAG_COMP_FLAG, SMAG_UPPER_LIM, NOFF, 
      & SMAG_LOWER_LIM, NODECODE, UU0, VV0, QX0, QY0, TK2, CBaroclinic,
-     & windlim
+     & windlim, H1, H2
       USE MESH, ONLY : NE, NP, NM, DP, X, Y, AREAS, TotalArea, MJU,
      &                  NEITAB, NEITABELE, NNEIGH, SFAC
       USE BOUNDARIES, ONLY : NFLUXGBC, NVELME, ME2GW, NBV, LBCODEI,
@@ -2040,8 +2041,8 @@ C
       REAL(8) DU1DX, DU1DY, DV1DX, DV1DY
       REAL(8) DU1DXA, DU1DYA, DV1DXA, DV1DYA
       REAL(8) EVMH1N1, EVMH1N2, EVMH1N3, EVMEle, EVMSmag
-      REAL(8) H1, H1N1, H1N2, H1N3
-      REAL(8) H2, H2N1, H2N2, H2N3
+      REAL(8) H1N1, H1N2, H1N3
+      REAL(8) H2N1, H2N2, H2N3
       REAL(8) LSXXN1, LSXXN2, LSXXN3
       REAL(8) LSXYN1, LSXYN2, LSXYN3
       REAL(8) LSYXN1, LSYXN2, LSYXN3
@@ -2140,12 +2141,13 @@ Corbitt 120322: Localized Advection
          V2N1=VV2(NM1)
          V2N2=VV2(NM2)
          V2N3=VV2(NM3)
-         H1N1=DP(NM1)+IFNLFA*ETA1(NM1)
-         H1N2=DP(NM2)+IFNLFA*ETA1(NM2)
-         H1N3=DP(NM3)+IFNLFA*ETA1(NM3)
-         H2N1=DP(NM1)+IFNLFA*ETA2(NM1)
-         H2N2=DP(NM2)+IFNLFA*ETA2(NM2)
-         H2N3=DP(NM3)+IFNLFA*ETA2(NM3)
+C........DMW202401 Use saved H1 and H2
+         H1N1=H1(NM1)
+         H1N2=H1(NM2)
+         H1N3=H1(NM3)
+         H2N1=H2(NM1)
+         H2N2=H2(NM2)
+         H2N3=H2(NM3)
          QX0N1=QX0(NM1)
          QX0N2=QX0(NM2)
          QX0N3=QX0(NM3)
@@ -2526,15 +2528,14 @@ C...  and adding in the lumped terms, bottom friction and boundary conditions
                MOM_LV_Y(I)=MOM_LV_Y(I)/MJU(I)
             ENDIF
          ENDIF
-         H1=DP(I)+IFNLFA*ETA1(I)
-         H2=DP(I)+IFNLFA*ETA2(I)
+C........DMW202401 Use saved H1 and H2
          IF((NWS.NE.0).OR.(NRS.NE.0)) THEN
-            WSX=DTO2*IFWIND*(WSX1(I)/H1+WSX2(I)/H2)
-            WSY=DTO2*IFWIND*(WSY1(I)/H1+WSY2(I)/H2)
+            WSX=DTO2*IFWIND*(WSX1(I)/H1(I)+WSX2(I)/H2(I))
+            WSY=DTO2*IFWIND*(WSY1(I)/H1(I)+WSY2(I)/H2(I))
             
 C.....      DMW 202207 tail off wind forcing in very shallow water
             IF (WINDLIM.eqv..true.) THEN
-               CALL windLimiter(H2,fwind)
+               CALL windLimiter(H2(I),fwind)
                WSX = fwind*WSX
                WSY = fwind*WSY
             ENDIF
@@ -2571,13 +2572,13 @@ C...  AUV12=-AUV21)
       DO J=1,NVELME
          I=ME2GW(J)
          NBDI=NBV(I)
-         H2=DP(NBDI)+IFNLFA*ETA2(NBDI)
+C........DMW202401 Use saved H2
          NCI=NODECODE(NBDI)
 
 C      Specified essential normal flow and free tangential slip
 
          IF((LBCODEI(I).GE.0).AND.(LBCODEI(I).LE.9)) THEN
-            VelNorm=-QN2(I)/H2
+            VelNorm=-QN2(I)/H2(NBDI)
             MOM_LV_X(NBDI)=(SIII(I)*MOM_LV_X(NBDI)
      &                     -CSII(I)*MOM_LV_Y(NBDI)
      &                     -VelNorm*AUV12(NBDI))*NCI !Tangential Eqn RHS
@@ -2589,7 +2590,7 @@ C      Specified essential normal flow and free tangential slip
 C     Specified essential normal flow and no tangential slip
 
          IF((LBCODEI(I).GE.10).AND.(LBCODEI(I).LE.19)) THEN
-            VelNorm=-QN2(I)/H2
+            VelNorm=-QN2(I)/H2(NBDI)
             VelTan=0.D0
             MOM_LV_X(NBDI)=VelTan*NCI !Tangential Eqn RHS
             MOM_LV_Y(NBDI)=VelNorm*NCI !Normal Eqn RHS
@@ -2716,9 +2717,9 @@ C...
 C...  Compute fluxes
 
       DO I=1,NP
-         H2=DP(I)+IFNLFA*ETA2(I)
-         QX2(I)=UU2(I)*H2
-         QY2(I)=VV2(I)*H2
+C........DMW202401 Use saved H2
+         QX2(I)=UU2(I)*H2(I)
+         QY2(I)=VV2(I)*H2(I)
          ENDDO
 
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -64,7 +64,7 @@ C-----------------------------------------------------------------------
      &   alloc_main6, openfileforread, nhoutonce, IFSPROTS,
      &   StatPartWetFix, How2FixStatPartWet, cgwce_hdp, ifnl_hdp, 
      &   CAliDisp, IFSFM, usingDynamicWaterLevelCorrection,slim,windlim,
-     &   directvelWD,useHF
+     &   directvelWD,useHF, errorvel
 #if defined CSWAN || defined ADCSWAN
      &   , SWAN_OutputHS, SWAN_OutputDIR,
      &    SWAN_OutputTM01, SWAN_OutputTPS, SWAN_OutputWIND,
@@ -584,6 +584,8 @@ C     for elevations. Initialize default values.
       WarnElevDumpLimit = 50  ! default
       WarnElevDumpCounter = 0 ! init
       ErrorElev = 1000.0      ! default
+C     DMW 202401 Add check for velocity error
+      ErrorVel = 1000.d0
 C     WJP add namelist
       namelistSpecifier = 'WarnElevControl'
       read(unit=15,nml=WarnElevControl,iostat=IOS)

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -1043,66 +1043,6 @@ C...
 C...
 C-------------END OF 2DDI MOMENTUM EQUATION SOLUTION--------------------
 C...
-C....DMW 20240109 - WARNING FOR NaNs IN VELOCITY SOLN
-      foundNaN = .false.
-      DO I = 1,NP 
-         IF(ISNAN(UU2(I)).OR.ISNAN(VV2(I))) THEN
-            foundNaN = .true.
-C     WJP 03.27.2018 with the addition of the hash table we now need to
-C     output the global node number to debug the local PE fort.14s
-            IF(NSCREEN.NE.0) THEN
-               WRITE(ScreenUnit,2993)
-     &              IT,NUMITR,TimeLoc,NODES_LG(I),
-     &              ETA2(I),DP(I),MYPROC
-               WRITE(16,2993) IT,NUMITR,TimeLoc,
-     &              NODES_LG(I),ETA2(I),DP(I),MYPROC
- 2993          FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
-     &              5X,'TIME = ',E15.8,
-     &              2X,'SPEED IS NaN AT NODE I =',I9,
-     &              /,2X,'ETA2(I) = ', 1pE12.4E3,
-     &              2X,'DP(I) = ', 1pE12.4E3,
-     &              2X,'ON MYPROC = ',I4)
-               DO J = 2,NNeigh(I)
-                  JJ = NeiTab(I,J)
-                  WRITE(ScreenUnit,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),               
-     &                 UU2(JJ),VV2(JJ),MYPROC
-              
-                  WRITE(16,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),
-     &                 UU2(JJ),VV2(JJ),MYPROC
- 2995             FORMAT(1X,'AT NEIGHBOR NODE I =',I9,
-     &                 /,2X,'ETA2(I) = ', 1pE12.4E3,
-     &                 2X,'DP(I) = ', 1pE12.4E3,
-     &                 2X,'UU2(I) = ', 1pE12.4E3,
-     &                 2X,'VV2(I) = ', 1pE12.4E3,
-     &                 2X,'ON MYPROC = ',I4)
-               ENDDO
-            ENDIF
-         ENDIF
-      ENDDO
-      IF (foundNaN) THEN
-         IF(NSCREEN.NE.0) THEN
-            WRITE(ScreenUnit,2994)
-     &           IT,NUMITR,TimeLoc,ETA2(KEMAX),NODES_LG(KEMAX),
-     &           VELMAX,NODES_LG(KVMAX),MYPROC
-            WRITE(16,2994) IT,NUMITR,TimeLoc,ETA2(KEMAX),
-     &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
- 2994       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
-     &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
-     &           2X,'ON MYPROC = ',I4,
-     &           3X,'** WARNING: Velocity is NaN **')
-         ENDIF
-      ENDIF
-      IF ((foundNaN).AND.(IT_foundNaN.EQ.0)) THEN
-         IT_foundNaN = IT
-      ELSEIF ((IT.EQ.IT_foundNaN + 20).AND.(IT_foundNaN.NE.0)) THEN
-         earlyterminate = 1
-      ENDIF
-#ifdef CMPI
-      call EarlyTermSum( earlyterminate )
-#endif
-
 
 C.....DW - ABS SPONGE LAYER     
       IF ( C2DDI .AND. LoadAbsLayerSigma .AND. (sponge_dis_mthd == 0) ) THEN
@@ -1413,6 +1353,63 @@ C     output the global node number to debug the local PE fort.14s
 #endif
 
       ENDIF
+C....DMW 20240109 - WARNING FOR NaNs IN VELOCITY SOLN
+      foundNaN = .false.
+      DO I = 1,NP 
+         IF(ISNAN(UU2(I)).OR.ISNAN(VV2(I))) THEN
+            foundNaN = .true.
+            IF(NSCREEN.NE.0) THEN
+               WRITE(ScreenUnit,2993)
+     &              IT,NUMITR,TimeLoc,NODES_LG(I),
+     &              ETA2(I),DP(I),MYPROC
+               WRITE(16,2993) IT,NUMITR,TimeLoc,
+     &              NODES_LG(I),ETA2(I),DP(I),MYPROC
+ 2993          FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &              5X,'TIME = ',E15.8,
+     &              2X,'SPEED IS NaN AT NODE I =',I9,
+     &              /,2X,'ETA2(I) = ', 1pE12.4E3,
+     &              2X,'DP(I) = ', 1pE12.4E3,
+     &              2X,'ON MYPROC = ',I4)
+               DO J = 2,NNeigh(I)
+                  JJ = NeiTab(I,J)
+                  WRITE(ScreenUnit,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),               
+     &                 UU2(JJ),VV2(JJ),MYPROC
+              
+                  WRITE(16,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),
+     &                 UU2(JJ),VV2(JJ),MYPROC
+ 2995             FORMAT(1X,'AT NEIGHBOR NODE I =',I9,
+     &                 /,2X,'ETA2(I) = ', 1pE12.4E3,
+     &                 2X,'DP(I) = ', 1pE12.4E3,
+     &                 2X,'UU2(I) = ', 1pE12.4E3,
+     &                 2X,'VV2(I) = ', 1pE12.4E3,
+     &                 2X,'ON MYPROC = ',I4)
+               ENDDO
+            ENDIF
+         ENDIF
+      ENDDO
+      IF (foundNaN) THEN
+         IF(NSCREEN.NE.0) THEN
+            WRITE(ScreenUnit,2994)
+     &           IT,NUMITR,TimeLoc,ETA2(KEMAX),NODES_LG(KEMAX),
+     &           VELMAX,NODES_LG(KVMAX),MYPROC
+            WRITE(16,2994) IT,NUMITR,TimeLoc,ETA2(KEMAX),
+     &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
+ 2994       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &           5X,'TIME = ',E15.8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
+     &           2X,'ON MYPROC = ',I4,
+     &           3X,'** WARNING: Velocity is NaN **')
+         ENDIF
+      ENDIF
+      IF ((foundNaN).AND.(IT_foundNaN.EQ.0)) THEN
+         IT_foundNaN = IT
+      ELSEIF ((IT.EQ.IT_foundNaN + 20).AND.(IT_foundNaN.NE.0)) THEN
+         earlyterminate = 1
+      ENDIF
+#ifdef CMPI
+      call EarlyTermSum( earlyterminate )
+#endif
 
 C...
 C...  ****************** TIME STEPPING LOOP ENDS HERE ********************

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -42,7 +42,7 @@ C
      &    MOM_LV_Y, WSX2, WSY2, PR1, PR2, TiP1, TiP2, UU0, VV0, QY0, 
      &    GWCE_LV, TRANS_LV_B, TRANS_LV_A, WSX1, WSY1, dp1, dp2, QN0, 
      &    EN0, EN1, EN2, CICE1, CICE2, CICEOUT, RSNX1, RSNX2, RSNY1, RSNY2,
-     &    QX0, QN1, QN2, RSNXOUT, RSNYOUT, LNM_BC1, LNM_BC2, 
+     &    QX0, QN1, QN2, RSNXOUT, RSNYOUT, LNM_BC1, LNM_BC2, H1, H2,
      &    QNIN1, QNIN2, ENIN1, ENIN2, EtaDisc, NIBNODECODE,
      &    BCHGTIMINC, ETA2,ElevDisc, BTIME1, BTIME2, BTIME_END, C2D_PTrans,
      &    C2DDI, C3D, C3DVS, CBAROCLINIC, CGWCE_New, CHOTHS, CICE_TIME1,
@@ -151,7 +151,6 @@ C     DMW 202401 Check for Velocity exceeding error level
       REAL(8) QTRatio
       REAL(8) RStRatio, RSX, RSY
       REAL(8) SAltMul, S2SFEA
-      REAL(8) H1
       REAL(8) TPMul
       REAL(8) UN1
 
@@ -186,7 +185,11 @@ C.......
       LOGICAL foundNaN
       
       IF (IT .EQ. 1) THEN
-        IT_foundNaN = 0
+C.......DMW202401 On first timestep, find H2 at start of timestepper since ETA2 = ETA1
+        DO I = 1,NP
+           H2(I) = DP(I)+IFNLFA*ETA2(I)
+           H1(I) = H2(I)
+        ENDDO
       ENDIF
 
       call setMessageSource("timestep")
@@ -908,9 +911,9 @@ C...
          DO J=1,NVEL
             IF(LBCODEI(J).EQ.30) THEN
                NNBB=NBV(J)
-               H1=DP(NNBB)+IFNLFA*ETA2(NNBB)
+C..............DMW202401 Use saved H2
                UN1=UU1(NNBB)*CSII(J)+VV1(NNBB)*SIII(J)
-               QN1(J)=H1*UN1
+               QN1(J)=H2(NNBB)*UN1
             ENDIF
          END DO
       ENDIF
@@ -922,9 +925,9 @@ C...
           DO J=1,NVEL
             IF((LBCODEI(J).EQ.40).OR.(LBCODEI(J).EQ.41)) THEN
               NNBB=NBV(J)
-              H1=DP(NNBB)+IFNLFA*ETA2(NNBB)
+C.............DMW202401 Use saved H2
               UN1=UU1(NNBB)*CSII(J)+VV1(NNBB)*SIII(J)
-              QN1(J)=H1*UN1
+              QN1(J)=H2(NNBB)*UN1
               ENDIF
             END DO
           ENDIF
@@ -1018,9 +1021,6 @@ C...
       if(subdomainOn.and.enforceBN.eq.1) call readFort019(it)  ! NCSU Subdomain
       if(subdomainOn.and.enforceBN.eq.2) call readFort020(it)  ! NCSU Subdomain
       if(subdomainOn.and.enforceBN.eq.2) call readFort021(it)  ! NCSU Subdomain
-      
-
-
 
 !----------------------SOLVE GWCE---------------------------------------
 C...
@@ -1029,12 +1029,16 @@ C...  Compute new water surface elevation
 
 !---------------------END SOLVE GWCE------------------------------------
 
-
 !--------------------WETTING AND DRYING--------------------------------
 
       call computeWettingAndDrying(it)
 
 !--------------------WETTING AND DRYING--------------------------------
+C.....DMW202401 Add update for flow depth at current timestep
+C......We do this after wetting/drying since bathy could change with subgrid barriers.
+      DO I = 1,NP
+         H2(I) = DP(I)+IFNLFA*ETA2(I)
+      ENDDO
 
 C...
 C---------------2DDI Momentum Equation Solution-------------------------
@@ -1270,7 +1274,7 @@ C     output the global node number to debug the local PE fort.14s
            CALL MSG_FINI()                    !  if there are Error Elvation nodes.
            CALL EXIT(1)                             !
          ENDIF                                !st3
-         
+#ifdef VELCHECK         
          ErrorVelExceeded = 0                ! Clint's Zombie Slyaer
          IF(VELMAX.GT.ErrorVel) THEN
          
@@ -1294,6 +1298,8 @@ C     output the global node number to debug the local PE fort.14s
            CALL MSG_FINI()                    !  if there are Error Velocity nodes.
            CALL EXIT(1)                             !
          ENDIF                                !st3
+#endif
+
 #else
          IF(ELMAX.LT.WarnElev.AND.ITEST.EQ.IT) THEN
             IF (KEMAX.GT.0) THEN
@@ -1336,6 +1342,7 @@ C     output the global node number to debug the local PE fort.14s
      &           'ADCIRC stopping. **')
             CALL ADCIRC_Terminate()
          ENDIF
+#ifdef VELCHECK
          IF(VELMAX.GT.ErrorVel) THEN
             write(6,*) 'velmax, errorvel',velmax, errorvel 
             Flag_VelError = .true.
@@ -1351,8 +1358,10 @@ C     output the global node number to debug the local PE fort.14s
             CALL ADCIRC_Terminate()
          ENDIF
 #endif
+#endif
 
       ENDIF
+#ifdef VELCHECK
 C....DMW 20240109 - WARNING FOR NaNs IN VELOCITY SOLN
       foundNaN = .false.
       DO I = 1,NP 
@@ -1411,6 +1420,8 @@ C....DMW 20240109 - WARNING FOR NaNs IN VELOCITY SOLN
       call EarlyTermSum( earlyterminate )
 #endif
 
+#endif
+
 C...
 C...  ****************** TIME STEPPING LOOP ENDS HERE ********************
 C...
@@ -1442,7 +1453,7 @@ C
       USE GLOBAL, only: ch1, trans_lv_b, nodecode, noff, lumpt, dtdp,
      &    trans_lv_a, soursin, uu1, vv1, ifnlfa, eta1, bedstr, tk,
      &    setmessagesource, unsetmessagesource, DEBUG,
-     &    allMessage
+     &    allMessage, H1
       USE CONSTANTS, ONLY: rhowat0
       USE MESH, ONLY : NE, NP, NM, DP, X, Y, AREAS, SFAC
       USE NodalAttributes, ONLY: EVC
@@ -1464,7 +1475,7 @@ C
       REAL(8) EVC1, EVC2, EVC3, EVCEA
       REAL(8) FDDDODT, FDDODODT
       REAL(8) HEA
-      REAL(8) H1, H1N1, H1N2, H1N3
+      REAL(8) H1N1, H1N2, H1N3
       REAL(8) HSD, HSE
       REAL(8) SFacAvg
       REAL(8) SS1N1, SS1N2, SS1N3
@@ -1501,9 +1512,9 @@ C.... SEDIMENT TRANSPORT RELATIONS
 
       DO I=1,NP
         UV1=SQRT(UU1(I)*UU1(I)+VV1(I)*VV1(I))
-        H1=DP(I)+IFNLFA*ETA1(I)
-        BEDSTR=H1*UV1*TK(I)*RhoWat0                           ![N/m^2]
-        C1=CH1(I)/H1
+C.......DMW202401 Use saved H1
+        BEDSTR=H1(I)*UV1*TK(I)*RhoWat0                           ![N/m^2]
+        C1=CH1(I)/H1(I)
 
 C.....Calculate the deposition rate using Krone's (1962) formulation:
 C.....dC/dt = -P*WSMOD*C/D     where
@@ -1566,9 +1577,10 @@ C.....SET NODAL VALUES FOR EACH ELEMENT
          SS1N1=SOURSIN(NM1)
          SS1N2=SOURSIN(NM2)
          SS1N3=SOURSIN(NM3)
-         H1N1=DP(NM1)+IFNLFA*ETA1(NM1)
-         H1N2=DP(NM2)+IFNLFA*ETA1(NM2)
-         H1N3=DP(NM3)+IFNLFA*ETA1(NM3)
+C........DMW202401 Use saved H1
+         H1N1=H1(NM1)
+         H1N2=H1(NM2)
+         H1N3=H1(NM3)
          SFacAvg=(SFAC(NM1)+SFAC(NM2)+SFAC(NM3))/3.
 
 C.....COMPUTE ELEMENTAL MATRICIES
@@ -1794,7 +1806,7 @@ c******************************************************************************
       USE CONSTANTS, ONLY: G, RhoWat0, SigT0
       USE GLOBAL, ONLY: IFNLFA, IFNLCT, IDEN, RAMP, NODECODE, NOFF, 
      &    VIDBCPDXOH, VIDBCPDYOH, ETA2, DTDP, DASigT, 
-     &    IFSFM
+     &    IFSFM, H2
       USE MESH, ONLY : NE, NM, FDXE, FDYE, NP, DP, AREAS, NODELE, 
      &      NEITABELE, NEITAB, NNEIGH, TOTALAREA,
      &      SFacEle, SFMYEle, SFMXEle
@@ -1849,9 +1861,10 @@ c******************************************************************************
          NC2=NODECODE(NM2)
          NC3=NODECODE(NM3)
          NCEle=NC1*NC2*NC3*NOFF(IE)
-         H2N1=DP(NM1)+IFNLFA*ETA2(NM1) !jgf45.11 add IFNLFA (kd bug fix)
-         H2N2=DP(NM2)+IFNLFA*ETA2(NM2) ! "
-         H2N3=DP(NM3)+IFNLFA*ETA2(NM3) ! "
+C........DMW202401 Use saved H2
+         H2N1=H2(NM1)
+         H2N2=H2(NM2)
+         H2N3=H2(NM3)
          EtaN1=IFNLFA*Eta2(NM1)
          EtaN2=IFNLFA*Eta2(NM2)
          EtaN3=IFNLFA*Eta2(NM3)
@@ -1956,7 +1969,7 @@ C
      &      NODECODE, NOFF, VIDBCPDXOH, VIDBCPDYOH,
      &      setMessageSource, unsetMessageSource, allMessage,
      &      logMessage, DEBUG, ECHO, INFO, WARNING, ERROR,
-     &      ETA2, H0, DTDP
+     &      ETA2, H0, DTDP, H2
       USE CONSTANTS, ONLY: SigT0
       USE MESH, ONLY : NM, X, Y, NP, DP, AREAS, NODELE, 
      &      NEITABELE, NEITAB, NNEIGH, SFAC
@@ -2060,8 +2073,8 @@ C
 
 Casey: Changed "NolIFA" to "IFNLFA."
 C
-            Hs=DP(NH)+IFNLFA*Eta2(NH) !total depth at previous (s) timestep
-            HGORhoOAMB=GORhoOAMB*Hs !(gravity/rho ref)*(H/(a-b))
+C...........DMW202401 Use saved H2
+            HGORhoOAMB=GORhoOAMB*H2(NH) !(gravity/rho ref)*(H/(a-b))
             BCP(NH,NFEN)=0.d0
 ! arash: this integration can be improved
             DO k=NFEN-1,1,-1    !loop over vertical nodes, starting at top and working down
@@ -2133,8 +2146,8 @@ C     Loop over each horizontal node to compute the horizontal velocity
 C
       DO NH=1,NP                !loop over horizontal nodes
 
-         Hs  = DP(NH)+IFNLFA*Eta2(NH) !Total depth at previous (s) timestep
-         HsOAMB=Hs/AMB
+C........DMW202401 Use saved H2
+         HsOAMB=H2(NH)/AMB
 
 c     Zero out baroclinic pressure gradient and vertically integrated
 c     baroclinic pressure gradient for a barotropic run
@@ -2167,8 +2180,8 @@ c     coordinates) at each node in the vertical
 
 Casey: Changed "NolIFA" to "IFNLFA."
 C
-               HsN2=DP(N2)+IFNLFA*Eta2(N2)
-               SigmaNN=B+AMB*(Zk+DP(N2))/HsN2 !equivalent sigma value at neighbor
+C..............DMW202401 Use saved H2
+               SigmaNN=B+AMB*(Zk+DP(N2))/H2(N2) !equivalent sigma value at neighbor
                CALL ZSURFBUOY_p3(SigmaNN,BCPN2,N2,k) !interp BCP at neighbor
 !!!!!!!!!         CALL ZSURFBUOY(SigmaNN,BCPN2,N2,k) !interp BCP at neighbor
                NNFirst=N2       !save these values until end
@@ -2181,8 +2194,8 @@ C
 
 Casey: Changed "NolIFA" to "IFNLFA."
 C
-                  HsN2=DP(N2)+IFNLFA*Eta2(N2)
-                  SigmaNN=B+AMB*(Zk+DP(N2))/HsN2 !equivalent sigma value at neighbor
+C.................DMW202401 Use saved H2
+                  SigmaNN=B+AMB*(Zk+DP(N2))/H2(N2) !equivalent sigma value at neighbor
 !!!!!!!!!            CALL ZSURFBUOY(SigmaNN,BCPN2,N2,k) !interp BCP at neighbor
                   CALL ZSURFBUOY_p3(SigmaNN,BCPN2,N2,k) !interp BCP at neighbor
                   NEle=NeiTabEle(NH,N-2) !element # defined by nodes NH,NN2,NN1
@@ -2791,7 +2804,7 @@ C**********************************************************************
 
        Subroutine Gaussian_filter_complex_BPG ( X, Y, NeiTab, NNeigh, quantity, NP, NFEN, MNEI )
 
-       Use Global,      Only : IFNLFA, ETA2
+       Use Global,      Only : H2
        Use Mesh,        Only : DP
        Use Global_3DVS, Only : SIGMA, AMB, B
 
@@ -2863,10 +2876,10 @@ C**********************************************************************
          !Write(*,'(I5,11f6.3)') NNeigh ( I ), weights(1:NNeigh ( I ))
          !Pause
          ! 2.4. compute elevation corresponding to this node
-         Hs = DP(I) + IFNLFA * Eta2(I)  !Total depth at current timestep - 'center' node
+C........DMW202401 Use saved H2  !Total depth at current timestep - 'center' node
          ! arash: not sure if the next line is necessary, but probably not. we aren't using it in the bpg routine either.
          ! IF( Hs .LT. H0 ) Hs = H0
-         HsOAMB = Hs / AMB
+         HsOAMB = H2(I) / AMB
 
          ! 3. apply the Gaussian filter
           Do J = 1, NNeigh ( I )
@@ -2875,8 +2888,8 @@ C**********************************************************************
              Do K = 1, NFEN
                 ! 3.0. obtain the z and sigma value corresponding to the 'center' node
                 Zk = HsOAMB * ( Sigma(K) - B ) - DP(I)
-                Hs_Neighbor_Node = DP(Neighbor_Node) + IFNLFA * Eta2(Neighbor_Node)
-                SigmaNN = B + AMB * ( Zk + DP(Neighbor_Node) ) / Hs_Neighbor_Node
+C...............DMW202401 Use saved H2
+                SigmaNN = B + AMB * ( Zk + DP(Neighbor_Node) ) / H2(Neighbor_Node)
                 ! 3.1. linearly interpolate surrounding BPG on the same horizontal plane
                 Call linear_vertical_interpolation_complex ( inarray_vertical, SigmaNN, interpolated_value, K )
                 quantity_smooth (I,K) = quantity_smooth (I,K) + Weights (J) * interpolated_value

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -37,7 +37,7 @@ C
 #ifdef IEEE_DEBUG
       USE, INTRINSIC :: IEEE_ARITHMETIC
 #endif
-      USE SIZES, ONLY : MNP, MNWPROH
+      USE SIZES, ONLY : MNP, MNWPROH, MYPROC
       USE GLOBAL, ONLY : UU1, VV1, QX1, QY1, QX2, QY2, UU2, VV2, MOM_LV_X,
      &    MOM_LV_Y, WSX2, WSY2, PR1, PR2, TiP1, TiP2, UU0, VV0, QY0, 
      &    GWCE_LV, TRANS_LV_B, TRANS_LV_A, WSX1, WSY1, dp1, dp2, QN0, 
@@ -62,7 +62,8 @@ C
      &    QNPH, QNAM, ENPH, ENAM, ETRF, FPER, FFACE, ETA1, FAMIG, LNM_BC,
      &    BCFLAG_LNM, usingDynamicWaterLevelCorrection,
      &    dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, L_N, TKM, 
-     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE
+     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE, 
+     &    earlyterminate, IT_foundNaN, ErrorVel, Flag_VelError
       USE CONSTANTS, ONLY: rhoWat0, sigT0, waveWindMultiplier
       USE GWCE, ONLY : solveGWCE, numitr
       USE MOMENTUM, ONLY : solveMomentumEq
@@ -70,7 +71,7 @@ C
       USE WRITE_OUTPUT, ONLY : writeOutput2D, writeHotStart, 
      &    writeWarnElev, collectInundationData, collectMinMaxData
       USE MESH, ONLY : NE, NP, DP, SLAM, SFEA, ICS, TotalArea,
-     &                  MJU, Areas, SFAC 
+     &                  MJU, Areas, SFAC, NNeigh, NeiTab
       USE BOUNDARIES, ONLY : NOPE, NETA, NBOU, NVEL, LBCODEI, NBV, SIII,
      &    NFLUXF, NFLUXB, NFLUXGBC, NFLUXIB, NFLUXIBP, NFLUXRBC, CSII,
      &    BARLANHT, BARLANCFSP, NVELL, IBCONN, BARINHT, BARINCFSP,
@@ -124,7 +125,7 @@ Casey 100205: Add a variable for writing of SWAN hot-start files.
       INTEGER, intent(in) :: IT
 C
 c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D wet/dry.
-      INTEGER IE, I, J, K                  !local loop counters
+      INTEGER IE, I, J, K, JJ                  !local loop counters
       INTEGER NM1, NM2, NM3
       INTEGER NC1, NC2, NC3, NCEle
       INTEGER NCyc, NA
@@ -136,6 +137,8 @@ c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D 
       REAL(8) :: vel
       REAL(8) :: velmax
       INTEGER :: errorElevExceeded
+C     DMW 202401 Check for Velocity exceeding error level
+      INTEGER :: errorVelExceeded
       INTEGER :: warnElevExceeded
       logical, save ::  EtaDisc_Fill = .TRUE.
 
@@ -180,6 +183,11 @@ C....... DW
       INTEGER:: NBDI, istep
 C.......
       LOGICAL ISFRONT
+      LOGICAL foundNaN
+      
+      IF (IT .EQ. 1) THEN
+        IT_foundNaN = 0
+      ENDIF
 
       call setMessageSource("timestep")
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)
@@ -1035,6 +1043,66 @@ C...
 C...
 C-------------END OF 2DDI MOMENTUM EQUATION SOLUTION--------------------
 C...
+C....DMW 20240109 - WARNING FOR NaNs IN VELOCITY SOLN
+      foundNaN = .false.
+      DO I = 1,NP 
+         IF(ISNAN(UU2(I)).OR.ISNAN(VV2(I))) THEN
+            foundNaN = .true.
+C     WJP 03.27.2018 with the addition of the hash table we now need to
+C     output the global node number to debug the local PE fort.14s
+            IF(NSCREEN.NE.0) THEN
+               WRITE(ScreenUnit,2993)
+     &              IT,NUMITR,TimeLoc,NODES_LG(I),
+     &              ETA2(I),DP(I),MYPROC
+               WRITE(16,2993) IT,NUMITR,TimeLoc,
+     &              NODES_LG(I),ETA2(I),DP(I),MYPROC
+ 2993          FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &              5X,'TIME = ',E15.8,
+     &              2X,'SPEED IS NaN AT NODE I =',I9,
+     &              /,2X,'ETA2(I) = ', 1pE12.4E3,
+     &              2X,'DP(I) = ', 1pE12.4E3,
+     &              2X,'ON MYPROC = ',I4)
+               DO J = 2,NNeigh(I)
+                  JJ = NeiTab(I,J)
+                  WRITE(ScreenUnit,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),               
+     &                 UU2(JJ),VV2(JJ),MYPROC
+              
+                  WRITE(16,2995) NODES_LG(JJ),ETA2(JJ),DP(JJ),
+     &                 UU2(JJ),VV2(JJ),MYPROC
+ 2995             FORMAT(1X,'AT NEIGHBOR NODE I =',I9,
+     &                 /,2X,'ETA2(I) = ', 1pE12.4E3,
+     &                 2X,'DP(I) = ', 1pE12.4E3,
+     &                 2X,'UU2(I) = ', 1pE12.4E3,
+     &                 2X,'VV2(I) = ', 1pE12.4E3,
+     &                 2X,'ON MYPROC = ',I4)
+               ENDDO
+            ENDIF
+         ENDIF
+      ENDDO
+      IF (foundNaN) THEN
+         IF(NSCREEN.NE.0) THEN
+            WRITE(ScreenUnit,2994)
+     &           IT,NUMITR,TimeLoc,ETA2(KEMAX),NODES_LG(KEMAX),
+     &           VELMAX,NODES_LG(KVMAX),MYPROC
+            WRITE(16,2994) IT,NUMITR,TimeLoc,ETA2(KEMAX),
+     &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
+ 2994       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &           5X,'TIME = ',E15.8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
+     &           2X,'ON MYPROC = ',I4,
+     &           3X,'** WARNING: Velocity is NaN **')
+         ENDIF
+      ENDIF
+      IF ((foundNaN).AND.(IT_foundNaN.EQ.0)) THEN
+         IT_foundNaN = IT
+      ELSEIF ((IT.EQ.IT_foundNaN + 20).AND.(IT_foundNaN.NE.0)) THEN
+         earlyterminate = 1
+      ENDIF
+#ifdef CMPI
+      call EarlyTermSum( earlyterminate )
+#endif
+
 
 C.....DW - ABS SPONGE LAYER     
       IF ( C2DDI .AND. LoadAbsLayerSigma .AND. (sponge_dis_mthd == 0) ) THEN
@@ -1227,8 +1295,8 @@ C     output the global node number to debug the local PE fort.14s
      &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
  1993       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I8,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
      &           2X,'ON MYPROC = ',I4,
      &           3X,'** WARNING: Elevation.gt.WarnElev **')
             IF (WarnElevDump) WarnElevExceeded=1
@@ -1249,8 +1317,8 @@ C     output the global node number to debug the local PE fort.14s
      &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
  1995       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I8,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
      &           2X,'ON MYPROC = ',I4,/,
      &           2X,'** ERROR: Elevation.gt.ErrorElev,',
      &           ' ADCIRC stopping. **')
@@ -1260,6 +1328,30 @@ C     output the global node number to debug the local PE fort.14s
          IF( ErrorElevExceeded /= 0 ) THEN    !  Finalize MPI Environment,
            Flag_ElevError = .true. 
            CALL MSG_FINI()                    !  if there are Error Elvation nodes.
+           CALL EXIT(1)                             !
+         ENDIF                                !st3
+         
+         ErrorVelExceeded = 0                ! Clint's Zombie Slyaer
+         IF(VELMAX.GT.ErrorVel) THEN
+         
+            WRITE(ScreenUnit,3995)
+     &           IT,NUMITR,TimeLoc,ETA2(KEMAX),NODES_LG(KEMAX),
+     &           VELMAX,NODES_LG(KVMAX),MYPROC
+            WRITE(16,3995) IT,NUMITR,TimeLoc,ETA2(KEMAX),
+     &           NODES_LG(KEMAX),VELMAX,NODES_LG(KVMAX),MYPROC
+ 3995       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &           5X,'TIME = ',E15.8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
+     &           2X,'ON MYPROC = ',I4,/,
+     &           2X,'** ERROR: Velocity.gt.ErrorVel,',
+     &           ' ADCIRC stopping. **')
+            ErrorVelExceeded = 1                ! Clint's Zombie Slayer
+         ENDIF
+         call WarnElevSum(ErrorVelExceeded)  ! Clint's Zombie Slayer 2010.08.07
+         IF( ErrorVelExceeded /= 0 ) THEN    !  Finalize MPI Environment,
+           Flag_VelError = .true. 
+           CALL MSG_FINI()                    !  if there are Error Velocity nodes.
            CALL EXIT(1)                             !
          ENDIF                                !st3
 #else
@@ -1274,8 +1366,8 @@ C     output the global node number to debug the local PE fort.14s
  1992       FORMAT(1X,'TIME STEP =',I8,1x,F6.2,'% COMPLETE',
      &           5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I8,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I8)
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9)
          ENDIF
          IF(ELMAX.GT.WarnElev) THEN
             WRITE(ScreenUnit,1994)
@@ -1283,8 +1375,8 @@ C     output the global node number to debug the local PE fort.14s
             WRITE(16,1994) IT,NUMITR,TimeLoc,ETA2(KEMAX),KEMAX,VELMAX,KVMAX
  1994       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I8,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
      &           2X,'** WARNING: Elevation.gt.WarnElev **')
 #ifdef DEBUG_WARN_ELEV
             IF (WarnElevDump) CALL WriteWarnElev(TimeLoc, IT)
@@ -1298,13 +1390,28 @@ C     output the global node number to debug the local PE fort.14s
             WRITE(16,1996) IT,NUMITR,TimeLoc,ETA2(KEMAX),KEMAX,VELMAX,KVMAX
  1996       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
      &           5X,'TIME = ',E15.8,
-     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I8,
-     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I8,/,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,/,
      &           2X,'** ERROR: Elevation.gt.ErrorElev, '
      &           'ADCIRC stopping. **')
             CALL ADCIRC_Terminate()
          ENDIF
+         IF(VELMAX.GT.ErrorVel) THEN
+            write(6,*) 'velmax, errorvel',velmax, errorvel 
+            Flag_VelError = .true.
+            WRITE(ScreenUnit,3996)
+     &           IT,NUMITR,TimeLoc,ETA2(KEMAX),KEMAX,VELMAX,KVMAX
+            WRITE(16,3996) IT,NUMITR,TimeLoc,ETA2(KEMAX),KEMAX,VELMAX,KVMAX
+ 3996       FORMAT(1X,'TIME STEP =',I8,5X,'ITERATIONS =',I5,
+     &           5X,'TIME = ',E15.8,
+     &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+     &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,/,
+     &           2X,'** ERROR: Velocity.gt.ErrorVel, '
+     &           'ADCIRC stopping. **')
+            CALL ADCIRC_Terminate()
+         ENDIF
 #endif
+
       ENDIF
 
 C...

--- a/src/vsmy.F
+++ b/src/vsmy.F
@@ -109,7 +109,7 @@ c.RJW merged 08282008 Casey 071219: Added the following variable declarations fr
      &                   BCFLAG_TEMP, BCRivRATIO,
      &                   RIVBCTIMINC, RIVBCTIME1, RIVBCTIME2,TK,
 Casey 140701: Prevent depths from becoming negative in bottom roughness calculations.
-     &                   H0
+     &                   H0, H1, H2
       USE GLOBAL_3DVS
       USE CONSTANTS, ONLY: G
       USE WRITE_OUTPUT, ONLY : writeOutput3D
@@ -212,7 +212,6 @@ Cjgfdebug      REAL(8) :: HsN2           !Total water depth at time level s at l
       REAL(8) :: Hsp1OAMB       !Hsp1/(a-b)
       REAL(8) :: Hsp1Hsp1OAMBAMB !(Hsp1/(a-b))^2
 Casey 140701: Prevent depths from becoming negative in bottom roughness calculations.
-      REAL(8) :: H1
 ! arash 12/14/2015
       Real(8) :: Biharmonic_viscosity
 
@@ -321,8 +320,8 @@ C!      ENDIF
       Biharmonic_viscosity_modified_Leith (:,:) = 0.0d0
 
       DO NH = 1, NP                      !loop over horizontal nodes
-         Hs = DP(NH) + IFNLFA * Eta1(NH) !Total depth at current timestep - 'center' node
-         HsOAMB = Hs / AMB
+C........DMW202401 Use saved H1
+         HsOAMB = H1(NH) / AMB
          ! begin the vertical loop
          DO k = 1, NFEN
             DqDXDPhiDX2A = 0.d0    ! variables for computing the biharmonic operator
@@ -338,8 +337,8 @@ C!      ENDIF
             N2  = NEITAB(NH,2)     !operate on 1st neighbor
             qN2 = q(N2,k)
 ! af 01/04/2016: interpolate it at the same z level as N1
-            HsN2 = DP(N2) + IFNLFA * Eta1(N2)
-            SigmaNN = B + AMB * ( Zk + DP(N2) ) / HsN2 !equivalent sigma value at neighbor
+C...........DMW202401 Use saved H1
+            SigmaNN = B + AMB * ( Zk + DP(N2) ) / H1(N2) !equivalent sigma value at neighbor
             inarray_vertical (:) = q(N2,:)
             Call linear_vertical_interpolation_complex ( inarray_vertical, SigmaNN, qN2_z, k )
 
@@ -357,8 +356,8 @@ C!      ENDIF
                N2  = NEITAB(NH,N)  !select new neighbor to work on
                qN2 = q(N2,k)
 ! af 01/04/2016: interpolate it at the same z level as N1
-               HsN2 = DP(N2) + IFNLFA * Eta1(N2)
-               SigmaNN = B + AMB * ( Zk + DP(N2) ) / HsN2 !equivalent sigma value at neighbor
+C..............DMW202401 Use saved H1
+               SigmaNN = B + AMB * ( Zk + DP(N2) ) / H1(N2) !equivalent sigma value at neighbor
                inarray_vertical (:) = q(N2,:)
                Call linear_vertical_interpolation_complex ( inarray_vertical, SigmaNN, qN2_z, k )
 
@@ -477,13 +476,14 @@ Corbitt 120328: Applies Advection Locally
          ENDIF
 
 c     Set up some values at the node being worked on
-
-         Hs  = DP(NH)+IFNLFA*Eta1(NH) !Total depth at previous (s) timestep
+C........DMW202401 Use saved H1
+         Hs  = H1(NH) !Total depth at previous (s) timestep
 Casey 140701: Check the total water depth.
          IF(Hs.LT.H0) Hs = H0
          HsOAMB=Hs/AMB
          HsHsOAMBAMB=HsOAMB*HsOAMB
-         Hsp1= DP(NH)+IFNLFA*Eta2(NH) !Total depth at present (s+1) timestep
+C........DMW202401 Use saved H2
+         Hsp1= H2(NH) !Total depth at present (s+1) timestep
 Casey 140701: Check the total water depth.
          IF(Hsp1.LT.H0) Hsp1 = H0
          Hsp1OAMB=Hsp1/AMB
@@ -574,14 +574,15 @@ C or as read in from nodal attributes
          ELSEIF (LoadManningsN) THEN
 Casey 140701: Prevent depths from becoming negative.  Cannot raise a negative number
 C             to the 1/6 power.
-            H1 = DP(NH)+IFNLFA*ETA2(NH)
-            IF(H1.LT.H0) H1=H0
+C...........DMW202401 Use saved H2
+            Hs = H2(NH)
+            IF(Hs.LT.H0) Hs=H0
 !            Z0B1 = ( DP(NH)+IFNLFA*ETA2(NH) )* exp(-(1.0D0+
 !     &             ( (0.41D0*( DP(NH)+IFNLFA*ETA2(NH))**(1.0D0/6.0D0) )/
 !     &                              (ManningsN(NH)*sqrt(g)) ) ))
 ! arash Sep 7 2015:
-            Z0B1 = ( H1 )* exp(-(1.0D0+
-     &             ( (0.41D0*( H1 )**(1.0D0/6.0D0) )/
+            Z0B1 = ( Hs )* exp(-(1.0D0+
+     &             ( (0.41D0*( Hs )**(1.0D0/6.0D0) )/
      &                              (ManningsN(NH)*sqrt(g)) ) ))
          ELSE
             Z0B1 = Z0B
@@ -825,8 +826,8 @@ c     Compute lateral advection and lateral stress terms
             N2=NEITAB(NH,2)     !operate on 1st neighbor
             qN2=q(N2,k)
 ! af 01/04/2016: interpolate it at the same z level as N1
-            HsN2 = DP(N2) + IFNLFA * Eta1(N2)
-            SigmaNN = B + AMB * ( Zk + DP(N2) ) / HsN2 !equivalent sigma value at neighbor
+C...........DMW202401 Use saved H1
+            SigmaNN = B + AMB * ( Zk + DP(N2) ) / H1(N2) !equivalent sigma value at neighbor
             inarray_vertical (:) = q(N2,:)
             Call linear_vertical_interpolation_complex ( inarray_vertical, SigmaNN, qN2_z, k )
 
@@ -874,8 +875,8 @@ c     Compute lateral advection and lateral stress terms
                N2  = NEITAB(NH,N)  !select new neighbor to work on
                qN2 = q(N2,k)
 ! af 01/04/2016: interpolate it at the same z level as N1
-               HsN2 = DP(N2) + IFNLFA * Eta1(N2)
-               SigmaNN = B + AMB * ( Zk + DP(N2) ) / HsN2 !equivalent sigma value at neighbor
+C..............DMW202401 Use saved H1
+               SigmaNN = B + AMB * ( Zk + DP(N2) ) / H1(N2) !equivalent sigma value at neighbor
                inarray_vertical (:) = q(N2,:)
                Call linear_vertical_interpolation_complex ( inarray_vertical, SigmaNN, qN2_z, k )
 
@@ -1309,8 +1310,8 @@ C     Compute the depth averaged velocity, depth averaged flux, bottom stress an
 C     velocity dispersion
 
       DO NH=1,NP                                !loop over horizontal nodes
-
-         Hsp1= DP(NH)+IFNLFA*Eta2(NH)           !Total depth at present (s+1) timestep
+C........DMW202401 Use saved H2
+         Hsp1= H2(NH)           !Total depth at present (s+1) timestep
          VIVel = (0.d0,0.d0)
          DO k=1,NFEN
             VIVel = VIVel + Qkp1(NH,k)*LVn(k)
@@ -1395,8 +1396,8 @@ C    &         NOFF(NEITABELE(NH,K+TEMPSTOP))
          ENDIF
 
 c     Set up some values at the node being worked on
-
-         Hsp1=DP(NH)+IFNLFA*Eta2(NH)
+C........DMW202401 Use saved H2
+         Hsp1=H2(NH)
 Casey 140701: Adjust for small depths.
          IF(Hsp1.LT.H0) Hsp1=H0
          Hsp1OAMB=Hsp1/AMB
@@ -1546,7 +1547,8 @@ c.
 c     Correct this using Adjoint method
 
          Wf=0.d0                !This value should match surface B.C. exactly
-         Hsp1= DP(NH)+IFNLFA*Eta2(NH) !Total depth at present (s+1) timestep
+C........DMW202401 Use saved H2
+         Hsp1= H2(NH) !Total depth at present (s+1) timestep
          WfOHH=Wf/(Hsp1*Hsp1)
          WZSurfBC=DEtaDT+REAL(qkp1(NH,NFEN))*DEtaDX
      &                  +AIMAG(qkp1(NH,NFEN))*DEtaDY


### PR DESCRIPTION
# Description

Add checker for error level and NaNs in velocity solution. Also, add the global variables H1 and H2 to save the flow depth at the previous and current timesteps.

These updates were primarily developed to solve an issue with subgrid barriers, whereby the wrong value of H1 (computed as the bathymetric depth plus the previous surface elevation at the node, DP + ETA1) was obtained when changing DP on the current timestep. In some cases, if DP is changed at a subgrid barrier, the value of H1 could become zero (even though the depth was not zero at the previous timestep, e.g., for very shallow flows), which leads to infinite wind stress in the momentum solver (since H1 is in the denominator of the formula for computing wind stress). The wind limiter code, for wind stress in very shallow water, then converts this Infinity into a NaN, which thereby leads to NaNs in the velocity solutions. This subsequently causes the elevation solution to become non-physical on the next timestep and onwards, although the model does not crash until the elevation error level is exceeded.

The NOAA team first encountered this problem around 1/5/2024 on the Global STOFS grid in their 7 day storm surge forecasts, and then the UND team encountered the same issue on 1/10/2024 in their own 7 day storm surge forecast using Global STOFS. The issue was eventually traced to NaNs in the velocity solution, originating at the location of a subgrid barrier near the coast of North Carolina.

The velocity check code was added in order to track down this error, and it is left in behind the "VELCHECK" compiler flag, since it remains generally useful for debugging. This code checks for velocity solutions that are either NaN or greater than the error level (currently hard-coded as 1000 m/s). If the error level is exceeded, then the model run is immediately aborted and the location of the error velocity is output to the screen and the fort.16 log file. If a NaN is detected in the velocity solution, then the location of the NaN is output to the screen and the fort.16 log file, as well as the velocities and elevations at the neighboring nodes, and the model run is aborted after 20 timesteps have passed.

To avoid improperly computing H1 after changing DP, we simply introduce the global variables H1 and H2 to store the values of the depths, and we then retrieve these values as needed. This slightly reduces the model's compute load, while slightly raising the memory load, since we no longer have to recompute the depths as frequently, e.g., DP + ETAX. The time varying bathymetry feature also suffered from this same issue, since the variables DP1 and DP2 are not used in either governing equations solver, so this update should also improve results from using that feature, and it should be compatible with any future updates that modify the DP variable.

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number
https://github.com/noaa-ocs-modeling/STOFS-2D-Global-Operation/issues/66#issuecomment-1904245083

# How Has This Been Tested?

We tested on the Global-STOFS 2D mesh over several days of hindcasting/forecasting during the first two weeks in January with forcing by 1-hourly GFS winds, ice cover and tidal potentials (major 8 constituents). The "VELCHECK" code was first used to track down a NaN in the velocity solution originating at a the location of a subgrid barrier on the US east coast. We discovered that when a subgrid barrier is overtopped, but the elevation is low enough at the barrier to cause a reset, i.e., when DP + ETA < HABSMIN and the elevation is raised so that ETA = HABSMIN - DP, then the bathy at the subgrid barrier could be raised by the same amount (or more) in the "applySubgridBarrier" routine. Therefore, when computing the depth at the previous timestep, H1 = DP + ETA1, since we no longer are using the value of DP at the previous timestep, a non-physical value could be obtained, either zero or negative, leading to the observed NaN in the velocity solution (when H1 = 0).

The "VELCHECK" code worked as intended, and did not present any false warnings or errors.

After tracking down the source of the issue, the global variables H1 and H2 were added to the code to save the depths at the previous and current timesteps, respectively. We attempted the error run in a few ways to test these code changes. First, we repeated the simulation without the code changes, but also without subgrid barriers, i.e., by removing the nodal attribute from the fort.15 file, to confirm this feature as the source of the issue, and we did not encounter any NaNs or error levels in the elevations/velocities. Next, we added the updated code (i.e., using the global variables H1 and H2) and repeated the simulation, again with no subgrid barriers, to ensure that the new code did not lead to any unexpected behavior when the subgrid barrier feature is not used. Again, no errors were encountered. Finally, we repeated the simulation with the new code as well as with the subgrid barriers, and again, found no errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

I have *not* made corresponding changes to the documentation, because I don't think any relevant documentation exists with respect to this issue.

I have *not* added new tests that prove my fix is effective or that my feature works. So far all of the existing tests are sufficient.

The code is *not* tested with changes from the latest version of `main` because it is based on the code currently operational on NOAA systems, which corresponds to the `noaa.stofs.2d.glo.v2.1.0r1.v55.10` release tag (which is the same code as on the `noaa` branch).

# Further comments

We considered using the existing global variables DP1 and DP2 that are used by the time-varying bathymetry feature, as opposed to bringing in the new global variables H1 and H2, however, we figured that it would be more straightforward to save the values of H1 and H2, rather than recompute them at each timestep, so that the changes could be applicable towards both the subgrid barrier and time-varying bathymetry features, without having to modify the code for either, as well as (hopefully) towards any other future updates on DP that may be integrated into the code.