### PR TITLE
NetCDF Output Updates

### DIFF
--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -57,6 +57,9 @@ C---------------------------------------------------------------------
      &   NPERBC, IPERCONN, IPERPTR 
       use hashtable
       use memory_usage
+      use boundaries, only: ibconnr_bc => ibconnr, barinhtr, barlanhtr,
+     &                      barlancfspr, barincfsbr, barincfspr, pipehtr, 
+     &                      pipediamr, pipecoefr
       implicit none
 
       integer(8) :: nbytes = 0
@@ -293,6 +296,17 @@ C..... DW
       !LBCODE array.
       numLBCodeValues = J
 
+      ! Save off the boundary data into the arrays used for 
+      ! writing into the netCDF files
+      ibconnr_bc  = ibconnr
+      barlanhtr   = bar1
+      barinhtr    = bar1
+      barlancfspr = bar2
+      barincfsbr  = bar2
+      barincfspr  = bar3
+      pipehtr     = bar4
+      pipecoefr   = bar5
+      pipediamr   = bar6
 
 C     jgf45.06 added the following section
 C MEB --------------------------------------------------

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -1202,6 +1202,10 @@ C
       ELSE
          READ(H0MSG,*) H0,NODEDRYMIN,NODEWETRMP,VELMIN
       ENDIF
+      IF(H0<=0.0D0)THEN
+          WRITE(*,'(A)') "ERROR: The value of H0 must be greater than 0.0"
+          CALL EXIT(1)
+      ENDIF
 C
       READ(15,80) SLMSG
       READ(SLMSG,*) SLAM0,SFEA0

--- a/src/boundaries.F
+++ b/src/boundaries.F
@@ -559,7 +559,7 @@ C     ------------------------------------------------------------------
       integer, intent(in) :: nfover
       integer, intent(inout) :: exist_flux
       integer :: i, j, k, nweir
-           
+
       if (nope.ne.0) then
          p_nvdll = nvdll
          p_nbdv = nbdv

--- a/src/mesh.F
+++ b/src/mesh.F
@@ -2925,12 +2925,7 @@ Csb...
 #else
       nfluxib64_gbl = nfluxib64
 #endif
-!sb...
 
-!jjwm001 - end add
-      ! jgf51.11.18: Free memory associated with the reading of the
-      ! levee and culvert parameters since it is no longer needed
-      call freeFluxBoundaryArrayTemporaries()
 !
 !...GENERAL PURPOSE FORMAT STATEMENTS for subtly expressed error messages
 !...

--- a/src/netcdf_error.F90
+++ b/src/netcdf_error.F90
@@ -16,7 +16,7 @@ module netcdf_error
 !-----------------------------------------------------------------------
     subroutine check_err(iret)
       USE SIZES, ONLY : myproc
-      USE GLOBAL, ONLY : screenUnit, ERROR, allMessage, &
+      USE GLOBAL, ONLY : screenUnit, ERROR, DEBUG, allMessage, &
           setMessageSource, unsetMessageSource
 #ifdef CMPI
       USE MESSENGER, ONLY : MSG_FINI

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -84,8 +84,6 @@
          INTEGER :: ibtypenc_id   ! discharge boundary type
          INTEGER :: ibtypeenc_id  ! elevation boundary type
          INTEGER :: nvellnc_id    ! nodes on norm flow spec boundary seg
-         INTEGER :: max_nvdllnc_id ! max num nodes on any elev boundary seg
-         INTEGER :: max_nvellnc_id ! max num nodes on any discharge boundary seg
          INTEGER :: slam0nc_id
          INTEGER :: sfea0nc_id
          INTEGER :: netanc_id
@@ -102,7 +100,6 @@
          INTEGER :: max_nvdllnc_dim_id
          INTEGER :: max_nvellnc_dim_id
          INTEGER :: num_v_nodes_dim_id
-         INTEGER :: mesh_dim_id       ! Mesh Definition (Corbitt)
          !WJP 02.20.2018: for one dimensional boundary
          INTEGER :: nvelnc_dim_id
          INTEGER :: netanc_dim_id
@@ -131,7 +128,6 @@
          INTEGER :: nopenc_dims(1)
          INTEGER :: nbdvnc_dims(2)
          INTEGER :: nbvvnc_dims(2)
