### PR TITLE
Main nws14 read option

### DIFF
--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -301,7 +301,7 @@ Casey 180318: Added NWS=13
 
       ! DW 2024
       LOGICAL :: found_NWS14Grib2NetCdf_Namelist = .false. 
-      NAMELIST /WindGrib2NetCdf/ read_NWS14_using_core_0
+      NAMELIST /WindGrib2NetCdf/ read_NWS14_NetCdf_using_core_0
 
       logical :: foundWetDryControlNamelist = .false. ! for namelist 
       logical :: outputNodeCode = .false.

--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -299,6 +299,10 @@ Casey 180318: Added NWS=13
       LOGICAL :: FOUND_OWINC_NML
 #endif
 
+      ! DW 2024
+      LOGICAL :: found_NWS14Grib2NetCdf_Namelist = .false. 
+      NAMELIST /WindGrib2NetCdf/ read_NWS14_using_core_0
+
       logical :: foundWetDryControlNamelist = .false. ! for namelist 
       logical :: outputNodeCode = .false.
       logical :: outputNOFF = .false.

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2315,6 +2315,14 @@ Casey 180318: Added NWS=13
          endif
 #endif
 
+#ifdef DATETIME
+         IF ( found_NWS14Grib2NetCdf_namelist ) THEN
+             write(15,'(a,L3,a)') "&WindGrib2NetCdf"//
+     &          " read_NWS14_NetCdf_using_core_0 = ", read_NWS14_NetCdf_using_core_0, "/"
+
+         END IF
+#endif 
+
          ! NCSU Subdomain Modeling
          if (FOUND_SM_NML) then
          WRITE(15,*) "&subdomainModeling subdomainOn=",subdomainOn," /"

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -125,7 +125,7 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
 #endif
       USE WIND, ONLY :  WindDragLimit,DragLawString,rhoAir,
      &                  initWindModule, 
-     &                  read_NWS14_using_core_0
+     &                  read_NWS14_NetCdf_using_core_0
       USE OWIWIND, ONLY: nPowellSearchDomains
 #ifdef ADCNETCDF
 Casey 180318: Added NWS=13

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -124,7 +124,8 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
      &    SWAN_OutputTMM10
 #endif
       USE WIND, ONLY :  WindDragLimit,DragLawString,rhoAir,
-     &                  initWindModule
+     &                  initWindModule, 
+     &                  read_NWS14_using_core_0
       USE OWIWIND, ONLY: nPowellSearchDomains
 #ifdef ADCNETCDF
 Casey 180318: Added NWS=13

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -545,6 +545,9 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
 Casey 180318: Added NWS=13
       INTEGER :: IOS_OWINC
 #endif
+      ! DW
+      INTEGER :: IOS_NWS14Grib2NC
+
 C...tcm v51.20.03 Local variables for external station location files
       INTEGER :: NSTAE2,NSTAV2,NSTAC2,NSTAM2
       INTEGER :: IOS_STATIONS
@@ -685,6 +688,20 @@ Casey 180318: Added NWS=13
      &         'The owiWindNetcdf namelist was not found.')
       ENDIF
       REWIND(15)
+#endif
+
+#ifdef DATETIME
+      READ(UNIT=15,NML=WindGrib2NetCdf,IOSTAT=IOS_NWS14Grib2NC)
+      IF(IOS_NWS14Grib2NC .EQ. 0)THEN
+         found_NWS14Grib2NetCdf_Namelist= .TRUE.
+         call logMessage(INFO,
+     &         'The WindGrid2NetCdf namelist was found.')
+      else
+         call logMessage(INFO,
+     &         'The WindGrib2NetCdf namelist was not found.')
+      ENDIF
+      REWIND(15)
+
 #endif
 
       READ(UNIT = 15, NML = wetDryControl,IOSTAT = ios_wetDry)

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -125,7 +125,8 @@ C-----------------------------------------------------------------------
      &   dynamicWaterLevelCorrectionRampEnd,
      &   dynamicWaterLevelCorrectionSkipSnaps,
      &   dynamicWaterLevelCorrectionRampReferenceTime,
