### PR TITLE
Adding wave stress gradient limiter

### DIFF
--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -112,10 +112,12 @@ C----------------------------------------------------------------------------
 
       MODULE PRESIZES
 Casey 121019: Added multiplication factor to be used before sending winds to coupled wave models.
-      USE ADC_CONSTANTS, ONLY: waveWindMultiplier, Ad, Bd, Cs
+      USE ADC_CONSTANTS, ONLY: waveWindMultiplier, Ad, Bd, Cs,
+     &                         WaveStressGrad_CAP !tcm v56 2024: added
       USE GLOBAL, ONLY :
      &    USE_TVW,TVW_FILE,NOUT_TVW,TOUTS_TVW,TOUTF_TVW,NSPOOL_TVW,
-     &    outputWindDrag,slim,windlim,directvelWD,useHF
+     &    outputWindDrag,slim,windlim,directvelWD,useHF,
+     &    Limit_WaveStressGrad  !tcm v56 2024: added
 #if defined CSWAN || defined ADCSWAN
      &   ,SWAN_OutputHS,SWAN_OutputDIR,SWAN_OutputTM01,
      &    SWAN_OutputTPS,SWAN_OutputWIND,SWAN_OutputTM02,
@@ -241,7 +243,8 @@ C Logicals added for adcprep paths
       LOGICAL :: NETCDF_AVAIL ! true if netCDF was compiled in
       LOGICAL :: XDMF_AVAIL ! true if XDMF was compiled in
 Casey 121019: Added multiplication factor to be used before sending winds to coupled wave models.
-      NAMELIST /waveCoupling/ WaveWindMultiplier
+      NAMELIST /waveCoupling/ WaveWindMultiplier,
+     &          Limit_WaveStressGrad, WaveStressGrad_Cap  !tcm v56 2024: added 
 #ifdef ADCNETCDF
 Casey 180318: Added NWS=13
       NAMELIST /owiWindNetcdf/ NWS13File,NWS13ColdStartString,

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -646,7 +646,7 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
          FOUND_WC_NML = .TRUE.
          call logMessage(INFO,
      &         'The waveCoupling namelist was found.')
-      else
+      ELSE
          call logMessage(INFO,
      &         'The waveCoupling namelist was not found.')
       ENDIF
@@ -658,7 +658,7 @@ Casey 180318: Added NWS=13
          FOUND_OWINC_NML = .TRUE.
          call logMessage(INFO,
      &         'The owiWindNetcdf namelist was found.')
-      else
+      ELSE
          call logMessage(INFO,
      &         'The owiWindNetcdf namelist was not found.')
       ENDIF

--- a/src/constants.F
+++ b/src/constants.F
@@ -112,6 +112,9 @@
 
           !...Wave Wind Multiplier. Applied to winds sent to wave models
           REAL(8) :: waveWindMultiplier = 1.0D0
+          
+          !... Wave Stress Gradient Magnitude CAP
+          REAL(8) :: WaveStressGrad_Cap = 1000.0D0
 
           REAL(8), PARAMETER :: DEG2RAD = PI/180.0D0
           REAL(8), PARAMETER :: RAD2DEG = 180.0D0/PI

--- a/src/cstart.F
+++ b/src/cstart.F
@@ -1113,7 +1113,10 @@ C...
       ENDIF
 
 !  tcm v50.75 changed ifdef cwan to output for nrs=3 or 4
-      IF ((ABS(NRS).EQ.3).or.(ABS(NRS).eq.4)) then
+!      IF ((ABS(NRS).EQ.3).or.(ABS(NRS).eq.4)) then
+! tcm v56 2024 added NRS = 1 and NRS = 5
+      IF ( (ABS(NRS).EQ.1).or.(ABS(NRS).EQ.3).or.(ABS(NRS).eq.4).or.
+     &     (ABS(NRS).EQ.5) ) then
 !#ifdef CSWAN  tcm temp
 Casey 090302: Added the output of radiation stress gradients.
          IGRadS=0