-         INTEGER :: mesh_dims(1)       ! Mesh Definition (Corbitt)
          REAL(8), ALLOCATABLE :: xnc(:) ! x coordinate or longitude
          REAL(8), ALLOCATABLE :: ync(:) ! y coordinate or latitude
          !WJP 02.20.2018: changed to one dimensional boundary
@@ -9681,9 +9677,6 @@ C
          iret = nf90_def_dim(ncid, 'max_nvell',
      &          myMesh%max_nvellnc, myMesh%max_nvellnc_dim_id)
       endif
-!Corbitt: Define ADCIRC-Mesh Dimension
-      iret = nf90_def_dim(ncid,'mesh',1,myMesh%mesh_dim_id)
-      call check_err(iret)
 !
 !     Define variables
 !     Define X
@@ -9703,10 +9696,7 @@ C
      &       myMesh%ELE_dims, myMesh%ELE_id)
       CALL check_err(iret)
 !Corbitt: Define ADCIRC-Mesh Variable
-      myMesh%MESH_dims(1) = myMesh%mesh_dim_id
-      iret = nf90_def_var(ncid, 'adcirc_mesh',NF90_INT,
-     &       myMesh%MESH_dims, myMesh%MESH_id)
-      CALL check_err(iret)
+      call check_err(nf90_def_var(ncid,'adcirc_mesh',NF90_INT,myMesh%MESH_id))
       !
       ! jgf50.44: Turn on compression if this is a netcdf4-formatted file.
 #ifdef NETCDF_CAN_DEFLATE
@@ -9722,15 +9712,9 @@ C
 !
 !     Define elevation specified boundary forcing segments information
       if (myMesh%nopenc.ne.0) then
-         iret = nf90_def_var(ncid,'neta', NF90_INT,
-     &       varid=myMesh%netanc_id)
-         CALL check_err(iret)
          myMesh%nvdllnc_dims(1) = myMesh%nopenc_dim_id
          iret = nf90_def_var(ncid, 'nvdll',NF90_INT,
      &                  myMesh%nvdllnc_dims, myMesh%nvdllnc_id)
