### PR TITLE
NetCDF boundary bug, VEW/Condensed Nodes Conditional Bug

### DIFF
--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -302,11 +302,11 @@ C..... DW
       ! writing into the netCDF files
       if(meshHasExternalWeir)then
         barlanhtr   = bar1
+        barlancfspr = bar2
       endif
       if(meshHasInternalWeir)then
         ibconnr_bc  = ibconnr
         barinhtr    = bar1
-        barlancfspr = bar2
         barincfsbr  = bar2
         barincfspr  = bar3
         if(meshHasWeirWithPipes)then

--- a/src/gwce.F
+++ b/src/gwce.F
@@ -3232,7 +3232,9 @@ C.... end WP
             ! If the limiter is on already, go to the next node. 
             IF (elemental_slope_limiter_active(NM(IE,I))) CYCLE
             ! If this is one of the condensed nodes, go to the next node. 10/12/2023 sb
-            IF (LoadCondensedNodes .AND. NCondensedNodes(NM(IE,I)) > 0) CYCLE
+            IF (LoadCondensedNodes) THEN
+                IF (NCondensedNodes(NM(IE,I)) > 0) CYCLE
+            ENDIF
             ! Compare the elemental slope to the maximum elemental gradient.
             grad_check: IF (dEta2Mag.GE.
      &           ABS(elemental_slope_limiter_grad_max(NM(IE,I)))) THEN

--- a/src/netcdfio.F
+++ b/src/netcdfio.F
@@ -10000,21 +10000,21 @@ C
             iret = nf90_def_var_deflate(ncid, myMesh%ibtypenc_id,
      &             1, 1, 2)
             CALL check_err(iret)
-            iret = nf90_def_var_deflate(ncid, myMesh%nbvvnc_id,
-     &             1, 1, 2)
-            CALL check_err(iret)
             if(myMesh%hasWeirs)then
                 iret = nf90_def_var_deflate(ncid, myMesh%barht_id,
      &                 1, 1, 2)
                 CALL check_err(iret)
-                iret = nf90_def_var_deflate(ncid, myMesh%barsb_id,
+                iret = nf90_def_var_deflate(ncid, myMesh%nbvvnc_id,
+     &                 1, 1, 2)
+                CALL check_err(iret)
+                iret = nf90_def_var_deflate(ncid, myMesh%barsp_id,
      &                 1, 1, 2)
                 CALL check_err(iret)
                 if(myMesh%hasInternalWeirs)then
                     iret = nf90_def_var_deflate(ncid, myMesh%ibconn_id,
      &                     1, 1, 2)
                     CALL check_err(iret)
-                    iret = nf90_def_var_deflate(ncid, myMesh%barsp_id,
+                    iret = nf90_def_var_deflate(ncid, myMesh%barsb_id,
      &                     1, 1, 2)
                     CALL check_err(iret)
                     if(myMesh%hasPipes)then

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -298,7 +298,7 @@ C     The following attribute contains BK(I),BALPHA(I),BDELX(I), and POAN(I)
       REAL(8), ALLOCATABLE :: ManningsN(:)
 
 C     Variables for bottom friction evaluation along VEW1D channels considering wet perimeter of rectangular cross-section 11/06/2023 sb
-      LOGICAL :: ActivateVEW1DChannelWetPerimeter
+      LOGICAL :: ActivateVEW1DChannelWetPerimeter = .FALSE.
       REAL(8), ALLOCATABLE :: WetPerimWidth(:)    ! Widths of the channels
       REAL(8), ALLOCATABLE :: WetPerimBankElev(:) ! Elevations of the channel banks
 
@@ -2337,11 +2337,14 @@ C     Step 0. Convert Manning's N to Cd, if necessary.
                ENDIF
             ELSE
                HT = DP(I)+IFNLFA*ETA2(I)
-               IF (activateVEW1DChannelWetPerimeter .AND.
-     &             WetPerimWidth(I).GT.0.D0) THEN    ! Evaluating wet perimeter factor along VEW1D channels
-                  HCH = DP(I)+IFNLFA*MIN( ETA2(I), WetPerimBankElev(I) ) ! Height from bottom to which ever lower among the water elevation and the bank elevation
-                  WCH = WetPerimWidth(I)
-                  WPFac = (1.D0+2.D0*HCH/WCH)**(2.D0/3.D0) ! Wet perimeter factor
+               IF (activateVEW1DChannelWetPerimeter)THEN
+                  IF(WetPerimWidth(I).GT.0.D0) THEN    ! Evaluating wet perimeter factor along VEW1D channels
+                      HCH = DP(I)+IFNLFA*MIN( ETA2(I), WetPerimBankElev(I) ) ! Height from bottom to which ever lower among the water elevation and the bank elevation
+                      WCH = WetPerimWidth(I)
+                      WPFac = (1.D0+2.D0*HCH/WCH)**(2.D0/3.D0) ! Wet perimeter factor
+                  ELSE
+                      WPFac = 1.D0
+                  ENDIF
                ELSE
                   WPFac = 1.D0
                ENDIF


### PR DESCRIPTION
# Description

Fixing issue where boundary conditions were not allocated correctly during netcdf writes. Fixing issue where VEW/Condensed nodes conditions may be evaluated simultaneously by the compiler leading to a segfault. 

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