--- a/src/global.F
+++ b/src/global.F
@@ -59,6 +59,11 @@ C... v50.xx sm -- added for coupling with NOUPC Cap
       LOGICAL   ::  NUOPC4MET = .FALSE.  ! assign in CAP
       LOGICAL   ::  NUOPC4WAV = .FALSE.  ! assign in CAP
 
+C... TCM v56 2024 --- added variable for using a limiter or cap
+C           on wave stress gradients
+      LOGICAL   ::  Limit_WaveStressGrad = .FALSE. ! set in fort.15 file 
+      
+
 C      real(8) rampriver,drampriver,rampriver1,rampriver2
 C     jgf46.08 Fine grained ramp functions (jgf46.21 split flux b.c.s)
       REAL(8) RampExtFlux,DRampExtFlux ! Ramp for external flux b.c.s
@@ -1476,7 +1481,8 @@ C
 
 !  tcm v50.75 removed ifdef cswan to allow for use whenever nrs=3 or nrs=4
 !   nrs = 5 -- Saeed's nuopc implementation
-      IF ((ABS(NRS).EQ.3).or.(ABS(NRS).EQ.4).or.(ABS(NRS).EQ.5)) then
+! tcm v56 -- added nrs = 1
+      IF ((ABS(NRS).EQ.1).or.(ABS(NRS).EQ.3).or.(ABS(NRS).EQ.4).or.(ABS(NRS).EQ.5)) then
 !#ifdef CSWAN
 Casey 090302: Added the next line for output of radiation stress gradients.
          ALLOCATE ( RSNXOUT(MNP),RSNYOUT(MNP) )

--- a/src/hstart.F
+++ b/src/hstart.F
@@ -2614,7 +2614,11 @@ Casey 090310: Added the possibility for NOUTGW = -4.
       ENDIF
 
 ! tcm v50.75 removed ifdef cswan and added test for nrs=3 or 4
-        IF ((ABS(NRS).EQ.3).OR.(ABS(NRS).EQ.4)) THEN
+!        IF ((ABS(NRS).EQ.3).OR.(ABS(NRS).EQ.4)) THEN
+! tcm v56 20240 -- added NRS=1 and NRS=5
+        IF ( (ABS(NRS).EQ.1).OR.(ABS(NRS).EQ.3).OR.(ABS(NRS).EQ.4)
+     &       .OR.(ABS(NRS).EQ.5) ) THEN
+
 !#ifdef CSWAN
 Casey 090310: Added the output of radiation stress gradients.
            IF(NOUTGW.LT.0)THEN

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -83,7 +83,7 @@ C-----------------------------------------------------------------------
      &   alloc_main6, openfileforread, nhoutonce, IFSPROTS,
      &   StatPartWetFix, How2FixStatPartWet, cgwce_hdp, ifnl_hdp, 
      &   CAliDisp, IFSFM, usingDynamicWaterLevelCorrection,slim,windlim,
-     &   directvelWD,useHF
+     &   directvelWD,useHF,Limit_WaveStressGrad
 #if defined CSWAN || defined ADCSWAN
      &   , SWAN_OutputHS, SWAN_OutputDIR,
      &    SWAN_OutputTM01, SWAN_OutputTPS, SWAN_OutputWIND,
@@ -95,7 +95,7 @@ C-----------------------------------------------------------------------
      &   ,NUOPC4WAV, NUOPC4MET
       USE ADC_CONSTANTS, ONLY: G, Ad, Bd, Cs, Cs2,
      &                     waveWindMultiplier,deg2rad,rhoAir,
-     &                     rad2deg,omega
+     &                     rad2deg,omega,WaveStressGrad_Cap
 
       USE MESH, ONLY : NE, SLAM0, SFEA0, BCXY, RMAX, ICS, X, Y, DP, NP,
      &   SLAM, SFEA, NM, readMesh, initializeMesh, initializeBoundaries,