-         CALL check_err(iret)
-         iret = nf90_def_var(ncid, 'max_nvdll',NF90_INT,
-     &                  varid=myMesh%max_nvdllnc_id)
          CALL check_err(iret)
          myMesh%ibtypeenc_dims(1) = myMesh%nopenc_dim_id
          iret = nf90_def_var(ncid, 'ibtypee',NF90_INT,
@@ -9739,9 +9723,6 @@ C
          CALL check_err(iret)
 !        WJP to make arrays smaller only have dimension of neta
          myMesh%nbdvnc_dims(1) = myMesh%netanc_dim_id
-C         myMesh%nbdvnc_dims(1) = myMesh%nopenc_dim_id
-C         myMesh%nbdvnc_dims(2) = myMesh%netanc_dim_id
-C         myMesh%nbdvnc_dims(2) = myMesh%max_nvdllnc_dim_id
          iret = nf90_def_var(ncid, 'nbdv',NF90_INT,
      &          myMesh%nbdvnc_dims(1), myMesh%nbdvnc_id)
          CALL check_err(iret)
@@ -9762,15 +9743,9 @@ C         myMesh%nbdvnc_dims(2) = myMesh%max_nvdllnc_dim_id
       endif
 !     Define normal flow boundary information
       if (myMesh%nbounc.ne.0) then
-         iret = nf90_def_var(ncid,'nvel', NF90_INT,
-     &      varid=myMesh%nvelnc_id)
-         CALL check_err(iret)
          myMesh%nvellnc_dims(1) = myMesh%nbounc_dim_id
          iret = nf90_def_var(ncid, 'nvell',NF90_INT,
      &          myMesh%nvellnc_dims, myMesh%nvellnc_id)
-         CALL check_err(iret)
-         iret = nf90_def_var(ncid, 'max_nvell',NF90_INT,
-     &                  varid=myMesh%max_nvellnc_id)
          CALL check_err(iret)
          myMesh%ibtypenc_dims(1) = myMesh%nbounc_dim_id
          iret = nf90_def_var(ncid, 'ibtype',NF90_INT,
@@ -9778,9 +9753,6 @@ C         myMesh%nbdvnc_dims(2) = myMesh%max_nvdllnc_dim_id
          CALL check_err(iret)
 !        WJP to make arrays smaller only have dimension of nvel
          myMesh%nbvvnc_dims(1) = myMesh%nvelnc_dim_id
-C         myMesh%nbvvnc_dims(1) = myMesh%nbounc_dim_id
-C         myMesh%nbvvnc_dims(2) = myMesh%nvelnc_dim_id
-C         myMesh%nbvvnc_dims(2) = myMesh%max_nvellnc_dim_id
          iret = nf90_def_var(ncid, 'nbvv',NF90_INT,
      &          myMesh%nbvvnc_dims(1), myMesh%nbvvnc_id)
          CALL check_err(iret)
@@ -9863,14 +9835,6 @@ C         CALL check_err(iret)
 C         iret = nf90_put_att(ncid, myMesh%nopenc_id, 'units', 14,
 C     &                     'nondimensional')
 C         CALL check_err(iret)
-C        NETA
-         att_text = "total number of elevation specified boundary nodes"
-         iret = nf90_put_att(ncid, myMesh%netanc_id, 'long_name',
-     &          trim(att_text))
-         CALL check_err(iret)
-         iret = nf90_put_att(ncid, myMesh%netanc_id, 'units',
-     &   'nondimensional')
-         CALL check_err(iret)
 C        NVDLL
          att_text = "number of nodes in each elevation specified "
      &   //"boundary segment"
@@ -9908,16 +9872,6 @@ C         CALL check_err(iret)
 C         iret = nf90_put_att(ncid, myMesh%nbounc_id, 'units', 14,
 C     &                      'nondimensional')
 C         CALL check_err(iret)
-C        NVEL
-         att_text = "total number of normal flow specified boundary "
-     &      //"nodes including both the front and back nodes on "
-     &      //"internal barrier boundaries"
-         iret = nf90_put_att(ncid, myMesh%nvelnc_id, 'long_name',
-     &          trim(att_text))
-         CALL check_err(iret)
-         iret = nf90_put_att(ncid, myMesh%nvelnc_id, 'units',
-     &   'nondimensional')
-         CALL check_err(iret)
 C        IBTYPE
          att_text = "type of normal flow (discharge) boundary"
          iret = nf90_put_att(ncid, myMesh%ibtypenc_id, 'long_name',
@@ -10099,12 +10053,7 @@ C
 
 !     Store elevation boundary information
       if(myMesh%nopenc.ne.0) then
-         iret = nf90_put_var(ncid, myMesh%netanc_id, myMesh%netanc)
-         CALL check_err(iret)
          iret = nf90_put_var(ncid, myMesh%nvdllnc_id, myMesh%nvdllnc)
-         CALL check_err(iret)
-         iret = nf90_put_var(ncid, myMesh%max_nvdllnc_id,
-     &          myMesh%max_nvdllnc)
          CALL check_err(iret)
          iret = nf90_put_var(ncid,myMesh%ibtypeenc_id,
      &          myMesh%ibtypeenc)
@@ -10114,14 +10063,9 @@ C
       endif
 !     Store normal flow boundary information
       if(myMesh%nbounc.ne.0) then
-         iret = nf90_put_var(ncid, myMesh%nvelnc_id, myMesh%nvelnc)
-         CALL check_err(iret)
          iret = nf90_put_var(ncid,myMesh%ibtypenc_id, myMesh%ibtypenc)
          CALL check_err(iret)
          iret = nf90_put_var(ncid, myMesh%nvellnc_id, myMesh%nvellnc)
-         CALL check_err(iret)
-         iret = nf90_put_var(ncid, myMesh%max_nvellnc_id,
-     &          myMesh%max_nvellnc)
          CALL check_err(iret)
          iret = nf90_put_var(ncid, myMesh%nbvvnc_id, myMesh%nbvvnc)
          CALL check_err(iret)

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -80,6 +80,13 @@
          INTEGER :: ELE_id        ! elements in grid
          INTEGER :: nbdvnc_id       ! nodes on elev spec boundary seg
          INTEGER :: nbvvnc_id       ! nodes on normal flow boundary seg
+         INTEGER :: ibconn_id       ! connected internal boundary node
+         INTEGER :: barht_id        ! barrier height
+         INTEGER :: barsp_id        ! barrier supercritical flow coef
+         INTEGER :: barsb_id        ! barrier subcritical flow coef
+         INTEGER :: pipeht_id       ! barrier pipe height id
+         INTEGER :: pipecoef_id     ! barrier pipe coefficient id
+         INTEGER :: pipediam_id     ! barrier pipe diameter id
          INTEGER :: nvdllnc_id      ! num nodes on elev boundary seg
          INTEGER :: ibtypenc_id   ! discharge boundary type
          INTEGER :: ibtypeenc_id  ! elevation boundary type
@@ -132,6 +139,7 @@
          REAL(8), ALLOCATABLE :: ync(:) ! y coordinate or latitude
          !WJP 02.20.2018: changed to one dimensional boundary
          INTEGER, ALLOCATABLE ::  nbvvnc(:) ! boundary array
+         INTEGER, ALLOCATABLE ::  ibconnnc(:) ! boundary array
          INTEGER, ALLOCATABLE ::  nbdvnc(:) ! boundary array
          INTEGER, ALLOCATABLE ::  nvellnc(:)  ! boundary array
          INTEGER, ALLOCATABLE ::  nvdllnc(:)  ! boundary array
@@ -139,6 +147,12 @@
          INTEGER, ALLOCATABLE ::  ibtypeenc(:)
          INTEGER, ALLOCATABLE ::  nmnc(:,:)
          INTEGER, ALLOCATABLE ::  element(:,:)
+         REAL(8), ALLOCATABLE ::  barht(:)
+         REAL(8), ALLOCATABLE ::  barsp(:)
+         REAL(8), ALLOCATABLE ::  barsb(:)
+         REAL(8), ALLOCATABLE ::  pipeht(:)
+         REAL(8), ALLOCATABLE ::  pipediam(:)
+         REAL(8), ALLOCATABLE ::  pipecoef(:)
          INTEGER :: netanc
          INTEGER :: nvelnc
          !WJP 02.20.2018: added fort.53-54 harmonic outputs
@@ -4086,7 +4100,8 @@ C-----------------------------------------------------------------------
       USE MESH, ONLY : X, Y, SLAM, SFEA, ICS, NM,
      &  SLAM0, SFEA0
       USE BOUNDARIES, ONLY : NBOU, NVEL, NOPE, NBVV, NVDLL, NBDV, NVELL,
-     &  NETA, IBTYPEE, IBTYPE
+     &  NETA, IBTYPEE, IBTYPE, IBCONNR, barlanhtr, barinhtr, barincfspr, 
+     &  barlancfspr, barincfsbr, pipehtr, pipecoefr, pipediamr 
       IMPLICIT NONE
       type(meshStructure), intent(inout) :: myMesh
       INTEGER :: i, j, k, kj  ! array indices
@@ -4112,11 +4127,15 @@ C
       ALLOCATE(myMesh%nvellnc(myMesh%nbounc))
 !     WJP to make nbdvnc arrays smaller:
       ALLOCATE(myMesh%nbdvnc(myMesh%netanc)) !(myMesh%nopenc,myMesh%max_nvdllnc))
-C      ALLOCATE(myMesh%nbdvnc(myMesh%nopenc,myMesh%netanc))
-!     WJP to make nbvvnc arrays smaller
       ALLOCATE(myMesh%nbvvnc(myMesh%nvelnc)) !(myMesh%nbounc,myMesh%max_nvellnc))
-C      ALLOCATE(myMesh%nbvvnc(myMesh%nbounc,myMesh%nvelnc))
       ALLOCATE(myMesh%element(myMesh%nface_len,NE_G))
+      ALLOCATE(myMesh%ibconnnc(myMesh%nvelnc)) !(myMesh%nbounc,myMesh%max_nvellnc))
+      ALLOCATE(myMesh%barht(myMesh%nvelnc))
+      ALLOCATE(myMesh%barsp(myMesh%nvelnc))
+      ALLOCATE(myMesh%barsb(myMesh%nvelnc))
+      ALLOCATE(myMesh%pipecoef(myMesh%nvelnc))
+      ALLOCATE(myMesh%pipediam(myMesh%nvelnc))
+      ALLOCATE(myMesh%pipeht(myMesh%nvelnc))
       ALLOCATE(myMesh%nmnc(NE_G,myMesh%nface_len))
 C
 C     Store nodal coordinates