-     &   dynamicWaterLevelCorrectionMultiplier
+     &   dynamicWaterLevelCorrectionMultiplier,
+     &   read_NWS14_using_core_0
       USE OWIWIND,ONLY: nPowellSearchDomains
       USE WETDRY, ONLY : noffActive, velmin
       USE ITPACKV
@@ -226,6 +227,8 @@ C.... DMW
 #endif
 !JLW: adding subgrid namelist
       NAMELIST /subgridControl/ subgridFilename, level0, level1
+
+      NAMELIST /WindGrib2NetCdf/ read_NWS14_using_core_0
 
       CHARACTER(len=160) :: origLine     ! raw line of input from fort.15
       CHARACTER(len=200) :: modifiedLine ! converted to namelist
@@ -448,6 +451,18 @@ Casey 180318: Added NWS=13
      & " NWS13ColdStartString=",trim(adjustl(NWS13ColdStartString)),
      & " NWS13WindMultiplier=",trim(adjustl(NWS13WindMultiplier)),
      & " NWS13GroupForPowell=",trim(adjustl(NWS13GroupForPowell))
+      call logMessage(ECHO,trim(scratchMessage))
+      rewind(15)
+#endif
+
+
+#ifdef DATETIME
+      namelistSpecifier = 'WindGrib2NetCdf' 
+      read( unit = 15, nml=WindGrib2NetCdf,iostat=ios ) ;
+      call logNamelistReadStatus(namelistSpecifier, ios)
+      write(scratchMessage,*) "NWS 14: use core 0"//
+     &   "to read grib2/netcdf data = ",
+     &   read_NWS14_using_core_0 
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 #endif

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -126,7 +126,7 @@ C-----------------------------------------------------------------------
      &   dynamicWaterLevelCorrectionSkipSnaps,
      &   dynamicWaterLevelCorrectionRampReferenceTime,
      &   dynamicWaterLevelCorrectionMultiplier,
-     &   read_NWS14_using_core_0
+     &   read_NWS14_NetCdf_using_core_0
       USE OWIWIND,ONLY: nPowellSearchDomains
       USE WETDRY, ONLY : noffActive, velmin
       USE ITPACKV
@@ -228,7 +228,7 @@ C.... DMW
 !JLW: adding subgrid namelist
       NAMELIST /subgridControl/ subgridFilename, level0, level1
 
-      NAMELIST /WindGrib2NetCdf/ read_NWS14_using_core_0
+      NAMELIST /WindGrib2NetCdf/ read_NWS14_NetCdf_using_core_0
 
       CHARACTER(len=160) :: origLine     ! raw line of input from fort.15
       CHARACTER(len=200) :: modifiedLine ! converted to namelist
@@ -462,7 +462,7 @@ Casey 180318: Added NWS=13
       call logNamelistReadStatus(namelistSpecifier, ios)
       write(scratchMessage,*) "NWS 14: use core 0"//
      &   "to read grib2/netcdf data = ",
-     &   read_NWS14_using_core_0 
+     &   read_NWS14_NetCdf_using_core_0 
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 #endif

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -101,7 +101,9 @@ C
       USE GLOBAL_IO, ONLY : nddt2get
       USE HARM, ONLY : updateHarmonicAnalysis
       USE WIND, ONLY : getMeteorologicalForcing, PRBCKGRND_MH2O, rsget,
-     &    getdynamicWaterLevelCorrections
+     &    getdynamicWaterLevelCorrections, 
+     &    CLOSE_MET_FILES 
+
       USE ADCIRC_MOD, ONLY : ADCIRC_Terminate
 C.... TCM V49.64.01 ADDITIONS FOR ICE
       USE OWI_ICE,ONLY : NCICE1_INIT,NCICE1_GET