@@ -252,7 +252,9 @@ C.... DMW
       NAMELIST /Smag_Control/ SMAG_COMP_FLAG,SMAG_UPPER_LIM, SMAG_LOWER_LIM
 
 Casey 121019: Added multiplication factor to be used before sending winds to coupled wave models.
-      NAMELIST /waveCoupling/ WaveWindMultiplier
+!tcm 2024: added wave stress gradient limiting
+      NAMELIST /waveCoupling/ WaveWindMultiplier,
+     &         Limit_WaveStressGrad, WaveStressGrad_Cap
 
       call setMessageSource("read_input")
 #if defined(READ_INPUT_TRACE) || defined(ALL_TRACE)
@@ -480,6 +482,14 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
       call logNamelistReadStatus(namelistSpecifier,ios)
       write(scratchMessage,*) "WaveWindMultiplier=",WaveWindMultiplier
       call logMessage(ECHO,trim(scratchMessage))
+!TCM 2024 -- added wave stress gradient limiter      
+      write(scratchMessage,*)"Limit_WaveStressGrad=",
+     &                        Limit_WaveStressGrad
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "WaveStressGrad_Cap=",
+     &                         WaveStressGrad_Cap
+      call logMessage(ECHO,trim(scratchMessage))
+      
       rewind(15)
       !
       ! jgf52.05: Add a namelist for the user to control

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -81,8 +81,10 @@ C
      &    QNPH, QNAM, ENPH, ENAM, ETRF, FPER, FFACE, ETA1, FAMIG, LNM_BC,
      &    BCFLAG_LNM, usingDynamicWaterLevelCorrection,
      &    dynamicWaterLevelCorrection1, dynamicWaterLevelCorrection2, L_N, TKM, 
-     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE
-      USE ADC_CONSTANTS, ONLY: rhoWat0, sigT0, waveWindMultiplier
+     &    WarnElevDump, nodes_lg, NT, NM, NB, DEBUG, NHOUTONCE,
+     &    Limit_WaveStressGrad     
+      USE ADC_CONSTANTS, ONLY: rhoWat0, sigT0, waveWindMultiplier,
+     &                         WaveStressGrad_Cap 
       USE GWCE, ONLY : solveGWCE, numitr
       USE MOMENTUM, ONLY : solveMomentumEq
       USE WETDRY, ONLY : computeWettingAndDrying
@@ -171,6 +173,7 @@ c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D 
       REAL(8) EtaN1,EtaN2,EtaN3
       REAL(8) QTRatio
       REAL(8) RStRatio, RSX, RSY
+      REAL(8) RSXLIM,RSYLIM,RSXYMAG,RSSCALE
       REAL(8) SAltMul, S2SFEA
       REAL(8) H1
       REAL(8) TPMul
@@ -668,7 +671,6 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
       IF(NRS.NE.0) THEN
 
         if((NRS.eq.1).or.(nrs.eq.2).or.(nrs.eq.3) .or. (nrs.eq.5)) then  !saeed added 5
-!          if((NRS.eq.1).or.(nrs.eq.2).or.(nrs.eq.3)) then
             IF(TimeLoc.GT.RSTIME2) THEN
                RSTIME1=RSTIME2
                RSTIME2=RSTIME2+RSTIMINC
@@ -702,7 +704,7 @@ C             into RSNX1/RSNY1, and then load the future forces into RSNX2/RSNY2
 C... v50.xx sm -- nrs=5 for NUOPC coupling wave data from coupler
                NRS5: IF (NRS == 5) THEN    ! saeed
 
-                  DO I=1,NP
+                 DO I=1,NP
                    RSX = RSNX1(I)
                    RSY = RSNY1(I)
                    RSNX1(I) = RSNX2(I)
@@ -712,24 +714,47 @@ C... v50.xx sm -- nrs=5 for NUOPC coupling wave data from coupler
                  ENDDO
                ENDIF NRS5 !(NRS = 5)
 