@@ -4147,22 +4166,42 @@ C     Store nodal coordinates
 C
       myMesh%nvellnc = 0
       myMesh%nbvvnc = 0
+      myMesh%ibconnnc = 0
+      myMesh%barht = -99999d0
+      myMesh%barsp = -99999d0
+      myMesh%barsb = -99999d0
+      myMesh%pipeht = -99999d0
+      myMesh%pipecoef = -99999d0
+      myMesh%pipediam = -99999d0
       kj = 0 !WJP initializing linear index
       DO k=1,myMesh%nbounc
          myMesh%nvellnc(k) = nvell(k)
          myMesh%ibtypenc(k) = ibtype(k)
          DO J=1,myMesh%nvellnc(k)
-            ! WJP counting the linear index
             kj = kj + 1
             myMesh%nbvvnc(kj) = nbvv(k,j)
-            !myMesh%nbvvnc(k,j)=nbvv(k,j)
+            if(ibtype(k).eq.3.or.ibtype(k).eq.13.or.ibtype(k).eq.23)then
+                myMesh%barht(kj) = barlanhtr(k,j)
+                myMesh%barsp(kj) = barlancfspr(k,j)
+            elseif(ibtype(k).eq.4.or.ibtype(k).eq.24)then
+                myMesh%ibconnnc(kj) = ibconnr(k,j)
+                myMesh%barht(kj) = barinhtr(k,j)
+                myMesh%barsp(kj) = barincfspr(k,j)
+                myMesh%barsb(kj) = barincfsbr(k,j)
+            elseif(ibtype(k).eq.5.or.ibtype(k).eq.25)then
+                myMesh%ibconnnc(kj) = ibconnr(k,j)
+                myMesh%barht(kj) = barinhtr(k,j)
+                myMesh%barsp(kj) = barincfspr(k,j)
+                myMesh%barsb(kj) = barincfsbr(k,j)
+                myMesh%pipeht(kj) = pipehtr(k,j)
+                myMesh%pipecoef(kj) = pipecoefr(k,j)
+                myMesh%pipediam(kj) = pipediamr(k,j)
+            endif
          END DO
       END DO
 !
       myMesh%nmnc=NM
 !     Switch order in array for NETCDF