@@ -1518,6 +1520,11 @@ c. RJW merged 08/26/2008 Casey 071219: Added the folowing call to the mass balan
 C      IF(C3DVS)THEN
 C         CALL MASSBAL3D(IT)
 C      ENDIF
+
+      IF ( IT == NT ) THEN
+        ! close NWS14 NetCdf files !
+        CALL CLOSE_MET_FILES() ; 
+      END IF        
 
 #if defined(TIMESTEP_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")

--- a/src/wind.F
+++ b/src/wind.F
@@ -9749,7 +9749,7 @@ C---------------------------------------------------------------------
 #ifdef DATETIME        
 #ifdef ADCNETCDF
         IF ( NWS == 14 ) THEN
-          IF ( read_NWS14_NetCdf_using_core_0 )  THEN   
+          IF ( (.not. grb2flag) .AND. read_NWS14_NetCdf_using_core_0 )  THEN   
              IF ( MYPROC == 0 ) THEN     
                call Check_err(NF90_CLOSE(PfileNCID))
                call Check_err(NF90_CLOSE(WfileNCID))

--- a/src/wind.F
+++ b/src/wind.F
@@ -271,7 +271,7 @@ C
       integer :: NT, NTC
 #endif
 
-      logical:: read_NWS14_using_core_0 = .true. ! read NWS14 (grib2,netcdf) from a computed core 0
+      logical:: read_NWS14_NetCdf_using_core_0 = .true. ! read NWS14 (grib2,netcdf) from a computed core 0
  
       real(8) :: wtime1_12 ! time associated with previous met dataset
       real(8) :: wtime2_12 ! time associated with new met dataset
@@ -8948,7 +8948,7 @@ C----------------------------------------------------------------------
 
 
 #ifdef ADCNETCDF ! BEGIN ADCNETCDF
-         IF ( read_NWS14_using_core_0 ) THEN
+         IF ( read_NWS14_NetCdf_using_core_0 ) THEN
            IF ( MYPROC .EQ. 0 ) THEN
              call Check_err(NF90_OPEN(Pfile,nf90_nowrite,PfileNCID))
              call Check_err(NF90_OPEN(Wfile,nf90_nowrite,WfileNCID))
@@ -9425,7 +9425,7 @@ C----------------------------------------------------------------------
       CALL setMessageSource('READNWS14_netCDF')
 
 #ifdef ADCNETCDF
-      IF ( read_NWS14_using_core_0 ) THEN
+      IF ( read_NWS14_NetCdf_using_core_0 ) THEN
         ! Use core zero to read data
         ! and then broadcast them 
         IF (MYPROC.EQ.0) THEN
@@ -9571,7 +9571,7 @@ C----------------------------------------------------------------------
 #ifdef ADCNETCDF
       IF (MYPROC.EQ.0) THEN
               
-         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+         IF ( .NOT. read_NWS14_NetCdf_using_core_0 ) THEN
            call Check_err(NF90_OPEN(FileN,nf90_nowrite,ncid))  
          END IF      
                 
@@ -9605,7 +9605,7 @@ C----------------------------------------------------------------------
             enddo
          endif
 
-         IF ( .NOT. read_NWS14_using_core_0 ) THEN 
+         IF ( .NOT. read_NWS14_NetCdf_using_core_0 ) THEN 
            call Check_err(NF90_CLOSE(ncid))  
          END IF
 
@@ -9652,7 +9652,7 @@ C----------------------------------------------------------------------
       IF (MYPROC.EQ.0) THEN
 #endif
 
-         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+         IF ( .NOT. read_NWS14_NetCdf_using_core_0 ) THEN
             call Check_err(NF90_OPEN(FileN,nf90_nowrite,NC_ID))  
          END IF     
 
@@ -9706,7 +9706,7 @@ C----------------------------------------------------------------------
          endif
          NTC = NT
 
