### PR TITLE
Fix inconsistent omega in wind module

### DIFF
--- a/src/constants.F
+++ b/src/constants.F
@@ -71,6 +71,8 @@
           ! REAL(8), PARAMETER :: RhoAir = 1.1774D0 !... T=79.79, P=1013D0
 
           REAL(8), PARAMETER :: PI = 3.141592653589793D0
+          REAL(8), PARAMETER :: TWOPI=PI*2.D0
+          REAL(8), PARAMETER :: HFPI=PI/2.D0
           REAL(8), PARAMETER :: e = 2.718281828459045D0
 
           !...Radius of earth (m)

--- a/src/constants.F
+++ b/src/constants.F
@@ -118,6 +118,7 @@
 
           REAL(8), PARAMETER :: DEG2RAD = PI/180.0D0
           REAL(8), PARAMETER :: RAD2DEG = 180.0D0/PI
+          REAL(8), PARAMETER :: MPERDEG  = REarth * PI / 180.0d0
 
           !---Length based factors---!
           REAL(8), PARAMETER :: nm2m = 1852.0D0 ! nautical miles to meters

--- a/src/wind.F
+++ b/src/wind.F
@@ -92,7 +92,6 @@ C
 
       REAL(8), PARAMETER :: TWOPI=PI*2.D0
       REAL(8), PARAMETER :: HFPI=PI/2.D0
-      REAL(8), PARAMETER :: mperdeg  = Rearth * pi / 180.0d0
       real(8) :: prbckgrnd_mH2O, RhoWat0g
       real(8) :: airwaterdensityrat
 
@@ -4989,7 +4988,7 @@ C     ----------------------------------------------------------------
       SUBROUTINE HollandGet(WVNX,WVNY,PRESS,TIMELOC)
       USE SIZES, ONLY : MyProc, LOCALDIR
       USE MESH, ONLY : X, Y, SLAM, SFEA, NP, ICS
-      USE ADC_CONSTANTS, ONLY : RHOWAT0, G, mb2pa
+      USE ADC_CONSTANTS, ONLY : RHOWAT0, G, mb2pa, omega
       IMPLICIT NONE
       REAL(8), intent(in) :: TIMELOC
       REAL(8), intent(out), dimension(NP) :: WVNX,WVNY
@@ -5006,8 +5005,7 @@ C     ----------------------------------------------------------------
       REAL(8) :: WindMultiplier         ! for storm 2 in LPFS ensemble
       REAL(8) :: centralPressureDeficit ! difference btw ambient and cpress
 C
-      REAL(8) :: omega, coriolis
-      REAL(8) :: mperdeg
+      REAL(8) :: coriolis
 
       LOGICAL, SAVE :: FIRSTCALL = .True.
 
@@ -5017,8 +5015,6 @@ C
 #endif
 
 C
-      mperdeg  = Rearth * pi / 180.0d0
-      omega = 2.0d0*pi / 86164.2d0
 C
       IF (FIRSTCALL) THEN
          FIRSTCALL = .False.

--- a/src/wind.F
+++ b/src/wind.F
@@ -90,8 +90,6 @@ C
       real(8) :: WLATMAX,WLONMIN,WLATINC,WLONINC
       integer  :: IREFYR,IREFMO,IREFDAY,IREFHR,IREFMIN
 
-      REAL(8), PARAMETER :: TWOPI=PI*2.D0
-      REAL(8), PARAMETER :: HFPI=PI/2.D0
       real(8) :: prbckgrnd_mH2O, RhoWat0g
       real(8) :: airwaterdensityrat
 
@@ -3781,6 +3779,7 @@ C     ----------------------------------------------------------------
       subroutine nws10Init()
       use global, only : ihot, ncice
       use mesh, only : np, slam, sfea
+      use adc_constants, only: twopi
       implicit none
       real(8) :: gdlon
       integer :: j, jj ! loop counters
@@ -3848,6 +3847,7 @@ C
 C***********************************************************************
       subroutine g2rini()
       use mesh, only : np, slam, sfea
+      use adc_constants, only: twopi, hfpi
       implicit none
       integer :: N,I,LON,LONP1,LAT,LATP1
       real(8) :: DLAT,DLON,FLONWORK,COLAT,DDLAT,XLAT,DFLAT,DFLAT1,


### PR DESCRIPTION
# Description

Fixes inconsistency in the variable `omega` which was duplicated in the wind module and the constants module. 

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

Resolves #377 