-            ENDIF
+            ENDIF  !timeloc gt rstime2
 
             RStRatio=(TimeLoc-RSTIME1)/RSTIMINC
-            DO I=1,NP
-               RSX = RampWRad*(RSNX1(I) + RStRatio*(RSNX2(I)-RSNX1(I)))
-               RSY = RampWRad*(RSNY1(I) + RStRatio*(RSNY2(I)-RSNY1(I)))
-               WSX2(I) = WSX2(I) + RSX
-               WSY2(I) = WSY2(I) + RSY
-!  tcm v50.75 removed ifdef cswan to allow for use whenever nrs=3 or nrs=4
-!#ifdef CSWAN
+            
+! tcm v56 2024 -- added option for limiting wave stress gradient magnitude
+            IF (Limit_WaveStressGrad.eqv..false.) then            
+               DO I=1,NP
+                 RSX = RampWRad*(RSNX1(I) + RStRatio*(RSNX2(I)-RSNX1(I)))
+                 RSY = RampWRad*(RSNY1(I) + RStRatio*(RSNY2(I)-RSNY1(I)))
+                 WSX2(I) = WSX2(I) + RSX
+                 WSY2(I) = WSY2(I) + RSY
+
 Casey 090302: Added these lines for output to the rads.64 file.
-               IF(ABS(NRS).EQ.3) then
-                  RSNXOUT(I) = RSX
-                  RSNYOUT(I) = RSY
-               ENDIF
-!#endif
-            ENDDO
-         ENDIF  !nrs = 1,2,or 3
+!TCM v56 2024: removed the test for NRS=3, to allow for outputting if any NRS>0
+!                IF(ABS(NRS).EQ.3) then
+                 RSNXOUT(I) = RSX
+                 RSNYOUT(I) = RSY
+!                ENDIF
+               ENDDO
+            ELSE !test and limit wave stress
+               DO I=1,NP
+                 RSX = RampWRad*(RSNX1(I) + RStRatio*(RSNX2(I)-RSNX1(I)))
+                 RSY = RampWRad*(RSNY1(I) + RStRatio*(RSNY2(I)-RSNY1(I)))
+                 RSXYMAG = SQRT(RSX*RSX + RSY*RSY)
+                 IF ((RSXYMAG .gt. WaveStressGrad_Cap ).and.
+     &               (RSXYMAG.gt.0.0d0)) then
+                    RSSCALE = WaveStressGrad_Cap/RSXYMAG
+                    RSXLIM = RSX*RSSCALE
+                    RSYLIM = RSY*RSSCALE
+                 ELSE
+                    RSXLIM = RSX
+                    RSYLIM = RSY
+                 ENDIF
+                 WSX2(I) = WSX2(I) + RSXLIM
+                 WSY2(I) = WSY2(I) + RSYLIM
+                 RSNXOUT(I) = RSX    !keep unlimited value for writing
+                 RSNYOUT(I) = RSY    !keep unlimited value for writing
+               ENDDO
+            ENDIF  ! test for limiting wave stress gradient magnitudes
+            
+         ENDIF  !nrs = 1,2,3, or 5
 
          ! Tightly Coupled Code with STWAVE
          ! Apply the ramping function and add wave stress to WSX2,WSY2
@@ -742,19 +767,44 @@ Casey 090302: Added these lines for output to the rads.64 file.
             IF (TimeLoc > ENDWAVE+RSTIMINC) THEN
               RSNX2(:) = 0.0d0;  RSNY2(:) = 0.0d0
             ENDIF