-         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+         IF ( .NOT. read_NWS14_NetCdf_using_core_0 ) THEN
             call Check_err(NF90_CLOSE(NC_ID))  
          END IF
 
@@ -9766,7 +9766,7 @@ C---------------------------------------------------------------------
 #ifdef DATATIME        
 #ifdef ADCNETCDF
         IF ( NWS == 14 ) THEN
-          IF ( read_NWS14_using_core_0 )  THEN   
+          IF ( read_NWS14_NetCdf_using_core_0 )  THEN   
              IF ( MYPROC == 0 ) THEN     
                call Check_err(NF90_CLOSE(PfileNCID))
                call Check_err(NF90_CLOSE(WfileNCID))

--- a/src/wind.F
+++ b/src/wind.F
@@ -8928,24 +8928,6 @@ C----------------------------------------------------------------------
          Uvar = 'dmy'
          Vvar = 'dmy'
          Cvar = 'dmy'
-!#ifdef ADCNETCDF ! BEG ADCNETCDF
-!
-!#ifdef CMPI
-!         IF (MYPROC.EQ.0) THEN
-!#endif
-!            call Check_err(NF90_OPEN(Pfile,nf90_nowrite,PfileNCID))
-!            call Check_err(NF90_OPEN(Wfile,nf90_nowrite,WfileNCID))
-!            call Check_err(NF90_OPEN(Wfile1,nf90_nowrite,Wfile1NCID))
-!            IF (NCICE.EQ.14) THEN
-!               call Check_err(NF90_OPEN(Cfile,nf90_nowrite,CfileNCID))
-!            ENDIF
-!#ifdef CMPI
-!         ENDIF
-!         ! wait til proc 0 has opened all the files
-!         CALL MSG_BARRIER()
-!#endif
-!#endif
-
 
 #ifdef ADCNETCDF ! BEGIN ADCNETCDF
          IF ( read_NWS14_NetCdf_using_core_0 ) THEN
@@ -9763,7 +9745,7 @@ C---------------------------------------------------------------------
 
         IMPLICIT NONE
 
-#ifdef DATATIME        
+#ifdef DATETIME        
 #ifdef ADCNETCDF
         IF ( NWS == 14 ) THEN
           IF ( read_NWS14_NetCdf_using_core_0 )  THEN   

--- a/src/wind.F
+++ b/src/wind.F
@@ -9741,6 +9741,7 @@ C---------------------------------------------------------------------
     
 #ifdef ADCNETCDF
         use netcdf
+        use netcdf_error, only: check_err
 #endif
 
         IMPLICIT NONE

--- a/src/wind.F
+++ b/src/wind.F
@@ -270,6 +270,9 @@ C
       logical :: grb2flag
       integer :: NT, NTC
 #endif
+
+      logical:: read_NWS14_using_core_0 = .true. ! read NWS14 (grib2,netcdf) from a computed core 0
+ 
       real(8) :: wtime1_12 ! time associated with previous met dataset
       real(8) :: wtime2_12 ! time associated with new met dataset
       real(8) :: wtiminc_12 ! time increment between met datasets (seconds)
@@ -8925,22 +8928,43 @@ C----------------------------------------------------------------------
          Uvar = 'dmy'
          Vvar = 'dmy'
          Cvar = 'dmy'