-C       write(*,*)  myMesh%num_elems
-C       write(*,*)  myMesh%nface_len
       do i=1, NE_G
          do j=1, myMesh%nface_len
             myMesh%element(j,i) = myMesh%nmnc(i,j)
@@ -9759,6 +9798,28 @@ C
          iret = nf90_def_var(ncid, 'nbvv',NF90_INT,
      &          myMesh%nbvvnc_dims(1), myMesh%nbvvnc_id)
          CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'ibconn', NF90_INT, 
+     &          myMesh%nbvvnc_dims(1), myMesh%ibconn_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'barht', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%barht_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'barsp', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%barsp_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'barsb', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%barsb_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'pipeht', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%pipeht_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'pipediam', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%pipediam_id)
+         CALL check_err(iret)
+         iret = nf90_def_var(ncid, 'pipecoef', NF90_DOUBLE,
+     &          myMesh%nbvvnc_dims(1), myMesh%pipecoef_id)
+         CALL check_err(iret)
+
          !jgf50.44: Turn on compression if this is a netcdf4 formatted file.
 #ifdef NETCDF_CAN_DEFLATE
          IF (myFile%ncformat.eq.ior(NF90_CLASSIC_MODEL,NF90_NETCDF4)) THEN
@@ -9769,6 +9830,27 @@ C
      &             1, 1, 2)
             CALL check_err(iret)
             iret = nf90_def_var_deflate(ncid, myMesh%nbvvnc_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%ibconn_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%barht_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%barsb_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%barsp_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%pipeht_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%pipediam_id,
+     &             1, 1, 2)
+            CALL check_err(iret)
+            iret = nf90_def_var_deflate(ncid, myMesh%pipecoef_id,
      &             1, 1, 2)
             CALL check_err(iret)
          ENDIF
@@ -9866,16 +9948,7 @@ C        NBDV
          CALL check_err(iret)
       endif
       if (myMesh%nbounc.ne.0) then
-C        NBOU
-C         att_text = "number of normal flow (discharge) specified &
-C     &boundary segments"
-C         iret = nf90_put_att(ncid, myMesh%nbounc_id, 'long_name',
-C     &          len_trim(att_text), trim(att_text))
-C         CALL check_err(iret)
-C         iret = nf90_put_att(ncid, myMesh%nbounc_id, 'units', 14,
-C     &                      'nondimensional')
-C         CALL check_err(iret)
-C        IBTYPE
+!        IBTYPE
          att_text = "type of normal flow (discharge) boundary"
          iret = nf90_put_att(ncid, myMesh%ibtypenc_id, 'long_name',
      &       trim(att_text))
