### PR TITLE
Fixing access to arrays out of bounds that casues segmentation fault …

### DIFF
--- a/src/gwce.F
+++ b/src/gwce.F
@@ -1641,7 +1641,8 @@ ckmd  Need to save z(s-1) and etas(s-1) for the corrector loop
          Eta1(I)=Eta2(I)
 C........DMW202401 Add update for flow depth at previous timestep, H1
          IF ((I.EQ.1).AND.(IT.EQ.ITIME_BGN)) THEN
-            WRITE(16,*) 'dmw202401 THIS CODE IS NOW MAKING ITS FIRST SAVE ON H1'
+            WRITE(16,*) 
+     &         'dmw202401 THIS CODE IS NOW MAKING ITS FIRST SAVE ON H1'
          ENDIF
          H1(I) = H2(I)
          Eta2(I)=0.0d0
@@ -1954,6 +1955,7 @@ C.... CONDENSED NODES: Summing up the values at condensed nodes
       IF((LoadCondensedNodes).AND.(ILump.NE.0)) THEN
          DO K=1,NListCondensedNodes
             I = ListCondensedNodes(K,1)
+            IF(I==0) CYCLE
             IF((NODECODE(I).NE.0)) THEN
                ! 1) Sum them up
                DO L=2,NNodesListCondensedNodes(K)

--- a/src/momentum.F
+++ b/src/momentum.F
@@ -1051,6 +1051,7 @@ C.... CONDENSED NODES: Summing up the values at condensed nodes
       IF((LoadCondensedNodes).AND.(ILump.NE.0)) THEN
          DO K=1,NListCondensedNodes
             I = ListCondensedNodes(K,1)