-#ifdef ADCNETCDF
+!#ifdef ADCNETCDF ! BEG ADCNETCDF
+!
+!#ifdef CMPI
+!         IF (MYPROC.EQ.0) THEN
+!#endif
+!            call Check_err(NF90_OPEN(Pfile,nf90_nowrite,PfileNCID))
+!            call Check_err(NF90_OPEN(Wfile,nf90_nowrite,WfileNCID))
+!            call Check_err(NF90_OPEN(Wfile1,nf90_nowrite,Wfile1NCID))
+!            IF (NCICE.EQ.14) THEN
+!               call Check_err(NF90_OPEN(Cfile,nf90_nowrite,CfileNCID))
+!            ENDIF
+!#ifdef CMPI
+!         ENDIF
+!         ! wait til proc 0 has opened all the files
+!         CALL MSG_BARRIER()
+!#endif
+!#endif
+
+
+#ifdef ADCNETCDF ! BEGIN ADCNETCDF
+         IF ( read_NWS14_using_core_0 ) THEN
+           IF ( MYPROC .EQ. 0 ) THEN
+             call Check_err(NF90_OPEN(Pfile,nf90_nowrite,PfileNCID))
+             call Check_err(NF90_OPEN(Wfile,nf90_nowrite,WfileNCID))
+             call Check_err(NF90_OPEN(Wfile1,nf90_nowrite,Wfile1NCID))
+             IF (NCICE.EQ.14) THEN
+                call Check_err(NF90_OPEN(Cfile,nf90_nowrite,CfileNCID))
+             ENDIF
+           END IF
 #ifdef CMPI
-         IF (MYPROC.EQ.0) THEN
-#endif
-            call Check_err(NF90_OPEN(Pfile,nf90_nowrite,PfileNCID))
-            call Check_err(NF90_OPEN(Wfile,nf90_nowrite,WfileNCID))
-            call Check_err(NF90_OPEN(Wfile1,nf90_nowrite,Wfile1NCID))
-            IF (NCICE.EQ.14) THEN
-               call Check_err(NF90_OPEN(Cfile,nf90_nowrite,CfileNCID))
-            ENDIF
-#ifdef CMPI
-         ENDIF
          ! wait til proc 0 has opened all the files
-         CALL MSG_BARRIER()
+           CALL MSG_BARRIER()
 #endif
-#endif
+         END IF
+
+#endif ! END ADCNETCDF
+
          RETURN
       ELSE
          ! should be unreachable
@@ -9307,9 +9331,9 @@ C----------------------------------------------------------------------
       CHARACTER(LEN=200),INTENT(IN) :: fileN
       REAL,ALLOCATABLE,INTENT(OUT) :: data2(:,:)
       CHARACTER(LEN=200),INTENT(IN) :: invN, var
-      INTEGER,INTENT(IN) :: ncid
+      INTEGER,INTENT(INOUT) :: ncid
       IF (.NOT.grb2flag) THEN
-         CALL READNWS14_netCDF(ncid, var, data2)
+         CALL READNWS14_netCDF(fileN, ncid, var, data2)
       ELSEIF (grb2flag) THEN
          CALL READNWS14_grib2(fileN, invN, var, data2)
       ELSE
@@ -9378,7 +9402,7 @@ C----------------------------------------------------------------------
       END SUBROUTINE READNWS14_grib2
 C----------------------------------------------------------------------
 C----------------------------------------------------------------------
-      SUBROUTINE READNWS14_netCDF(NC_ID,var,data2)
+      SUBROUTINE READNWS14_netCDF(fileN, NC_ID,var,data2)
 C----------------------------------------------------------------------
 C       CPB 10/2023: Reads in netCDF format met forcing for NWS = 14.
 C       NOTE: reads in on Proc 0 and broadcasts.
@@ -9391,27 +9415,50 @@ C----------------------------------------------------------------------
      &                           BcastToLocal_Int
       USE SIZES, ONLY : MYPROC
       implicit none
+
+      character(len=*),intent(in):: fileN
       character(len=200),intent(in) :: var
       real,allocatable,intent(out) :: data2(:,:) 
-      INTEGER,INTENT(IN) :: NC_ID
+      INTEGER,INTENT(INOUT) :: NC_ID
       integer :: i, Temp_ID, Lat_ID, Lon_ID, NX, NY
+
       CALL setMessageSource('READNWS14_netCDF')
+
 #ifdef ADCNETCDF
