### PR TITLE
Minor v56 bug fixes for subgrid filename initialization and GCC > 14

### DIFF
--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -312,7 +312,7 @@ Casey 180318: Added NWS=13
 
 !JLW: add subgrid namelist control
       logical :: foundSubgridControlNamelist = .false.
-      character(200) :: subgridFilename
+      character(200) :: subgridFilename = 'null'
       logical :: level0 = .true. 
       logical :: level1 = .false.
 

--- a/src/subgridLookup.F
+++ b/src/subgridLookup.F
@@ -38,7 +38,7 @@
 ! JLW: initialize the arrays for use in the subgrid
 ! code
       implicit none
-      CHARACTER(200) :: subgridFilename
+      CHARACTER(200) :: subgridFilename = 'null'
       ! Flag for subgrid corrections to wetting and drying
       LOGICAL :: level0
       ! Flag for subgrid corrections to bottom friction and advection


### PR DESCRIPTION
# Description

This pull request addresses two minor fixes in v56.0.0. 

1. Newer versions of the GCC compiler require additional flags when building old Metis libraries. These have been added to cmake. 
2. The subgrid input filename variable was uninitialized which could print garbage to the subdomain `PEXXXX/fort.15` files

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

#399 
#400 

# How Has This Been Tested?

Tested with GCC 14.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`