### PR TITLE
Fix for compilation error in src/subgridLookup.F when TRACE is on.

### DIFF
--- a/src/subgridLookup.F
+++ b/src/subgridLookup.F
@@ -491,7 +491,7 @@
 #ifdef CMPI
       USE MESSENGER
 #endif
-      USE GLOBAL, ONLY: INFO,allMessage,
+      USE GLOBAL, ONLY: INFO,DEBUG,allMessage,
      &                  setMessageSource,unsetMessageSource
       IMPLICIT NONE
       LOGICAL, OPTIONAL :: NO_MPI_FINALIZE


### PR DESCRIPTION
# Description

A fix for a compilation error. Variable "DEBUG" is not imported while it is used when either MESH_TRACE or ALL_TRACE is on. 

## Type of change

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->