@@ -9883,7 +9956,7 @@ C        IBTYPE
          iret = nf90_put_att(ncid, myMesh%ibtypenc_id, 'units',
      &   'nondimensional')
          CALL check_err(iret)
-C        NVELL
+!        NVELL
          att_text = 'number of nodes in each normal flow '
      &      //'specified boundary segment'
          iret = nf90_put_att(ncid, myMesh%nvellnc_id, 'long_name',
@@ -9892,7 +9965,7 @@ C        NVELL
          iret = nf90_put_att(ncid, myMesh%nvellnc_id, 'units',
      &                      'nondimensional')
          CALL check_err(iret)
-C        NBVV
+!        NBVV
          att_text = "node numbers on normal flow boundary segment"
          iret = nf90_put_att(ncid, myMesh%nbvvnc_id, 'long_name',
      &          trim(att_text))
@@ -9900,6 +9973,61 @@ C        NBVV
          iret = nf90_put_att(ncid, myMesh%nbvvnc_id, 'units',
      &                      'nondimensional')
          CALL check_err(iret)
+!        IBCONN
+         att_text = "internal barrier nodal connections"
+         iret = nf90_put_att(ncid, myMesh%ibconn_id, 'long_name',
+     &          trim(att_text))
+         call check_err(iret)
+         iret = nf90_put_att(ncid, mymesh%ibconn_id, 'units',
+     &                      'nondimensional')
+         call check_err(iret)
+!        BARHT
+         att_text = 
+     &      "external/internal barrier boundary height above geoid"
+         iret = nf90_put_att(ncid, myMesh%barht_id, 'long_name',
+     &          trim(att_text))
+         iret = nf90_put_att(ncid, myMesh%barht_id, 'units', 'm')
+         call check_err(iret)
+!        BARSP
+         att_text = "external/internal barrier boundary"//
+     &              " weir coefficient of supercritical flow"
+         iret = nf90_put_att(ncid, myMesh%barsp_id, "long_name",
+     &          trim(att_text))
+         call check_err(iret)
+         iret = nf90_put_att(ncid, mymesh%barsp_id, 'units',
+     &                      'nondimensional')
+         call check_err(iret)
+!        BARSB
+         att_text = "internal barrier boundary"//
+     &              " weir coefficient of subcritical flow"
+         iret = nf90_put_att(ncid, myMesh%barsb_id, "long_name",
+     &          trim(att_text))
+         call check_err(iret)
+         iret = nf90_put_att(ncid, mymesh%barsb_id, 'units',
+     &                      'nondimensional')
+         call check_err(iret)
+!        PIPEHT
+         att_text = 
+     &      "internal barrier boundary cross-barrier pipe height"
+         iret = nf90_put_att(ncid, myMesh%pipeht_id, "long_name",
+     &      trim(att_text))
+         iret = nf90_put_att(ncid, myMesh%pipeht_id, 'units', 'm')
+         call check_err(iret)
+!        PIPEDIAM
+         att_text = 
+     &      "internal barrier boundary cross-barrier pipe diameter"
+         iret = nf90_put_att(ncid, myMesh%pipediam_id, "long_name",
+     &      trim(att_text))
+         iret = nf90_put_att(ncid, myMesh%pipediam_id, 'units', 'm')
+         call check_err(iret)
+!        PIPECOEF
+         att_text = 
+     &      "internal barrier boundary cross-barrier pipe coefficient"
+         iret = nf90_put_att(ncid, myMesh%pipecoef_id, "long_name",
+     &      trim(att_text))
+         iret = nf90_put_att(ncid, mymesh%pipecoef_id, 'units',
+     &                      'nondimensional')
+         call check_err(iret)
       endif
 !Corbitt: Define ADCIRC-Mesh Attributes
          iret = nf90_put_att(ncid, myMesh%mesh_id, 'long_name',
@@ -10071,6 +10199,20 @@ C
          iret = nf90_put_var(ncid, myMesh%nvellnc_id, myMesh%nvellnc)
          CALL check_err(iret)
          iret = nf90_put_var(ncid, myMesh%nbvvnc_id, myMesh%nbvvnc)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%ibconn_id, myMesh%ibconnnc)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%barht_id, myMesh%barht)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%barsb_id, myMesh%barsb)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%barsp_id, myMesh%barsp)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%pipeht_id, myMesh%pipeht)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%pipediam_id, myMesh%pipediam)