-      IF (MYPROC.EQ.0) THEN
-         call Check_err(NF90_INQ_DIMID(NC_ID,Latdim,Temp_ID))
-         call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NY))
-         call Check_err(NF90_INQ_DIMID(NC_ID,Londim,Temp_ID))
-         call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NX))
-      ENDIF
-      CALL BcastToLocal_Int(NX)
-      CALL BcastToLocal_Int(NY)
-      allocate(data2(NX,NY))
-      IF (MYPROC.EQ.0) THEN
-         call Check_err(NF90_INQ_VARID(NC_ID,var,Temp_ID))
-         call Check_err(NF90_GET_VAR(NC_ID,Temp_ID,data2,
+      IF ( read_NWS14_using_core_0 ) THEN
+        ! Use core zero to read data
+        ! and then broadcast them 
+        IF (MYPROC.EQ.0) THEN
+           call Check_err(NF90_INQ_DIMID(NC_ID,Latdim,Temp_ID))
+           call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NY))
+           call Check_err(NF90_INQ_DIMID(NC_ID,Londim,Temp_ID))
+           call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NX))
+        ENDIF        
+        CALL BcastToLocal_Int(NX)
+        CALL BcastToLocal_Int(NY)
+        allocate(data2(NX,NY))
+        IF (MYPROC.EQ.0) THEN
+           call Check_err(NF90_INQ_VARID(NC_ID,var,Temp_ID))
+           call Check_err(NF90_GET_VAR(NC_ID,Temp_ID,data2,
      &                  start=[1, 1, NT],count=[NX, NY, 1]))
+        ENDIF
+        CALL BCastToLocal_2DRealArray(Data2,NX,NY)
+      ELSE 
+        ! Each core read data
+        call Check_err(NF90_OPEN(fileN,nf90_nowrite,NC_ID)) 
+        call Check_err(NF90_INQ_DIMID(NC_ID,Latdim,Temp_ID))
+        call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NY))
+        call Check_err(NF90_INQ_DIMID(NC_ID,Londim,Temp_ID))
+        call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,len=NX))
+
+        allocate(data2(NX,NY))
+        call Check_err(NF90_INQ_VARID(NC_ID,var,Temp_ID))
+        call Check_err(NF90_GET_VAR(NC_ID,Temp_ID,data2,
+     &                  start=[1, 1, NT],count=[NX, NY, 1]))
+
+        call Check_err(NF90_CLOSE(NC_ID))
       ENDIF
-      CALL BCastToLocal_2DRealArray(Data2,NX,NY)
+
 #endif
       CALL unsetMessageSource()
       RETURN
@@ -9429,7 +9476,7 @@ C----------------------------------------------------------------------
       CHARACTER(len=200),INTENT(IN) :: fileN
       REAL,ALLOCATABLE,INTENT(OUT) :: lat(:,:),lon(:,:)
       CHARACTER(LEN=200),INTENT(IN),OPTIONAL :: var, invN
-      INTEGER,INTENT(IN),OPTIONAL :: ncid
+      INTEGER,INTENT(INOUT),OPTIONAL :: ncid
       IF (grb2flag) THEN
          CALL READNWS14LatLon_grib2(fileN,invN,var,lat,lon)
       ELSEIF (.NOT.grb2flag) THEN
@@ -9516,13 +9563,18 @@ C----------------------------------------------------------------------
      &                           BcastToLocal_Int
       USE SIZES, ONLY : MYPROC
       implicit none
-      INTEGER,INTENT(IN) :: ncid ! already opened ncid tag
+      INTEGER,INTENT(INOUT) :: ncid ! already opened ncid tag
       character(len=200),intent(in) :: fileN
       real,allocatable,intent(out) :: lat(:,:), lon(:,:)
       integer :: i, Temp_ID, Lat_ID, Lon_ID, NX, NY, ndims
       CALL setMessageSource("READNWS14LatLon_netCDF")
 #ifdef ADCNETCDF
       IF (MYPROC.EQ.0) THEN
