### PR TITLE
Fixing bug where writers were shut down twice

### DIFF
--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -422,6 +422,9 @@ Casey 090302: We need the following information to couple to unstructured SWAN.
      &                       PADCSWAN_RUN
 #endif
       USE WRITE_OUTPUT,ONLY: writeOutput2D
+#ifdef CMPI      
+      USE MESSENGER, ONLY: writers_active, hs_writers_active
+#endif      
       IMPLICIT NONE
 C
       INTEGER, OPTIONAL :: NTIME_STP
@@ -445,8 +448,14 @@ C
             call unsetMessageSource()  !tcm 20150924 -- added
             return
          endif
-      elseif ( mnwproc > 0 .and. myproc == 0 ) then
-         call sendLabelInfoToWriters()
+      elseif ( (mnwproc > 0 .or. mnwproh > 0) .and. myproc == 0 ) then
+         if(mnwproc > 0)then
+             call sendLabelInfoToWriters()
+             writers_active = .true.
+         endif
+         if(mnwproh > 0)then
+             hs_writers_active = .true.
+         endif
       endif
 #endif
 

--- a/src/messenger.F
+++ b/src/messenger.F
@@ -73,6 +73,8 @@ C  Message-Passing Array space
       REAL(8),ALLOCATABLE :: SENDBUF(:,:), RECVBUF(:,:)
       !jgf50.82: Create a flag for unrecoverable issue on a subdomain
       LOGICAL :: subdomainFatalError ! true if mpi_abort should be called
+      LOGICAL :: writers_active = .false.
+      LOGICAL :: hs_writers_active = .false.
 
 C
 C
@@ -222,7 +224,7 @@ C
       call allMessage(DEBUG,"Enter.") 
 #endif
 C
-      IF(MNWPROC > 0) THEN
+      IF(MNWPROC > 0.and.writers_active) THEN
         IF(MYPROC.eq.0) THEN
           DO I=1,MNWPROC
             WRITE(16,*)'PROC ',MYPROC,' IS SENDING SIG_TERM TO WRITER ',
@@ -233,7 +235,7 @@ C
         ENDIF
       ENDIF
 
-      IF(MNWPROH > 0) THEN             !st3 100711 for hsfile
+      IF(MNWPROH > 0.and.hs_writers_active) THEN             !st3 100711 for hsfile
         IF(MYPROC.eq.0) THEN
           DO I=1,MNWPROH
             WRITE(16,*)'PROC ',MYPROC,' IS SENDING SIG_TERM TO HSWRITER',

--- a/src/writer.F
+++ b/src/writer.F
@@ -153,7 +153,7 @@ C-----------------------------------------------------------------------
               ENDDO
           ELSEIF(myproc.GT.mnproc-1.and.myproc.LT.mnproc+mnwproc)THEN
               CALL mpi_recv(n,1,mpi_integer,0,0,mpi_comm_adcirc,mpistat,ierr)
-              allocate(labels_g(1:n))
+              if (.not.allocated(labels_g)) allocate(labels_g(1:n))   !tcm 20240804 added test for allocated
               CALL mpi_recv(labels_g,n,mpi_integer,0,0,mpi_comm_adcirc,mpistat,ierr)
           ENDIF
 

--- a/src/writer.F
+++ b/src/writer.F
@@ -977,12 +977,15 @@ C     subroutine is only called by processor 0.
 C-----------------------------------------------------------------------
       subroutine writer_pause()
       use global
-      use messenger, only: tag, comm_writeh
+      use messenger, only: tag, comm_writeh, writers_active
       use mpi
       implicit none
       integer i
       integer ierr
-C
+
+      if(.not.writers_active)return
+      writers_active = .false.
+
       call setMessageSource("writer_pause")
 #if defined(WRITER_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Enter.")
@@ -1082,11 +1085,14 @@ C...  Main loop
 !
       subroutine HSWRITER_PAUSE()
       use global
-      use messenger, only: tag, comm_writeh
+      use messenger, only: tag, comm_writeh,hs_writers_active
       use mpi
       implicit none
       integer i
       integer ierr
+
+      if(.not.hs_writers_active)return
+      hs_writers_active = .false.
 
       DO I=1,MNWPROH
          CALL MPI_SEND( SIG_PAUSE, 1, MPI_INTEGER, MNPROC,


### PR DESCRIPTION
# Description
The writers are first paused at the end of the `ADCIRC_RUN` subroutine, however, they were also sent `sig_term` within `msg_fini`. This caused the MPI to complain/crash in some instances since the writers were shut down twice. Adding a variable that tracks the writer processors being active (and hs writers) so they are only shut down a single time.

This issue was first unearthed for specific versions of `libfabric.so`, though it's unclear why some builds of the MPI libraries tolerate this behavior and others do not. 

@chrismassey - I believe the distinction between `SIG_TERM` and `SIG_PAUSE` is to support CSTORM coupling. Could you take a look to make sure CSTORM is good with this change? 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)