+         CALL check_err(iret)
+         iret = nf90_put_var(ncid, myMesh%pipecoef_id, myMesh%pipecoef)
          CALL check_err(iret)
       endif
 
@@ -10871,6 +11013,7 @@ C
          DEALLOCATE(adcircMesh%nvellnc)
          DEALLOCATE(adcircMesh%nbdvnc)
          DEALLOCATE(adcircMesh%nbvvnc)
+         DEALLOCATE(adcircMesh%ibconnnc)
          DEALLOCATE(adcircMesh%element)
          DEALLOCATE(adcircMesh%nmnc)
          adcircMesh%initialized = .false.

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -8815,7 +8815,7 @@ C
      &     len=mesh_struct%num_nodes)
       CALL check_err(iret)
 C
-      iret=nf90_inq_dimid(ncid, "nele", mesh_struct%num_elems_dim_id)
+      iret=nf90_inq_dimid(ncid, "nfaces", mesh_struct%num_elems_dim_id)
       CALL check_err(iret)
       iret=nf90_inquire_dimension(ncid, mesh_struct%num_elems_dim_id,
      &     len=mesh_struct%num_elems)
@@ -9629,6 +9629,7 @@ C-----------------------------------------------------------------------
       character big_ben*10
       character zone*5
       integer values(8)
+      integer dmy
 C
       call setMessageSource("defineMeshVariables")
 #if defined(NETCDF_TRACE) || defined(ALL_TRACE)
@@ -9639,7 +9640,9 @@ C
       iret = nf90_def_dim(ncid,'node',myMesh%num_nodes,
      &       myMesh%num_nodes_dim_id)
       CALL check_err(iret)
-      iret = nf90_def_dim(ncid,'nele',myMesh%num_elems,
+      iret = nf90_def_dim(ncid,'nele',myMesh%num_elems,dmy)
+      call check_err(iret)
+      iret = nf90_def_dim(ncid,'nfaces',myMesh%num_elems,
      &       myMesh%num_elems_dim_id)
       call check_err(iret)
       IF (C3D.eqv..true.) THEN
@@ -10482,7 +10485,7 @@ C-----------------------------------------------------------------------
         CALL CHECK_ERR(nf90_get_att(NCID,NF90_GLOBAL,'cf',cf))
         CALL CHECK_ERR(nf90_get_att(NCID,NF90_GLOBAL,'eslm',eslm))
         CALL CHECK_ERR(nf90_inq_dimid(NCID,"node",dimid_node))
-        CALL CHECK_ERR(nf90_inq_dimid(NCID,"nele",dimid_nele))
+        CALL CHECK_ERR(nf90_inq_dimid(NCID,"nfaces",dimid_nele))
         CALL CHECK_ERR(nf90_inquire_dimension(ncid,dimid_node,len=NP_G))
         CALL CHECK_ERR(nf90_inquire_dimension(ncid,dimid_nele,len=NE_G))
         CALL CHECK_ERR(nf90_close(NCID))

--- a/src/write_output.F
+++ b/src/write_output.F
@@ -34,6 +34,7 @@ C----------------------------------------------------------------------
       USE GLOBAL, ONLY : OutputDataDescript_t, setMessageSource,
      &  unsetMessageSource, DEBUG, allMessage, screenMessage, ERROR,
      &  netcdf_avail
+      USE boundaries, only: freeFluxBoundaryArrayTemporaries
 
       !
       !    2 D   D A T A
@@ -1726,9 +1727,10 @@ C                      ! initialize it if it wasn't initialized above
             endif
          enddo
       endif ! ihot.ne.0
-      !
-      ! End  TCM v51.20.01 Mods for MaxMin Files to Local Variables
-      !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+
+      ! Initialization is complete, this information is
+      ! no longer needed
+      call freeFluxBoundaryArrayTemporaries()
 
 #if defined(WRITE_OUTPUT_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")


### PR DESCRIPTION
# Description

Updates to the netCDF output files so that they pass UGRID compliance checkers. Additionally, removing variables which were written as both variables and dimensions as this caused errors in packages like `xarray`. With these updates, ADCIRC output files now open cleanly in `xarray`. Lastly, embedding the boundary information (connected nodes, height, pipe parameters, weir coefficients) into the output file so the mesh is fully described in the output data. 

## Type of change

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

Resolves #184, #6, #54

Seems to address some of the questions raised by @tgasher in #174, though not fully

# How Has This Been Tested?

The ADCIRC test suite was run against these changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`