### PR TITLE
[FEATURE] Add git hash to output files

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -28,13 +28,18 @@ if(WIN32)
       COMMENT "Generating ADCIRC version...")
   endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/version.F)
 else(WIN32)
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/version_cmake.F
-    COMMAND ./adcirc_version.py --create-version-file --directory ${CMAKE_CURRENT_SOURCE_DIR} >/dev/null
-    COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/version.F ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/version_cmake.F
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts
-    COMMENT "Generating ADCIRC version...")
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/version_cmake.F
+      COMMAND ./adcirc_version.py --create-version-file --directory ${CMAKE_CURRENT_SOURCE_DIR} >/dev/null
+      COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/version.F ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/version_cmake.F
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+      COMMENT "Generating ADCIRC version...")
+    add_custom_target(version_generate
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+        COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/version_cmake.F
+    )
 endif(WIN32)
 set_target_properties(version PROPERTIES Fortran_MODULE_DIRECTORY CMakeFiles/version_mod)
 set_target_properties(version PROPERTIES COMPILE_FLAGS "${Fortran_LINELENGTH_FLAG} ${Fortran_COMPILER_SPECIFIC_FLAG}")
 set_target_properties(version PROPERTIES EXCLUDE_FROM_ALL TRUE)
+add_dependencies(version version_generate)

--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -109,7 +109,7 @@ C*    ADCIRC initialize routine
 C******************************************************************************
       SUBROUTINE ADCIRC_Init(COMM, ROOTD)
       !USE, INTRINSIC :: IEEE_ARITHMETIC !jgfdebug ieee_is_nan()
-      USE VERSION, ONLY : adc_version, fileFmtMajor, fileFmtMinor, 
+      USE VERSION, ONLY : adc_version, adc_hash, fileFmtMajor, fileFmtMinor, 
      &   FileFmtRev
       USE SIZES, ONLY : rootDir, mnproc, mnwproc, mnallproc, myproc,
      &   read_local_hot_start_files, make_dirname, write_local_harm_files,
@@ -164,12 +164,15 @@ C
          do while (i.lt.argcount)
             i = i + 1
             call getarg(i, cmdlinearg)
-            select case(cmdlinearg(1:2))
-            case("-V","-v") 
+            select case(trim(cmdlinearg))
+            case("-V","-v","--version") 
                ! write the version number string ... actually it is
                ! a series of two or three numbers with two digits 
                ! separated by dots, e.g., 51.02 or 51.52.07
                write(6,'(a)') trim(adc_version)                 
+               CALL EXIT(0) 
+            case("--hash")
+               write(6,'(a)') trim(adc_hash) 
                CALL EXIT(0) 
             case default
                ! do nothing, this is some other command line argument
@@ -228,6 +231,7 @@ C
      &   VERSION_NUMBER(FileFmtMajor, FileFmtMinor, FileFmtRev)
       IF ((NSCREEN.NE.0).AND.(MYPROC.EQ.0)) THEN
          WRITE(ScreenUnit,'(a)')"ADCIRC Version is "//ADC_VERSION
+         WRITE(ScreenUnit,'(a)')"ADCIRC Commit hash is "//ADC_HASH
       ENDIF
 
       !jgf49.44: Allocate memory for reading and writing full domain arrays

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -10221,6 +10221,8 @@ C     back to degrees to write them back out
       CALL check_err(iret)
       iret = nf90_put_att(ncid, NF_GLOBAL, 'version', ADC_VERSION)
       CALL check_err(iret)
+      iret = nf90_put_att(ncid, NF_GLOBAL, 'git_hash', ADC_HASH)
+      CALL check_err(iret)
       iret = nf90_put_att(ncid, NF_GLOBAL, 'grid_type', 'Triangular')
       CALL check_err(iret)
       iret = nf90_put_att(ncid, NF_GLOBAL, 'description',


### PR DESCRIPTION
# Description

The git commit hash is a useful piece of information to include in the ADCIRC output files as well as have accessible directly from the command line executable. This pull request implements the following changes:

1. Add the git commit hash to netCDF output files as a global attribute `git_hash`
2. Add the command line arguments `--hash` and `--version` (Note: version is already available via `-v` but this is just another option for the same info. 
3. Within CMake, force the regeneration of the `version_cmake.F` file every time the code is built. This ensures that an old `version_cmake.F` generated file is not hanging around.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

noaa-ocs-modeling/stofs-2d-global-operation#66

# How Has This Been Tested?

The code was tested inside and outside of a git repository to ensure that the version generation occurs reasonably. 

# Relevant Publications (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

There are no tests for this as it is a metadata change only.

# Further comments

The same change will be made for the NOAA fork of the code.