-            DO I=1,NP
-               RSX = RampWRad*RSNX2(I)
-               RSY = RampWRad*RSNY2(I)
-               WSX2(I) = WSX2(I) + RSX
-               WSY2(I) = WSY2(I) + RSY
-               !  tcm v50.75 added for use whenever nrs=3 or nrs=4
-               RSNXOUT(I) = RSX
-               RSNYOUT(I) = RSY
-            END DO
+
+!tcm v56 2024: Added test for limiting wave stress gradient magnitudes
+            IF (Limit_WaveStressGrad.eqv..false.) then
+               DO I=1,NP
+                  RSX = RampWRad*RSNX2(I)
+                  RSY = RampWRad*RSNY2(I)
+                  WSX2(I) = WSX2(I) + RSX
+                  WSY2(I) = WSY2(I) + RSY
+                  !  tcm v50.75 added for use whenever nrs=3 or nrs=4
+                  RSNXOUT(I) = RSX
+                  RSNYOUT(I) = RSY
+               ENDDO
+               
+            ELSE !test and limit wave stress gradients
+             
+               DO I=1,NP
+                  RSX = RampWRad*RSNX2(I)
+                  RSY = RampWRad*RSNY2(I)
+
+                  RSXYMAG = SQRT(RSX*RSX + RSY*RSY)
+                  IF ((RSXYMAG .gt. WaveStressGrad_Cap ).and.
+     &                (RSXYMAG.gt.0.0d0)) then
+                     RSSCALE = WaveStressGrad_Cap/RSXYMAG
+                     RSXLIM = RSX*RSSCALE
+                     RSYLIM = RSY*RSSCALE
+                  ELSE
+                     RSXLIM = RSX
+                     RSYLIM = RSY
+                  ENDIF
+
+                  WSX2(I) = WSX2(I) + RSXLIM
+                  WSY2(I) = WSY2(I) + RSYLIM
+                  RSNXOUT(I) = RSX !keep unlimited value for writing
+                  RSNYOUT(I) = RSY !keep unlimited value for writing
+               ENDDO
+            ENDIF !test for limit wave stress gradients      
          ENDIF !(NRS = 4)
-
       ENDIF  !(End test for updating wave radiation stress)
-
 
 C     jgf48.4627 Skip past GWCE and momentum calculations if only
 C     meteorological output was requested.

--- a/src/write_output.F
+++ b/src/write_output.F
@@ -1141,10 +1141,13 @@ C... v49.64.01 tcm -- added for ice stations
       RSDescript % alternate_value      = -99999.0
       RSDescript % considerWetDry       = .true.
       RSDescript % field_name           = 'RadStress'
-      RSDescript % file_basename            = 'rads'
+      RSDescript % file_basename        = 'rads'
       RSDescript % file_extension       = 64
       if (nrs.eq.0) then
          RSDescript % writeFlag         = .false.
+      ! tcm v56 2024 : added else to allow for outputting if nrs > 0
+      else
+         RSDescript % writeFlag         = .true.
       endif
 #ifndef CSWAN
       ! jgf52.30.02: Turn off rads.64 if compiled without SWAN but


### PR DESCRIPTION

# Description

Changes from @chrismassey for the wave stress gradient limiter:

Final changes for adding option to use a wave stress limiter within ADCIRC. Note that when wave stress
gradients are limited, the values outputted in the rads.64 are not limited, thus representing the original values provided to ADCIRC. The wave stress gradient magnitude limiting is by default turned off. There are two controls for this new feature, both are contained within the waveCoupling Namelist. The first is `Limit_WaveStressGrad` which is a logical variable that is set to `.false.` by default and means that limiting is not used, setting it to .true. turns on the checking for limiting of wave stress gradient magnitudes. The second variable is `WaveStressGrad_Cap` which is a real number value with a default setting of `1000.0d0`. This value represents the upper limit to the size of wave radiation stress gradient magnitude. If the magnitude is greater, then the `rsx` and `rsy` values are scaled proportionately so that the magnitude is no more than the `WaveStressGrad_Cap`. The default value is set to an unrealistically high value, in the case limiting is inadvertently turned on. More reasonable values for the upper limit would be in the range of `1.0` to `0.001`, but should be tested for sensitivity to results.  Finally, bug fixes were made to allow rads.64 file creation when using `NRS=1` and code changes made to allow for rads.64 output whenever `NRS>0`. 

## Type of change

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

This has been tested extensively by USACE ERDC @chrismassey 

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