+              
+         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+           call Check_err(NF90_OPEN(FileN,nf90_nowrite,ncid))  
+         END IF      
+                
          call Check_err(NF90_INQ_DIMID(ncid,Latdim,Temp_ID))
          call Check_err(NF90_INQUIRE_DIMENSION(ncid,Temp_ID,
      &                                         len=NY))
@@ -9552,6 +9604,11 @@ C----------------------------------------------------------------------
                lon(:,i) = lon(:,1)
             enddo
          endif
+
+         IF ( .NOT. read_NWS14_using_core_0 ) THEN 
+           call Check_err(NF90_CLOSE(ncid))  
+         END IF
+
       ENDIF
       CALL BcastToLocal_Int(NX)
       CALL BcastToLocal_Int(NY)
@@ -9582,7 +9639,7 @@ C----------------------------------------------------------------------
       USE NETCDF_ERROR, ONLY: CHECK_ERR
       implicit none
       integer :: iret, iter
-      INTEGER,INTENT(IN) :: NC_ID
+      INTEGER,INTENT(INOUT) :: NC_ID
       character(len=200),intent(in) :: fileN
       character(len=19),allocatable :: TimeStr(:) 
       character(len=200) :: str_date
@@ -9594,6 +9651,11 @@ C----------------------------------------------------------------------
 #ifdef CMPI
       IF (MYPROC.EQ.0) THEN
 #endif
+
+         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+            call Check_err(NF90_OPEN(FileN,nf90_nowrite,NC_ID))  
+         END IF     
+
          call Check_err(NF90_INQ_DIMID(NC_ID,Tdim,Temp_ID))
          call Check_err(NF90_INQUIRE_DIMENSION(NC_ID,Temp_ID,
      &                                         len=TL))
@@ -9643,6 +9705,11 @@ C----------------------------------------------------------------------
             NT = 1 
          endif
          NTC = NT
+
+         IF ( .NOT. read_NWS14_using_core_0 ) THEN
+            call Check_err(NF90_CLOSE(NC_ID))  
+         END IF
+
 #ifdef CMPI
       endif
       CALL BcastToLocal_Int(NT)
@@ -9684,6 +9751,41 @@ C-----------------------------------------------------------------------
 
 C.....END WJP (NWS = 14) ..............................................
 #endif
+
+C--------------------------------------------------------------------- 
+      SUBROUTINE CLOSE_MET_FILES()
+        use global, only: NWS, NCICE
+        USE SIZES, ONLY : MYPROC
+    
+#ifdef ADCNETCDF
+        use netcdf
+#endif
+
+        IMPLICIT NONE
+
+#ifdef DATATIME        
+#ifdef ADCNETCDF
+        IF ( NWS == 14 ) THEN
+          IF ( read_NWS14_using_core_0 )  THEN   
+             IF ( MYPROC == 0 ) THEN     
+               call Check_err(NF90_CLOSE(PfileNCID))
+               call Check_err(NF90_CLOSE(WfileNCID))
+               call Check_err(NF90_CLOSE(Wfile1NCID))
+
+               IF (NCICE.EQ.14) THEN
+                  call Check_err(NF90_CLOSE(CfileNCID))
+               ENDIF
+             ENDIF
+          END IF 
+        END IF
+#endif
+#endif        
+
+        RETURN ;
+      END SUBROUTINE CLOSE_MET_FILES        
+C---------------------------------------------------------------------
+
+
 
 C-----------------------------------------------------------------------
 C     S U B R O U T I N E   W I N D L I M I T E R 


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resurrect an approach reading NetCdf nws14 met files using all compute core to simultaneously read in data. This option is activated through specifying a namelist:
    
&WindGrib2NetCdf read_NWS14_NetCdf_using_core_0 = .false.

in fort.15. If this namelist is omitted or set to .true., a core 0 will read in met data and MPI broadcasts to all other compute cores. 

Faster runtime using this approach seen in some HPC systems is a primary reason to bring it back (as an option).   



## Type of change

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

The changes were tested on a few small test problems (Shinnecock, small global runs).

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->