+            IF(I==0) CYCLE
             IF((NODECODE(I).NE.0)) THEN
                ! 1) Mutiply LHS & RHS by total area at Node I
                IF ((flgNodesMultipliedByTotalArea(I).eq.0).and.

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -2203,7 +2203,8 @@ C     ----------------------------------------------------------------
       WetPerimWidth = 0.D0
       WetPerimBankElev = 0.D0
 
-      write(scratchMessage,'(a)') 'Initializing channel wet perimeter variables:'
+      write(scratchMessage,'(a)') 
+     &   'Initializing channel wet perimeter variables:'
       call logMessage(ECHO,trim(scratchMessage))
 
       DO ICN=1,NListCondensedNodes
@@ -2220,22 +2221,24 @@ C     ----------------------------------------------------------------
          
          ! Bank elevation
          !- I1
+         BE1 = 99999.D0
          IBND = LBArray_Pointer(I1)
-         IF(LBCODEI(IBND).EQ.64) THEN
-            NNBB1=NBV(IBND)
-            NNBB2=IBCONN(IBND)
-            BE1 = -MIN(DP(NNBB1),DP(NNBB2))
-         ELSE
-            BE1 = 99999.D0
+         IF(IBND >= 1) THEN
+            IF(LBCODEI(IBND).EQ.64) THEN
+               NNBB1=NBV(IBND)
+               NNBB2=IBCONN(IBND)
+               BE1 = -MIN(DP(NNBB1),DP(NNBB2))
+            ENDIF
          ENDIF
          !- I2
+         BE2 = 99999.D0
          IBND = LBArray_Pointer(I2)
-         IF(LBCODEI(IBND).EQ.64) THEN
-            NNBB1=NBV(IBND)
-            NNBB2=IBCONN(IBND)
-            BE2 = -MIN(DP(NNBB1),DP(NNBB2))
-         ELSE
-            BE2 = 99999.D0
+         IF(IBND >= 1) THEN
+            IF(LBCODEI(IBND).EQ.64) THEN
+               NNBB1=NBV(IBND)
+               NNBB2=IBCONN(IBND)
+               BE2 = -MIN(DP(NNBB1),DP(NNBB2))
+            ENDIF
          ENDIF
 
          ! Store the values
@@ -2245,7 +2248,8 @@ C     ----------------------------------------------------------------
          WetPerimBankElev(I2) = BE2
 
          write(scratchMessage,'(a,I10,a,I10,a,F10.3,a,F10.3,a,F10.3)')
-     &      'I1=',I1,', I2=',I2,', WIDTH=',WIDTH,', BankElev1=',BE1,', BankElev2=',BE2
+     &      'I1=',I1,', I2=',I2,', WIDTH=',WIDTH,', 
+     &      BankElev1=',BE1,', BankElev2=',BE2
          call logMessage(ECHO,trim(scratchMessage))
             
       ENDDO
@@ -3126,6 +3130,8 @@ C     ----------------------------------------------------------------
       SUBROUTINE PrepCondensedNodes()
 C     ----------------------------------------------------------------
       USE SIZES,ONLY : MNVEL
+      USE GLOBAL, ONLY : setMessageSource, unsetMessageSource, allMessage,
+     &   DEBUG, ECHO, INFO, WARNING, ERROR  
       USE MESH,ONLY : NP,LBArray_Pointer,X,Y
       USE BOUNDARIES,ONLY : CSIICN,SIIICN
       IMPLICIT NONE
@@ -3133,6 +3139,11 @@ C     ----------------------------------------------------------------
       INTEGER :: JMAX
       REAL(8) :: X1,Y1,X2,Y2,DX,DY,LEN
       LOGICAL :: ON_THE_SAME_BOUNDARY
+
+      call setMessageSource("prepcondensednodes")
+#if defined(NODALATTR_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Enter.")
+#endif
 
       IF (.NOT.LoadCondensedNodes) RETURN
 
@@ -3153,7 +3164,9 @@ C     ----------------------------------------------------------------
       ALLOCATE(NNodesListCondensedNodes(NListCondensedNodes))
 
       NCondensedNodes(:) = 0
-
+      ListCondensedNodes(:,:) = 0
+      NNodesListCondensedNodes(:) = 0
+      
       K = 0
       DO I=1,NP
          IF(CondensedNodes(I,1).GT.0) THEN
@@ -3207,6 +3220,10 @@ C     ----------------------------------------------------------------
          END IF
       END DO
 
+#if defined(NODALATTR_TRACE) || defined(ALL_TRACE)
+      call allMessage(DEBUG,"Return.") ! should be unreachable
+#endif
+      call unsetMessageSource()
       END SUBROUTINE PrepCondensedNodes
 C     ----------------------------------------------------------------
 

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -4052,7 +4052,8 @@ C...  RECORDING STATIONS
          ELSE         
             WRITE(16,3207) NSTAC
             IF (NSTAC.NE.0) THEN
-               WRITE(16,*) "CONC. STATION LOCATIONS WILL BE READ FROM FORT.15"
+               WRITE(16,*) 
+     &            "CONC. STATION LOCATIONS WILL BE READ FROM FORT.15"
             ENDIF
          ENDIF
  3207    FORMAT(///,5X,'NUMBER OF INPUT CONCENTRATION RECORDING ',
@@ -4825,7 +4826,7 @@ C...  SB
 C     Preparation of condensed nodes  SB
       call PrepCondensedNodes()
       
-C     Recompute a & b coefficients            
+C     Recompute a & b coefficients
       CALL RecomputeFDXEFDYEAtCondensedNodes()
       
 C...  SB END

--- a/src/vew1d.F
+++ b/src/vew1d.F
@@ -382,7 +382,7 @@ C
             EXIT
          END IF
       END DO
-      
+
       END FUNCTION CondensedNodePairFound
 
       FUNCTION FIND_IB2(N1,N2,N3)

--- a/src/wetdry.F
+++ b/src/wetdry.F
@@ -1267,6 +1267,7 @@ C.....
       IF(LoadCondensedNodes) THEN
          DO K=1,NListCondensedNodes
             I = ListCondensedNodes(K,1)
+            IF(I==0) CYCLE
             ! 0) DEFAULT VALUE
             NNC = NNODECODE(I)
             ! 1) FIND UPDATED VALUE 


### PR DESCRIPTION
…when nodal attribute condensed_nodes is loaded in parallel run

# Description

A bug fix for accessing arrays out of bounds that causes segmentation fault occasionally when condensed_nodes is loaded in parallel run.

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->