### PR TITLE
Adding method for explicitly computing Earth/Sun/Moon positions for tide potential calculations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,8 @@ workflows:
                         - adcirc_subgrid-serial
                         - adcirc_subgrid-parallel
                         - adcirc_swan_apes_irene-parallel
+                        - adcirc_global-tide-2d-full-tip-JPL-emphemerides-parallel
+                        - adcirc_global-tide-2d-full-tip-analytical-serial
       - test_grib2:
             requires: 
                 - test_suite_data
@@ -317,4 +319,6 @@ workflows:
                         - adcirc_baroclinic_2d_serial
                         - adcirc_baroclinic_2d_parallel
                         - adcirc_baroclinic_internaltide_2d
+                        - adcirc_global-tide-2d-full-tip-JPL-emphemerides-serial
+                        - adcirc_global-tide-2d-full-tip-analytical-parallel
 

--- a/cmake/adcirc.cmake
+++ b/cmake/adcirc.cmake
@@ -52,9 +52,15 @@ if(BUILD_ADCIRC)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/driver.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/sponge_layer.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/quadrature.F
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2loc_mapping.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/astronomic.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/moon.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun_moon_system.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/ephemerides.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/tidalpotential.F90
       ${CMAKE_CURRENT_SOURCE_DIR}/src/subgridLookup.F)
 
   if(NETCDF_WORKING)

--- a/cmake/adcswan.cmake
+++ b/cmake/adcswan.cmake
@@ -127,6 +127,12 @@ if(BUILD_ADCSWAN AND PERL_FOUND)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2loc_mapping.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/astronomic.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/ephemerides.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/tidalpotential.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/moon.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun_moon_system.F90
       ${CMAKE_CURRENT_SOURCE_DIR}/src/subgridLookup.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F)
 

--- a/cmake/libadcirc.cmake
+++ b/cmake/libadcirc.cmake
@@ -54,6 +54,12 @@ set(LIBADC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F
     ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2loc_mapping.F
     ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/astronomic.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ephemerides.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tidalpotential.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sun.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/moon.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sun_moon_system.F90
     ${CMAKE_CURRENT_SOURCE_DIR}/src/subgridLookup.F
     ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F)
 

--- a/cmake/metis.cmake
+++ b/cmake/metis.cmake
@@ -81,7 +81,8 @@ if(${C_COMPILER_NAME} MATCHES "gcc.*"
   # For GCC >= 10, we need to add -Wno-implicit-function-declaration and -Wno-incompatible-pointer-types
   if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER 10 OR ${CMAKE_C_COMPILER_VERSION} VERSION_EQUAL 10)
     set(ADDITIONAL_METIS_COMPILER_FLAGS
-        "${ADDITIONAL_METIS_COMPILER_FLAGS} -Wno-implicit-function-declaration -Wno-incompatible-pointer-types")
+        "${ADDITIONAL_METIS_COMPILER_FLAGS} -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-shift-op-parentheses -Wno-format-security"
+    )
     message(STATUS "Adding additional compiler flags to metis: ${ADDITIONAL_METIS_COMPILER_FLAGS}")
     set_target_properties(metis PROPERTIES COMPILE_FLAGS ${ADDITIONAL_METIS_COMPILER_FLAGS})
   endif()

--- a/cmake/padcirc.cmake
+++ b/cmake/padcirc.cmake
@@ -57,6 +57,12 @@ if(BUILD_PADCIRC)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2loc_mapping.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/astronomic.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/ephemerides.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/tidalpotential.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/moon.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun_moon_system.F90
       ${CMAKE_CURRENT_SOURCE_DIR}/src/subgridLookup.F)
 
   if(NETCDF_WORKING)

--- a/cmake/padcswan.cmake
+++ b/cmake/padcswan.cmake
@@ -124,11 +124,17 @@ if(BUILD_PADCSWAN AND PERL_FOUND)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/quadrature.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/couple2baroclinic3D.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2loc_mapping.F
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/subgridLookup.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/wetdry.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/gwce.F
       ${CMAKE_CURRENT_SOURCE_DIR}/src/momentum.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/internaltide.F
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/ephemerides.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/tidalpotential.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/astronomic.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/moon.F90
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/sun_moon_system.F90
       ${CMAKE_CURRENT_SOURCE_DIR}/src/control.F)
 
   set(PADCSWAN_SOURCES

--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -336,6 +336,23 @@ Casey 180318: Added NWS=13
 C     VEW1D channel namelist 11/06/2023 sb
       logical :: foundVEW1DChannelControlNamelist = .false. 
       logical :: activateVEW1DChannelWetPerimeter
+
+C     Full luni-solar tidal potential namelist: 2024
+      logical:: foundTidalPotentialControlNamelist = .false. 
+      LOGICAL:: UseFullTIPFormula = .FALSE. 
+      INTEGER:: TIPOrder = 2
+      CHARACTER (LEN=24):: TIPStartDate = 'Basedate' 
+      CHARACTER (LEN=24):: MoonSunPositionComputeMethod = 'JM' 
+      CHARACTER (LEN=80):: MoonSunCoordFile = 'none'
+      CHARACTER (LEN=24):: TpBaseDate = 'none'
+      LOGICAL:: UniformResMoonSunTimeData = .FALSE.  
+      LOGICAL:: IncludeNutation = .TRUE.  
+      REAL (8):: k2value = 0.302D0 
+      REAL (8):: h2value = 0.609D0    
+      NAMELIST /TidalPotentialControl/ UseFullTIPFormula, TIPOrder,
+     &    TIPStartDate, MoonSunPositionComputeMethod, MoonSunCoordFile,
+     &    IncludeNutation, k2Value, h2Value, UniformResMoonSunTimeData,
+     &    TpBaseDate
       
 C     SOLVER  section
       INTEGER ITITER,ISLDIA,ITMAX

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2319,13 +2319,30 @@ Casey 180318: Added NWS=13
          IF ( found_NWS14Grib2NetCdf_namelist ) THEN
              write(15,'(a,L3,a)') "&WindGrib2NetCdf"//
      &          " read_NWS14_NetCdf_using_core_0 = ", read_NWS14_NetCdf_using_core_0, "/"
-
          END IF
 #endif 
 
+         ! Namelist of input variable for the full luni-Solar tidal potential function 
+         IF ( foundTidalPotentialControlNamelist ) THEN
+             write(15,'(a,L3,a)') "&TidalPotentialControl"//
+     &          " UseFullTIPFormula = ", UseFullTIPFormula, ","
+             write(15,'(a,I5,a)') " TIPORder = ", TIPOrder, ","
+             write(15,'(a)') " TIPStartDate = '"//trim(TIPStartDate)//"',"
+             write(15,'(a)') " MoonSunPositionComputeMethod = '"
+     &                       //trim(MoonSunPositionComputeMethod)//"',"
+             write(15,'(a)') " MoonSunCoordFile = '"
+     &                       //trim(MoonSunCoordFile)//"',"
+             write(15,'(a,L3,a)') " UniformResMoonSunTimeData = ",
+     &        UniformResMoonSunTimeData, "," 
+             write(15,'(a,L3,a)') " IncludeNutation = ", IncludeNutation, ","
+             write(15,'(a,F15.9,a)') " k2Value = ", k2Value, ","
+             write(15,'(a,F15.9,a)') " h2Value = ", h2Value, ","
+             write(15,'(2a)') " TpBaseDate = '"//trim(TpBaseDate)//"' /"
+         END IF
+
          ! NCSU Subdomain Modeling
          if (FOUND_SM_NML) then
-         WRITE(15,*) "&subdomainModeling subdomainOn=",subdomainOn," /"
+           WRITE(15,*) "&subdomainModeling subdomainOn=",subdomainOn," /"
          endif
 
 !JLW: adding subgridcontrol namelist

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -548,6 +548,8 @@ Casey 180318: Added NWS=13
       ! DW
       INTEGER :: IOS_NWS14Grib2NC
 
+      INTEGER :: IOS_TIPNL 
+
 C...tcm v51.20.03 Local variables for external station location files
       INTEGER :: NSTAE2,NSTAV2,NSTAC2,NSTAM2
       INTEGER :: IOS_STATIONS
@@ -702,7 +704,6 @@ Casey 180318: Added NWS=13
      &         'The WindGrib2NetCdf namelist was not found.')
       ENDIF
       REWIND(15)
-
 #endif
 
       READ(UNIT = 15, NML = wetDryControl,IOSTAT = ios_wetDry)
@@ -842,7 +843,18 @@ c..
       endif
       rewind(15)  !Return to the top of the fort.15 file
 
-
+C  DW
+      read(unit=15,nml=TidalPotentialControl,iostat=IOS_TIPNL)
+      IF( IOS_TIPNL .ge. 0 )THEN
+         foundTidalPotentialControlNamelist = .true. 
+         call logMessage(INFO,
+     &         'The Tidalpotentialcontrol namelist was found.')
+      else
+         call logMessage(INFO,
+     &         'The Tidalpotentialcontrol namelist was not found.')
+      ENDIF
+      REWIND(15)
+     
       READ(15,80) RUNDES
 C
       READ(15,80) RUNID

--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -94,6 +94,9 @@ C******************************************************************************
       MODULE ADCIRC_Mod
 C******************************************************************************
 C******************************************************************************
+#ifdef CMPI
+      USE mpi
+#endif
 
       IMPLICIT NONE
       PUBLIC
@@ -153,6 +156,10 @@ C
       INTEGER :: argcount ! number of command line arguments
       CHARACTER(2048) :: cmdlinearg ! a single command line argument
       INTEGER :: i        ! command line argument counter
+
+      !
+      REAL (8):: start_time = 0.D0, end_time = 0.D0
+
       !
       ! jgf51.52.07: Added command line option to just write out
       ! the ADCIRC version number and exit. This is to allow 
@@ -234,6 +241,7 @@ C
          WRITE(ScreenUnit,'(a)')"ADCIRC Commit hash is "//ADC_HASH
       ENDIF
 
+      
       !jgf49.44: Allocate memory for reading and writing full domain arrays
       IF ( (MNPROC.gt.1).and.
      &        ( (myProc.eq.0)
@@ -395,6 +403,8 @@ Corbitt 1203022: Local Advection Flags
 C
  1999 format(1X, a," ADCIRC Version: ",a)
 C
+
+
 #if defined(ADCIRC_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")
 #endif
@@ -430,10 +440,15 @@ C
       INTEGER, OPTIONAL :: NTIME_STP
       REAL(8) :: TimeLoc
 C
+ 
+      REAL(8):: start_time, end_time
+
       call setMessageSource("ADCIRC_Run")
 #if defined(ADCIRC_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Enter.")
 #endif
+
+
 !TCM v49.52.01 added this ifdef (brought in from adcirc_init()
 #ifdef CMPI
       if (((mnwproh > 0).or.(mnwproc > 0)) .and. myproc >= mnproc) then
@@ -498,6 +513,7 @@ C
       IF (MYPROC == 0 .and. MNWPROH > 0) CALL HSWRITER_PAUSE()
 #endif
 
+
 #if defined(ADCIRC_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")
 #endif
@@ -518,16 +534,22 @@ C******************************************************************************
 #ifdef CMPI
       USE MESSENGER, ONLY : msg_fini
 #endif
+      USE SIZES, ONLY : mnproc, mnwproc, mnwproh, myproc
+
       IMPLICIT NONE
 C
       LOGICAL, OPTIONAL :: NO_MPI_FINALIZE
 C
       INTEGER :: I
+
+      REAL (8):: start_time, end_time
 C
       call setMessageSource("ADCIRC_Final")
 #if defined(ADCIRC_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Enter.")
 #endif
+
+
 C
 C...
 C...*************** SOLVE THE HARMONIC ANALYSIS PROBLEM ****************
@@ -535,6 +557,7 @@ C...
       CALL solveHarmonicAnalysis(ITIME)
       CALL writeHarmonicAnalysisOutput(ITIME)
 C
+
 #ifdef CMPI
       IF (PRESENT(NO_MPI_FINALIZE)) THEN
         CALL MSG_FINI(NO_MPI_FINALIZE)
@@ -646,6 +669,8 @@ C-----------------------------------------------------------------------
 
 C******************************************************************************
 C******************************************************************************
+
+
       END MODULE ADCIRC_Mod
 C******************************************************************************
 C******************************************************************************

--- a/src/astronomic.F90
+++ b/src/astronomic.F90
@@ -1,0 +1,449 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+! Ref:
+!   J. MEEUS, Astronomic algorithms, 2nd Edition, 1991
+!
+! Implemented by D. Wirasaet, 2024
+!
+!  NOTE:
+!    T - JDE or JD centuries
+!
+module mod_astronomic
+
+  implicit none
+
+  real(8), parameter :: SEC2DEG = 2.777777777777778d-4, &
+                        MIN2DEG = 0.01666666666666d0
+
+  ! Astronomical unit in km
+  real(8), parameter :: AUDIST = 1.495978707e+8
+  real(8), parameter :: km2AU = 1.d0/AUDIST
+
+  ! Ratio of Sun/Moon mass to Earth mass: Wikipedia !
+  real(8), parameter :: MassRatioSunEarth = 332946.0487
+  real(8), parameter :: MassRatioMoonEarth = 1.d0/81.3005678d0
+
+  ! Keep the value in two saperate numbers: significant and exponent
+  real(8), parameter :: EarthRadiuskm(2) = (/6371.0088d0, 1.0d0/)   ! km
+  real(8), parameter :: EarthRadiusm(2) = (/6.3710088d0, 1.0d+6/)   ! m
+  real(8), parameter :: EarthRadiusAU(2) = (/4.258756338033895d0, 1.0d-5/)  ! in AU
+
+  type t_astronomic_values
+    real(8) :: JD    ! Julain days.
+    real(8) :: T     ! Julian centuries from the Epoch J2000.0
+    real(8) :: LP    ! Moon's mean longtitude, J2000.0 Epoch.
+    real(8) :: D     ! Mean elongation of the Moon, J2000.0 Epoch.
+    real(8) :: M     ! Sun's mean anomaly, J2000.0 Epoch.
+    real(8) :: MP    ! Moon's mean anomaly, J2000 Epoch.
+    real(8) :: F     ! Moon's argument of latitude, J2000 Epoch.
+    real(8) :: OG    ! Longtitude of the ascending node of the moon's mean orbit on the ecliptic.
+    real(8) :: L0    ! Mean longitude of the Sun, refered to the mean equnoix of the date.
+    real(8) :: DPsi  ! The nutation in longitude.
+    real(8) :: vareps0  ! Mean obliquity of the ecliptic.
+    real(8) :: Dvareps  ! The nutation in obliquity.
+    real(8) :: vareps ! the obliquity of the ecliptic.
+    real(8) :: eccen ! the eccentricity of the Earth's orbit
+
+  contains
+    procedure, public, pass(self) :: compute_astronomic_values
+  end type t_astronomic_values
+
+  interface ECLIP2EQ
+    module procedure ECLIP2EQ_S, ECLIP2EQ_V
+  end interface ECLIP2EQ
+
+  private :: ECLIP2EQ_S, ECLIP2EQ_V
+
+contains
+
+  subroutine compute_astronomic_values(self, JD)
+    implicit none
+    class(t_astronomic_values), intent(inout) :: self
+    real(8), intent(in) :: JD
+    real(8) :: T, OG, L0, LP
+
+    self%JD = JD
+
+    T = JULIAN_CENTURIES(JD)
+    self%T = JULIAN_CENTURIES(JD)
+    self%D = modulo(D_DEG(T), 360.d0)
+    self%M = modulo(M_DEG(T), 360.d0)
+    self%MP = modulo(MP_DEG(T), 360.d0)
+    self%F = modulo(F_DEG(T), 360.d0)
+
+    OG = modulo(OMEGA_DEG(T), 360.d0)
+    L0 = modulo(L0_DEG(T), 360.d0)
+    LP = modulo(LP_DEG(T), 360.d0)
+
+    self%LP = LP
+    self%L0 = L0
+    self%OG = OG
+    self%DPsi = DeltaPsiL(OG, L0, LP)
+    self%vareps0 = varepsilon0_ecliptic(T)
+    self%DVareps = DeltaVarepsL(OG, L0, LP)
+    self%vareps = self%vareps0 + self%Dvareps
+    self%eccen = eccentricity_earth_orbit(T)
+
+  end subroutine compute_astronomic_values
+
+  ! Julian day, p. 61
+  real(8) function JULIANDAY(DD, MM, YYYY, CALENDAR_TYPE) result(JD)
+    implicit none
+
+    real(8), intent(IN) :: DD
+    integer :: MM, YYYY
+    character(LEN=*), optional :: CALENDAR_TYPE
+
+    integer :: A, B
+    real(8) :: D, M, Y
+    character(LEN=9) :: CTYPE = 'Gregorian'
+    D = DD
+    M = MM
+    Y = YYYY
+
+    if (present(CALENDAR_TYPE)) then
+      select case (trim(CALENDAR_TYPE))
+      case ('Julian', 'JULIAN', 'julian')
+        CTYPE = 'Julian'
+      end select
+    end if
+
+    if (M <= 2) then
+      Y = Y - 1
+      M = M + 12
+    end if
+
+    A = floor(Y/100.d0)
+    B = 2 - A + floor(A/4.d0)
+    select case (trim(CTYPE))
+    case ('Julian')
+      B = 0
+    end select
+
+    JD = floor(365.25d0*(Y + 4716)) + floor(30.6001d0*(M + 1)) + D + B - 1524.50
+
+  end function JULIANDAY
+
+  ! - Compute Julian centuries from the Epoch J2000.0 (JDE
+  !    2451545)
+  function JULIAN_CENTURIES(JDE) result(T)
+    implicit none
+
+    real(8) :: T
+    real(8), intent(IN) :: JDE
+
+    T = (JDE - 2451545.d0)/36525.d0
+
+  end function JULIAN_CENTURIES
+
+  ! Sidereal time at Greenwich for any JD.                    !
+  ! page. 87                                                  !
+  !  JD     = Julian days                                     !
+  !  DPSi (optional)   = The nutation in longitude (degrees)  !
+  !  vareps (optional) = obliquity of the ecliptic.           !
+  function GMST_DEG(JD, NUTATION, ASVAL) result(gmst)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+
+    real(8) :: gmst
+    real(8), intent(IN) :: JD
+    logical, optional, intent(IN) :: NUTATION
+    type(t_astronomic_values), optional :: ASVAL
+
+    real(8) :: T, JD0, RM
+    logical :: include_nutation = .false.
+
+    ! If nutation is require !
+    real(8) :: LP, L0, OG, DPsi, Dvareps, vareps
+    logical :: have_asval = .false.
+    ! Find JD of the date at UT 0h
+    RM = JD - floor(JD)
+
+    JD0 = JD
+    if (RM < 0.5d0 - 1.0e-10) then
+      JD0 = floor(JD) - 0.5
+    else if (RM > 0.5d0 + 1.0e-10) then
+      JD0 = floor(JD) + 0.5
+    end if
+    RM = JD - JD0
+
+    ! Compute T at UT 0h
+    T = (JD0 - 2451545.0)/36525.d0
+
+    ! \Theta0 EQ. (12.2) page 87
+    gmst = 100.46061837d0 + 36000.770053608*T &
+           + T*T*(0.000387933 - T/38710000.d0)
+
+    ! Mean sidereal time at Greenwich for JD. Page 87
+    gmst = gmst + 1.00273790935d0*RM*360.d0
+
+    if (present(NUTATION)) include_nutation = NUTATION
+
+    if (include_nutation) then
+      if (present(ASVAL)) then
+        if (abs(JD - ASVAL%JD) < 1.0e-9) have_asval = .true.
+      end if
+
+      if (.not. have_asval) then
+        T = JULIAN_CENTURIES(JD)
+        LP = modulo(LP_DEG(T), 360.d0)
+        L0 = modulo(L0_DEG(T), 360.d0)
+
+        OG = modulo(OMEGA_DEG(T), 360.d0)
+        DPsi = DeltaPsiL(OG, L0, LP)
+        vareps = varepsilon0_ecliptic(T) + DeltaVarepsL(OG, L0, LP)
+      else
+        DPsi = ASVAL%DPsi
+        vareps = ASVAL%vareps
+      end if
+
+      gmst = gmst + DPsi*cos(vareps*DEG2RAD)/15.d0
+    end if
+
+!! Eq. 12.4. Yeild slightly differnt results from
+!!           the formula above
+!!          gmst = 280.46061837D0 + 360.98564736629*(JD -
+!!     &       2451545.D0) + T*T*(0.000387933 - T/38710000.D0)
+!!
+    gmst = modulo(gmst, 360.d0)
+
+  end function GMST_DEG
+
+  ! Moon's mean longtitude, J2000.0 Epoch. page 338
+  elemental function LP_DEG(T) result(LP)
+    implicit none
+
+    real(8) :: LP
+    real(8), intent(IN) :: T  ! Julian centuries
+
+    LP = 218.3164477d0 + T*(481267.88123421d0 &
+                            + T*(-0.0015786d0 &
+                                 + T*(1.d0/538841.d0 &
+                                      + T*(-1.d0/65194000.d0))))
+
+  end function LP_DEG
+
+  ! Mean elongation of the Moon, J2000.0 Epoch. page 338
+  elemental function D_DEG(T) result(D)
+    implicit none
+
+    real(8) :: D
+    real(8), intent(IN) :: T
+
+    D = 297.8501921d0 + T*(445267.1114034d0 &
+                           + T*(-0.0018819d0 &
+                                + T*(1.d0/545868.d0 &
+                                     + T*(-1.d0/113065000.d0))))
+
+  end function D_DEG
+
+  ! Sun's mean anomaly, J2000.0 Epoch, page 338
+  elemental function M_DEG(T) result(M)
+    implicit none
+
+    real(8) :: M
+    real(8), intent(IN) :: T
+
+    M = 357.5291092d0 + T*(35999.0502909 &
+                           + T*(-0.0001536d0 &
+                                + T*(1.d0/24490000.d0)))
+  end function M_DEG
+
+  ! Moon's mean anomaly, J2000 Epoch. Page 338
+  elemental function MP_DEG(T) result(MP)
+    implicit none
+
+    real(8) :: MP
+    real(8), intent(IN) :: T
+
+    MP = 134.9633964d0 + T*(477198.8675055d0 &
+                            + T*(0.0087414d0 &
+                                 + T*(1.d0/69699.d0 &
+                                      + T*(-1.d0/14712000.d0))))
+  end function MP_DEG
+
+  ! Moon's argument of latitude, J2000 Epoch. Page 338
+  elemental function F_DEG(T) result(F)
+    implicit none
+
+    real(8) :: F
+    real(8), intent(IN) :: T
+
+    F = 93.2720950d0 + T*(483202.0175233d0 &
+                          + T*(-0.0036539 &
+                               + T*(-1.d0/3526000 &
+                                    + T*(1.d0/863310000.d0))))
+  end function F_DEG
+
+  ! Longtitude of the ascending node of the moon's mean orbit on
+  ! the ecliptic. Page 144
+  real(8) elemental function OMEGA_DEG(T) result(OMEGA)
+    implicit none
+    real(8), intent(IN) :: T
+    OMEGA = 125.04452d0 + T*(-1934.136261d0 &
+                             + T*(0.0020708d0 &
+                                  + T*(1.d0/450000.d0)))
+  end function OMEGA_DEG
+
+  ! Mean longitude of the Sun, refered to the mean equnoix of the
+  ! date. Page 163
+  real(8) elemental function L0_DEG(T) result(L0)
+    implicit none
+    real(8), intent(IN) :: T
+    L0 = 280.46646d0 + T*(36000.76983d0 + T*(0.0003032d0))
+  end function L0_DEG
+
+  ! The eccentricity of the Earth's orbit. Page 163
+  real(8) elemental function eccentricity_earth_orbit(T) result(eps)
+    implicit none
+    real(8), intent(IN) :: T
+    eps = 0.016708634d0 + T*(-0.000042037d0 &
+                             - 0.0000001267*T)
+  end function eccentricity_earth_orbit
+
+  ! The nutation in longitude. p. 144
+  !  -- low accuracy
+  ! \Delta \Psi
+  real(8) elemental function DeltaPsiL(OMEGA, L, LP) result(DPsi)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+    real(8), intent(IN) :: OMEGA, L, LP
+    real(8) :: OG_R, L_R, LP_R
+
+    OG_R = OMEGA*DEG2RAD
+    L_R = L*DEG2RAD
+    LP_R = LP*DEG2RAD
+
+    DPsi = -(17.20d0*sec2deg)*sin(OG_R) &
+           - (1.32d0*sec2deg)*sin(2.d0*L_R) &
+           - (0.23d0*sec2deg)*sin(2.d0*LP_R) &
+           + (0.21d0*sec2deg)*sin(2.d0*OG_R)
+  end function DeltaPsiL
+
+  ! The nutation in obliquity. p. 144
+  !  -- low accuracy
+  ! \Delta \varepsilon
+  real(8) elemental function DeltaVarepsL(OMEGA, L, LP) result(DVareps)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+    real(8), intent(IN) :: OMEGA, L, LP
+    real(8) :: OG_R, L_R, LP_R
+
+    OG_R = OMEGA*DEG2RAD
+    L_R = L*DEG2RAD
+    LP_R = LP*DEG2RAD
+
+    DVareps = (9.20d0*sec2deg)*cos(OG_R) &
+              + (0.57d0*sec2deg)*cos(2.d0*L_R) &
+              + (0.10d0*sec2deg)*cos(2.d0*LP_R) &
+              - (0.09d0*sec2deg)*cos(2.d0*OG_R)
+
+  end function DeltaVarepsL
+
+  ! Mean obliquity of the ecliptic. Eq. 22.3. Page 147
+  real(8) elemental function varepsilon0_ecliptic(T) result(varepsilon0)
+    implicit none
+    real(8), intent(IN) :: T
+    real(8) :: U
+
+    U = 0.01d0*T
+
+    varepsilon0 = 23.d0 + 26.d0*min2deg + 21.448d0*sec2deg
+
+    varepsilon0 = varepsilon0 + U*(-4680.93*sec2deg &
+                                   + U*(-1.55d0 &
+                                        + U*(1999.25d0 &
+                                             + U*(-51.38d0 &
+                                                  + U*(-249.67d0 &
+                                                       + U*(-39.05d00 &
+                                                            + U*(7.12d0 &
+                                                                 + U*(27.87d0 &
+                                                                      + U*(5.79d0 &
+                                                                           + U*(2.45d0))))))))))
+
+  end function varepsilon0_ecliptic
+
+  ! Coordinate transformation                            !
+  !   Transformation from ecliptical into EQ coordinates !
+  subroutine ECLIP2EQ_S(RA, DEC, LAMBDA, BETA, varepsilon)
+    use ADC_CONSTANTS, only: deg2rad, rad2deg
+    implicit none
+
+    real(8), intent(OUT) :: RA, DEC
+    real(8), intent(IN) :: LAMBDA, BETA, varepsilon
+
+    real(8) :: NUM, DEN
+
+    ! Right ascension
+    NUM = sin(LAMBDA*deg2rad)*cos(varepsilon*deg2rad) &
+          - tan(BETA*deg2rad)*sin(varepsilon*deg2rad)
+    DEN = cos(LAMBDA*deg2rad)
+
+    RA = atan2(NUM, DEN)
+
+    ! Declination
+    NUM = sin(BETA*deg2rad)*cos(varepsilon*deg2rad) &
+          + cos(BETA*deg2rad)*sin(varepsilon*deg2rad)*sin(LAMBDA*deg2rad)
+
+    DEC = asin(NUM)
+
+    ! Convert to degree
+    RA = modulo(RA*RAD2DEG, 360.d0)
+    DEC = DEC*RAD2DEG
+
+    return
+  end subroutine ECLIP2EQ_S
+
+  ! Coordinate transformation                            !
+  !   Transformation from ecliptical into EQ coordinates !
+  subroutine ECLIP2EQ_V(RA, DEC, LAMBDA, BETA, varepsilon)
+    use ADC_CONSTANTS, only: deg2rad, rad2deg
+    implicit none
+
+    real(8), dimension(:), intent(OUT) :: RA, DEC
+    real(8), dimension(:), intent(IN) :: LAMBDA, BETA, varepsilon
+
+    integer :: len
+    real(8), dimension(:), allocatable :: NUM, DEN
+
+    len = size(LAMBDA)
+    allocate (NUM(len), DEN(len))
+
+    ! Right ascension
+    NUM = sin(LAMBDA*deg2rad)*cos(varepsilon*deg2rad) &
+          - tan(BETA*deg2rad)*sin(varepsilon*deg2rad)
+    DEN = cos(LAMBDA*deg2rad)
+
+    RA = atan2(NUM, DEN)
+
+    ! Declination
+    NUM = sin(BETA*deg2rad)*cos(varepsilon*deg2rad) &
+          + cos(BETA*deg2rad)*sin(varepsilon*deg2rad)*sin(LAMBDA*deg2rad)
+
+    DEC = asin(NUM)
+
+    ! Convert to degree
+    RA = modulo(RA*RAD2DEG, 360.d0)
+    DEC = DEC*RAD2DEG
+
+    deallocate (NUM, DEN)
+  end subroutine ECLIP2EQ_V
+
+end module mod_astronomic

--- a/src/constants.F
+++ b/src/constants.F
@@ -88,6 +88,9 @@
           REAL(8), PARAMETER :: day2sec = day2hour * hour2sec
           REAL(8), PARAMETER :: sec2day = 1.0D0/day2sec 
 
+          REAL (8), parameter:: hour2min = 60.D0 
+          REAL (8), parameter:: min2hour = 1.D0/hour2min
+          REAL (8), parameter:: min2day = 1.D0*min2hour*hour2day ; 
           !---Conversion Factors---!
           
           !...Wind Reduction Factor

--- a/src/ephemerides.F90
+++ b/src/ephemerides.F90
@@ -1,0 +1,441 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+!
+! By Al Cerrone,
+! Jun 2024.
+!
+module mod_ephemerides
+
+  implicit none
+
+  type t_ephemerides
+    private
+    logical :: first = .true.
+    integer :: len_times
+    character(len=256) :: MoonSunCoordFile = "none"
+    real(8) :: tbeg(2) = (/0d0, 0d0/)
+    real(8) :: tend(2) = (/0d0, 0d0/)
+    real(8), allocatable :: times(:), lunar_distances(:), solar_distances(:)
+    real(8), allocatable :: lunar_ras(:), solar_ras(:), lunar_decs(:), solar_decs(:)
+    real(8) :: tcache = 2592000.d0 ! cache 30 days of data for a faster retrival when
+    ! HAVENLY_OBJS_COORDS_FROM_TABLE is called multiple
+    ! times in a single program
+  contains
+    procedure, pass(self) :: HEAVENLY_OBJS_COORDS_FROM_TABLE
+    procedure, pass(self), private :: reallocate_arrays
+    procedure, pass(self), private :: recache_data
+    procedure, pass(self), private :: init => initialize_ephemerides
+  end type t_ephemerides
+
+  interface t_ephemerides
+    module procedure createEphemerides
+  end interface t_ephemerides
+
+  private :: interpolate, L, adjust_RA, GET_RANK_SIMPLE_SEARCH, &
+             GET_RANK_UNIFORM, GET_RANK_BINARY_SEARCH, initialize_ephemerides, &
+             recache_data, reallocate_arrays
+
+contains
+
+  subroutine initialize_ephemerides(self, in_rnday, in_MoonSunCoordFile)
+    implicit none
+    class(t_ephemerides), intent(inout) :: self
+    real(8), intent(in) :: in_rnday
+    character(len=*), intent(in) :: in_MoonSunCoordFile
+
+    self%first = .true.
+    self%len_times = 0
+    self%MoonSunCoordFile = in_MoonSunCoordFile
+
+    ! Keep a portion of ephemeride data that covers an entire run period
+    self%tcache = in_rnday*86400.0d0
+
+  end subroutine initialize_ephemerides
+
+  function createEphemerides(rnday, MoonSunCoordFile) result(ephemerides)
+    implicit none
+    real(8), intent(in) :: rnday
+    character(len=*), intent(in) :: MoonSunCoordFile
+    type(t_ephemerides) :: ephemerides
+
+    call ephemerides%init(rnday, MoonSunCoordFile)
+
+  end function createEphemerides
+
+  subroutine HEAVENLY_OBJS_COORDS_FROM_TABLE(self, MoonSunCoor, julian_date_loc, ierr, UniformDT)
+    use mod_astronomic, only: km2AU
+#ifdef CMPI
+    use messenger, only: msg_fini
+#endif
+    implicit none
+    class(t_ephemerides), intent(inout) :: self
+    real(8), intent(in) :: julian_date_loc
+    real(8) :: MoonSunCoor(3, 2)
+    integer, intent(out) :: ierr
+    logical, optional :: UniformDT
+
+#ifndef ADCNETCDF
+    write (*, '(A)') "ERROR: Must compile with netCDF support enabled"
+#ifdef CMPI
+    call msg_fini()
+#endif
+    call exit(1)
+#else
+    integer :: retval, j, ii
+    real(8) :: julian_datetime_2000, seconds_between
+    logical :: UniformRankSearch = .false.
+    real(8) :: ratmp(4)
+    logical :: match
+    integer :: idarr(4)
+
+    ! Calculate seconds between the provided date and the reference date !
+    julian_datetime_2000 = 2451544.5d0
+    seconds_between = (julian_date_loc - julian_datetime_2000)*86400.0d0
+
+    if (present(UniformDT)) then
+      UniformRankSearch = UniformDT
+    end if
+
+    if (.not. self%first) then
+      if (seconds_between > self%times(self%len_times - 4)) then
+        ierr = self%recache_data(seconds_between, UniformRankSearch)
+      end if
+    else
+      ierr = self%recache_data(seconds_between, UniformRankSearch)
+    end if
+
+    if (.not. UniformRankSearch) then
+      J = GET_RANK_BINARY_SEARCH(seconds_between, self%times, self%len_times); 
+    else
+      J = GET_RANK_UNIFORM(seconds_between, self%times, self%len_times); 
+    end if
+
+    match = .false.; 
+    if (j >= 3 .and. j <= self%len_times - 2) then
+      match = .true.; 
+      idarr = (/(j - ii, ii=-2, 1)/); 
+    else if (j == 2) then
+      match = .true.; 
+      idarr = (/(ii, ii=1, 4)/); 
+    else if (j == self%len_times) then
+      match = .true.
+      idarr = (/(self%len_times - 3 + ii, ii=0, 3)/); 
+    end if
+
+    if (match) then
+      ! Lunar distance interpolation
+      call interpolate(self%times(idarr), self%lunar_distances(idarr), seconds_between, MoonSunCoor(3, 1))
+
+      ! Solar distance interpolation
+      call interpolate(self%times(idarr), self%solar_distances(idarr), seconds_between, MoonSunCoor(3, 2))
+
+      ! Lunar right ascension interpolation
+      ratmp(1:4) = self%lunar_ras(idarr); 
+      call adjust_RA(ratmp(1:4)); 
+      call interpolate(self%times(idarr), ratmp(1:4), seconds_between, MoonSunCoor(1, 1))
+      MoonSunCoor(1, 1) = modulo(MoonsunCoor(1, 1), 360.d0); 
+      ! Solar right ascension interpolation
+      ratmp(1:4) = self%solar_ras(idarr); 
+      call adjust_RA(ratmp(1:4)); 
+      call interpolate(self%times(idarr), ratmp(1:4), seconds_between, MoonSunCoor(1, 2))
+      MoonSunCoor(1, 2) = modulo(MoonsunCoor(1, 2), 360.d0); 
+      ! Lunar declination interpolation
+      call interpolate(self%times(idarr), self%lunar_decs(idarr), seconds_between, MoonSunCoor(2, 1))
+
+      ! Solar declination interpolation
+      call interpolate(self%times(idarr), self%solar_decs(idarr), seconds_between, MoonSunCoor(2, 2))
+    end if
+
+    if (.not. match) then
+      IERR = 2; 
+    end if
+
+    ! Convert solar distance to AU
+    ! MoonSunCoor(3,2) = MoonSunCoor(3,2) * 6.6845871226706E-9
+    MoonSunCoor(3, 2) = MoonSunCoor(3, 2)*km2AU; 
+#endif
+  end subroutine HEAVENLY_OBJS_COORDS_FROM_TABLE
+
+  integer function recache_data(self, seconds_between, UniformRankSearch) result(ierr)
+#ifdef ADCNETCDF
+    use netcdf
+    use netcdf_error, only: check_err
+#endif
+    implicit none
+    class(t_ephemerides), intent(inout) :: self
+    real(8), intent(in) :: seconds_between
+    logical, intent(in) :: UniformRankSearch
+
+#ifdef ADCNETCDF
+    integer, parameter :: NC_ERR = -1
+    integer :: time_dimid, ndimsp, dimlen
+    integer :: ncid, time_varid, lunar_distance_varid, solar_distance_varid
+    integer :: lunar_ra_varid, solar_ra_varid, lunar_dec_varid, solar_dec_varid
+    integer :: lenarr, iabeg, iaend
+    integer :: dimids(nf90_max_dims)
+    real(8), allocatable :: tmparr(:)
+
+    ! Open the NetCDF file
+    call check_err(nf90_open(self%MoonSunCoordFile, nf90_nowrite, ncid))
+
+    ! Get variable IDs
+    call check_err(nf90_inq_varid(ncid, 'time', time_varid))
+    call check_err(nf90_inq_varid(ncid, 'lunar_distance', lunar_distance_varid))
+    call check_err(nf90_inq_varid(ncid, 'solar_distance', solar_distance_varid))
+    call check_err(nf90_inq_varid(ncid, 'lunar_ra', lunar_ra_varid))
+    call check_err(nf90_inq_varid(ncid, 'solar_ra', solar_ra_varid))
+    call check_err(nf90_inq_varid(ncid, 'lunar_dec', lunar_dec_varid))
+    call check_err(nf90_inq_varid(ncid, 'solar_dec', solar_dec_varid))
+
+    ! Inquire about the time variable to get dimension IDs
+    call check_err(nf90_inquire_variable(ncid, time_varid, ndims=ndimsp, dimids=dimids))
+
+    ! Get the length of the time dimension
+    call check_err(nf90_inquire_dimension(ncid, dimids(1), len=dimlen))
+
+    lenarr = dimlen
+    allocate (tmparr(lenarr)); tmparr = 0.d0
+    call check_err(nf90_get_var(ncid, time_varid, tmparr))
+    self%tbeg(2) = tmparr(1)
+    self%tend(2) = tmparr(lenarr)
+    if (seconds_between < self%tbeg(2) .or. seconds_between > self%tend(2)) then
+      ierr = 2
+      return
+    end if
+
+    if (.not. UniformRankSearch) then
+      iabeg = GET_RANK_BINARY_SEARCH(seconds_between, tmparr, lenarr) - 4; 
+    else
+      iabeg = GET_RANK_UNIFORM(seconds_between, tmparr, lenarr) - 4; 
+    end if
+
+    if (iabeg < 1) iabeg = 1; 
+    if (.not. UniformRankSearch) then
+      iaend = GET_RANK_BINARY_SEARCH(seconds_between + self%tcache, tmparr, lenarr) + 4
+    else
+      iaend = GET_RANK_UNIFORM(seconds_between + self%tcache, tmparr, lenarr) + 4
+    end if
+    if (iaend > lenarr) iaend = lenarr; 
+    self%tbeg(1) = tmparr(iabeg); 
+    self%tend(1) = tmparr(iaend); 
+    self%len_times = (iaend - iabeg) + 1; 
+    call self%reallocate_arrays()
+
+    self%times = tmparr(iabeg:iaend); 
+    call check_err(nf90_get_var(ncid, lunar_distance_varid, self%lunar_distances, (/iabeg/), (/self%len_times/)))
+    call check_err(nf90_get_var(ncid, solar_distance_varid, self%solar_distances, (/iabeg/), (/self%len_times/)))
+    call check_err(nf90_get_var(ncid, lunar_ra_varid, self%lunar_ras, (/iabeg/), (/self%len_times/)))
+    call check_err(nf90_get_var(ncid, solar_ra_varid, self%solar_ras, (/iabeg/), (/self%len_times/)))
+    call check_err(nf90_get_var(ncid, lunar_dec_varid, self%lunar_decs, (/iabeg/), (/self%len_times/)))
+    call check_err(nf90_get_var(ncid, solar_dec_varid, self%solar_decs, (/iabeg/), (/self%len_times/)))
+
+    ! Close the NetCDF file
+    call check_err(nf90_close(ncid))
+    deallocate (tmparr)
+    self%first = .false.
+#endif
+  end function recache_data
+
+  subroutine reallocate_arrays(self)
+    implicit none
+    class(t_ephemerides), intent(inout) :: self
+
+    ! Allocate arrays !
+    if (allocated(self%times)) then
+      deallocate (self%times)
+      deallocate (self%lunar_distances)
+      deallocate (self%solar_distances)
+      deallocate (self%lunar_ras, self%solar_ras)
+      deallocate (self%lunar_decs, self%solar_decs)
+    end if
+    allocate (self%times(self%len_times))
+    allocate (self%lunar_distances(self%len_times))
+    allocate (self%solar_distances(self%len_times))
+    allocate (self%lunar_ras(self%len_times))
+    allocate (self%solar_ras(self%len_times))
+    allocate (self%lunar_decs(self%len_times))
+    allocate (self%solar_decs(self%len_times))
+  end subroutine reallocate_arrays
+
+  ! check whether RA change cross the zero hr line.
+  ! if so, adjust accordingly
+  subroutine adjust_RA(RA, fadjust)
+    implicit none
+
+    logical, optional :: fadjust
+    real(8), intent(INOUT) :: RA(:)
+
+    integer :: I, N
+    logical :: CrossZeroRA
+
+    N = ubound(RA, 1); 
+    CrossZeroRA = .false.; 
+    do I = 1, N - 1
+      if (abs(RA(I + 1) - RA(I)) > 120.d0) then
+        CrossZeroRA = .true.; 
+      end if
+    end do
+
+    if (CrossZeroRA) then
+      where (RA < 180.d0) RA = RA + 360.d0; 
+    end if
+
+    if (present(fadjust)) fadjust = CrossZeroRA; 
+    return; 
+  end subroutine adjust_RA
+
+  ! Subroutine to perform Lagrange interpolation
+  subroutine interpolate(x, y, xi, yi)
+    real(8), intent(in) :: x(:), y(:), xi
+    real(8), intent(out) :: yi
+    integer :: k
+    real(8) :: term
+    yi = 0.0d0
+    do k = 1, size(x)
+      call L(k, xi, x, term)
+      yi = yi + y(k)*term
+    end do
+  end subroutine interpolate
+
+  ! Subroutine to calculate Lagrange polynomial term
+  subroutine L(k, xi, x, term)
+    integer, intent(in) :: k
+    real(8), intent(in) :: xi, x(:)
+    real(8), intent(out) :: term
+    integer :: i
+    term = 1.0d0
+    do i = 1, size(x)
+      if (i /= k) then
+        term = term*(xi - x(i))/(x(k) - x(i))
+      end if
+    end do
+  end subroutine L
+
+  ! Return a rank j in ARR such that arr(j-1) < val <= arr(j1) !
+  function GET_RANK_SIMPLE_SEARCH(val, arr, len) result(rank)
+    implicit none
+
+    integer :: rank
+    real(8), intent(IN) :: val
+    real(8), intent(IN) :: arr(:)
+    integer, intent(IN) :: len
+
+    integer :: J
+
+    if (val < arr(1)) then
+      rank = 0; 
+      return; 
+    end if
+
+    if (val > arr(len)) then
+      rank = len + 1; 
+      return; 
+    end if
+
+    RANK = 0; 
+    do J = 1, LEN
+      if (ARR(J) >= val) then
+        RANK = J; 
+        exit; 
+      end if
+    end do
+
+  end function GET_RANK_SIMPLE_SEARCH
+
+  ! Find a rank j in arr such that arr(j-1) < val < = arr(j)         !
+  ! in a unifrom table, i,e, arr(i+1) - arr(i) = arr(i+2) - arr(i+1) !
+  function GET_RANK_UNIFORM(val, arr, len) result(rank)
+    implicit none
+
+    integer :: rank
+    real(8), intent(IN) :: val
+    real(8), intent(IN) :: arr(:)
+    integer, intent(IN) :: len
+
+    real(8) :: ds
+
+    if (val < arr(1)) then
+      rank = 0; 
+      return; 
+    end if
+
+    if (val > arr(len)) then
+      rank = len + 1; 
+      return; 
+    end if
+
+    ds = (arr(2) - arr(1)); 
+    rank = ceiling((val - arr(1))/ds) + 1; 
+  end function GET_RANK_UNIFORM
+
+  ! Find a rank j in arr such that arr(j-1) < val < = arr(j)  !
+  ! using a binary search                                     !
+  function GET_RANK_BINARY_SEARCH(val, arr, len) result(rank)
+    implicit none
+
+    integer :: rank
+    real(8), intent(IN) :: val
+    real(8), intent(IN) :: arr(:)
+    integer :: len
+
+    integer :: low, high, mid
+
+    if (val < arr(1)) then
+      rank = 0; 
+      return; 
+    end if
+    if (val > arr(len)) then
+      rank = len + 1; 
+      return; 
+    end if
+
+    low = 1; 
+    high = len; 
+    do
+      mid = (low + high)/2; 
+      if (abs(val - arr(mid)) < 1.0e-12) then
+        ! Exact match is found !
+        rank = mid; 
+        exit; 
+      end if
+
+      if (val < arr(mid)) then
+        high = mid; 
+      else
+        low = mid; 
+      end if
+
+      if (high == low + 1) then
+        ! found the interval to which val  !
+        ! falls inbetween is found         !
+        rank = high; 
+        exit; 
+      end if
+
+      if (high < low) then
+        write (*, *) "Error in GET_RANK_BINARY_SEARCH()"; 
+        rank = -1; 
+        exit; 
+      end if
+    end do
+
+  end function GET_RANK_BINARY_SEARCH
+
+end module mod_ephemerides

--- a/src/global.F
+++ b/src/global.F
@@ -890,10 +890,13 @@ C     cms51.06: moved fort.33 file from read_input.F to here
      &    STATUS='REPLACE')
       OPEN(33,FILE=trim(localdir)//'/'//'fort.33', ACTION='WRITE',
      &    STATUS='REPLACE')
+      
 #else
       OPEN(16,FILE='fort.16', ACTION='WRITE', STATUS='REPLACE')
       OPEN(33,FILE='fort.33', ACTION='WRITE', STATUS='REPLACE')
 #endif
+
+    
 C--------------------------------------------------------------------
       END SUBROUTINE openLogFile
 C--------------------------------------------------------------------

--- a/src/messenger.F
+++ b/src/messenger.F
@@ -1690,6 +1690,61 @@ C---------------------------------------------------------------------
 C---------------------------------------------------------------------      
 !=============================================================================
 
+!=============================================================================
+C--------------------------------------------------------------------- 
+C DW, 2024   
+      SUBROUTINE MSG_RScalar_Reduce( OP, vali, valo, loco )
+       IMPLICIT NONE
+
+       character (LEN=*):: OP
+       REAL (8):: vali, valo 
+       REAL (8), intent(inout), optional:: loco !/ in - rank, out - max/min rank
+
+       REAL (8):: tempi(2), tempo(2)
+C      
+       call setMessageSource("msg_rvecreduce")
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+       call allMessage(DEBUG,"Enter.") 
+#endif
+C       
+       SELECT CASE(OP)
+       CASE ('max','MAX')
+         IF ( present(loco) ) THEN
+           tempi  = (/ vali, loco /) 
+           CALL MPI_Reduce( tempi, tempo, 1, MPI_2DOUBLE_PRECISION,
+     &         MPI_MAXLOC, 0, comm, ierr ) 
+           valo = tempo(1)  
+           loco = tempo(2)  
+         ELSE      
+           CALL MPI_Reduce( vali, valo, 1, DBLETYPE, MPI_MAX, 0, 
+     &         comm, ierr )
+         END IF
+       CASE ('min','MIN')
+         IF ( present(loco) ) THEN  
+           tempi  = (/ vali, loco /) 
+           CALL MPI_Reduce( tempi, tempo, 1, MPI_2DOUBLE_PRECISION,
+     &         MPI_MINLOC, 0, comm, ierr ) 
+           valo = tempo(1)  
+           loco = tempo(2)  
+         ELSE
+           CALL MPI_Reduce( vali, valo, 1, DBLETYPE, MPI_MIN, 0, 
+     &        comm, ierr )
+         END IF
+       CASE ('sum','SUM')
+         CALL MPI_Reduce( vali, valo, 1, DBLETYPE, MPI_SUM, 0, 
+     &      comm, ierr ) 
+       END SELECT    
+C
+#if defined(MESSENGER_TRACE) || defined(ALL_TRACE)
+       call allMessage(DEBUG,"Return.")
+#endif
+       call unsetMessageSource() 
+
+       RETURN       
+      END SUBROUTINE MSG_RScalar_Reduce        
+C---------------------------------------------------------------------
+!=============================================================================
+
       END MODULE MESSENGER
 
       subroutine MSG_ABORT()

--- a/src/moon.F90
+++ b/src/moon.F90
@@ -1,0 +1,578 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+!
+! Postion of the Moon. Chapter 47
+! Page. 337 -344
+module mod_moon_position
+
+  implicit none
+
+  ! Variables string periodic terms in the the Moon's longtitude,
+  ! latitude, and dfistance
+  integer, private, parameter :: NPER = 60 !
+
+  !  TABLE 47. B. page 341. Periodic terms for the latitude of
+  !  the Moon (\Sum b). The unit is 1e-6 degree
+  real(8), parameter, private :: LATARG(NPER, 4) = reshape((/0.d0, 0.d0, 0.d0, 1.d0, &
+                                                             0.d0, 0.d0, 1.d0, 1.d0, &
+                                                             0.d0, 0.d0, 1.d0, -1.d0, &
+                                                             2.d0, 0.d0, 0.d0, -1.d0, &
+                                                             2.d0, 0.d0, -1.d0, 1.d0, &
+                                                             2.d0, 0.d0, -1.d0, -1.d0, &
+                                                             2.d0, 0.d0, 0.d0, 1.d0, &
+                                                             0.d0, 0.d0, 2.d0, 1.d0, &
+                                                             2.d0, 0.d0, 1.d0, -1.d0, &
+                                                             0.d0, 0.d0, 2.d0, -1.d0, &
+                                                             2.d0, -1.d0, 0.d0, -1.d0, &
+                                                             2.d0, 0.d0, -2.d0, -1.d0, &
+                                                             2.d0, 0.d0, 1.d0, 1.d0, &
+                                                             2.d0, 1.d0, 0.d0, -1.d0, &
+                                                             2.d0, -1.d0, -1.d0, 1.d0, &
+                                                             2.d0, -1.d0, 0.d0, 1.d0, &
+                                                             2.d0, -1.d0, -1.d0, -1.d0, &
+                                                             0.d0, 1.d0, -1.d0, -1.d0, &
+                                                             4.d0, 0.d0, -1.d0, -1.d0, &
+                                                             0.d0, 1.d0, 0.d0, 1.d0, &
+                                                             0.d0, 0.d0, 0.d0, 3.d0, &
+                                                             0.d0, 1.d0, -1.d0, 1.d0, &
+                                                             1.d0, 0.d0, 0.d0, 1.d0, &
+                                                             0.d0, 1.d0, 1.d0, 1.d0, &
+                                                             0.d0, 1.d0, 1.d0, -1.d0, &
+                                                             0.d0, 1.d0, 0.d0, -1.d0, &
+                                                             1.d0, 0.d0, 0.d0, -1.d0, &
+                                                             0.d0, 0.d0, 3.d0, 1.d0, &
+                                                             4.d0, 0.d0, 0.d0, -1.d0, &
+                                                             4.d0, 0.d0, -1.d0, 1.d0, &
+                                                             0.d0, 0.d0, 1.d0, -3.d0, &
+                                                             4.d0, 0.d0, -2.d0, 1.d0, &
+                                                             2.d0, 0.d0, 0.d0, -3.d0, &
+                                                             2.d0, 0.d0, 2.d0, -1.d0, &
+                                                             2.d0, -1.d0, 1.d0, -1.d0, &
+                                                             2.d0, 0.d0, -2.d0, 1.d0, &
+                                                             0.d0, 0.d0, 3.d0, -1.d0, &
+                                                             2.d0, 0.d0, 2.d0, 1.d0, &
+                                                             2.d0, 0.d0, -3.d0, -1.d0, &
+                                                             2.d0, 1.d0, -1.d0, 1.d0, &
+                                                             2.d0, 1.d0, 0.d0, 1.d0, &
+                                                             4.d0, 0.d0, 0.d0, 1.d0, &
+                                                             2.d0, -1.d0, 1.d0, 1.d0, &
+                                                             2.d0, -2.d0, 0.d0, -1.d0, &
+                                                             0.d0, 0.d0, 1.d0, 3.d0, &
+                                                             2.d0, 1.d0, 1.d0, -1.d0, &
+                                                             1.d0, 1.d0, 0.d0, -1.d0, &
+                                                             1.d0, 1.d0, 0.d0, 1.d0, &
+                                                             0.d0, 1.d0, -2.d0, -1.d0, &
+                                                             2.d0, 1.d0, -1.d0, -1.d0, &
+                                                             1.d0, 0.d0, 1.d0, 1.d0, &
+                                                             2.d0, -1.d0, -2.d0, -1.d0, &
+                                                             0.d0, 1.d0, 2.d0, 1.d0, &
+                                                             4.d0, 0.d0, -2.d0, -1.d0, &
+                                                             4.d0, -1.d0, -1.d0, -1.d0, &
+                                                             1.d0, 0.d0, 1.d0, -1.d0, &
+                                                             4.d0, 0.d0, 1.d0, -1.d0, &
+                                                             1.d0, 0.d0, -1.d0, -1.d0, &
+                                                             4.d0, -1.d0, 0.d0, -1.d0, &
+                                                             2.d0, -2.d0, 0.d0, 1.d0/), (/NPER, 4/))
+
+  real(8), parameter, private :: LAT_SIN_COEF(NPER) = (/5128122.d0, &
+                                                        280602.d0, &
+                                                        277693.d0, &
+                                                        173237.d0, &
+                                                        55413.d0, &
+                                                        46271.d0, &
+                                                        32573.d0, &
+                                                        17198.d0, &
+                                                        9266.d0, &
+                                                        8822.d0, &
+                                                        8216.d0, &
+                                                        4324.d0, &
+                                                        4200.d0, &
+                                                        -3359.d0, &
+                                                        2463.d0, &
+                                                        2211.d0, &
+                                                        2065.d0, &
+                                                        -1870.d0, &
+                                                        1828.d0, &
+                                                        -1794.d0, &
+                                                        -1749.d0, &
+                                                        -1565.d0, &
+                                                        -1491.d0, &
+                                                        -1475.d0, &
+                                                        -1410.d0, &
+                                                        -1344.d0, &
+                                                        -1335.d0, &
+                                                        1107.d0, &
+                                                        1021.d0, &
+                                                        833.d0, &
+                                                        777.d0, &
+                                                        671.d0, &
+                                                        607.d0, &
+                                                        596.d0, &
+                                                        491.d0, &
+                                                        -451.d0, &
+                                                        439.d0, &
+                                                        422.d0, &
+                                                        421.d0, &
+                                                        -366.d0, &
+                                                        -351.d0, &
+                                                        331.d0, &
+                                                        315.d0, &
+                                                        302.d0, &
+                                                        -283.d0, &
+                                                        -229.d0, &
+                                                        223.d0, &
+                                                        223.d0, &
+                                                        -220.d0, &
+                                                        -220.d0, &
+                                                        -185.d0, &
+                                                        181.d0, &
+                                                        -177.d0, &
+                                                        176.d0, &
+                                                        166.d0, &
+                                                        -164.d0, &
+                                                        132.d0, &
+                                                        -119.d0, &
+                                                        115.d0, &
+                                                        107.d0/)
+
+  ! TABLE 47. A.
+  !  Periodic terms for the longitude \Sum l and distance \Sum r
+  !  of the Moon. The unit is 1e-6 for \Sum l and Kilometer for \Sum r
+  real(8), parameter, private :: LONARG(NPER, 4) = reshape((/0.d0, 0.d0, 1.d0, 0.d0, &
+                                                             2.d0, 0.d0, -1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 0.d0, 0.d0, &
+                                                             0.d0, 0.d0, 2.d0, 0.d0, &
+                                                             0.d0, 1.d0, 0.d0, 0.d0, &
+                                                             0.d0, 0.d0, 0.d0, 2.d0, &
+                                                             2.d0, 0.d0, -2.d0, 0.d0, &
+                                                             2.d0, -1.d0, -1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 1.d0, 0.d0, &
+                                                             2.d0, -1.d0, 0.d0, 0.d0, &
+                                                             0.d0, 1.d0, -1.d0, 0.d0, &
+                                                             1.d0, 0.d0, 0.d0, 0.d0, &
+                                                             0.d0, 1.d0, 1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 0.d0, -2.d0, &
+                                                             0.d0, 0.d0, 1.d0, 2.d0, &
+                                                             0.d0, 0.d0, 1.d0, -2.d0, &
+                                                             4.d0, 0.d0, -1.d0, 0.d0, &
+                                                             0.d0, 0.d0, 3.d0, 0.d0, &
+                                                             4.d0, 0.d0, -2.d0, 0.d0, &
+                                                             2.d0, 1.d0, -1.d0, 0.d0, &
+                                                             2.d0, 1.d0, 0.d0, 0.d0, &
+                                                             1.d0, 0.d0, -1.d0, 0.d0, &
+                                                             1.d0, 1.d0, 0.d0, 0.d0, &
+                                                             2.d0, -1.d0, 1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 2.d0, 0.d0, &
+                                                             4.d0, 0.d0, 0.d0, 0.d0, &
+                                                             2.d0, 0.d0, -3.d0, 0.d0, &
+                                                             0.d0, 1.d0, -2.d0, 0.d0, &
+                                                             2.d0, 0.d0, -1.d0, 2.d0, &
+                                                             2.d0, -1.d0, -2.d0, 0.d0, &
+                                                             1.d0, 0.d0, 1.d0, 0.d0, &
+                                                             2.d0, -2.d0, 0.d0, 0.d0, &
+                                                             0.d0, 1.d0, 2.d0, 0.d0, &
+                                                             0.d0, 2.d0, 0.d0, 0.d0, &
+                                                             2.d0, -2.d0, -1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 1.d0, -2.d0, &
+                                                             2.d0, 0.d0, 0.d0, 2.d0, &
+                                                             4.d0, -1.d0, -1.d0, 0.d0, &
+                                                             0.d0, 0.d0, 2.d0, 2.d0, &
+                                                             3.d0, 0.d0, -1.d0, 0.d0, &
+                                                             2.d0, 1.d0, 1.d0, 0.d0, &
+                                                             4.d0, -1.d0, -2.d0, 0.d0, &
+                                                             0.d0, 2.d0, -1.d0, 0.d0, &
+                                                             2.d0, 2.d0, -1.d0, 0.d0, &
+                                                             2.d0, 1.d0, -2.d0, 0.d0, &
+                                                             2.d0, -1.d0, 0.d0, -2.d0, &
+                                                             4.d0, 0.d0, 1.d0, 0.d0, &
+                                                             0.d0, 0.d0, 4.d0, 0.d0, &
+                                                             4.d0, -1.d0, 0.d0, 0.d0, &
+                                                             1.d0, 0.d0, -2.d0, 0.d0, &
+                                                             2.d0, 1.d0, 0.d0, -2.d0, &
+                                                             0.d0, 0.d0, 2.d0, -2.d0, &
+                                                             1.d0, 1.d0, 1.d0, 0.d0, &
+                                                             3.d0, 0.d0, -2.d0, 0.d0, &
+                                                             4.d0, 0.d0, -3.d0, 0.d0, &
+                                                             2.d0, -1.d0, 2.d0, 0.d0, &
+                                                             0.d0, 2.d0, 1.d0, 0.d0, &
+                                                             1.d0, 1.d0, -1.d0, 0.d0, &
+                                                             2.d0, 0.d0, 3.d0, 0.d0, &
+                                                             2.d0, 0.d0, -1.d0, -2.d0/), (/NPER, 4/))
+
+  real(8), parameter, private :: LON_SIN_COEF(NPER) = (/6288774.d0, &
+                                                        1274027.d0, &
+                                                        658314.d0, &
+                                                        213618.d0, &
+                                                        -185116.d0, &
+                                                        -114332.d0, &
+                                                        58793.d0, &
+                                                        57066.d0, &
+                                                        53322.d0, &
+                                                        45758.d0, &
+                                                        -40923.d0, &
+                                                        -34720.d0, &
+                                                        -30383.d0, &
+                                                        15327.d0, &
+                                                        -12528.d0, &
+                                                        10980.d0, &
+                                                        10675.d0, &
+                                                        10034.d0, &
+                                                        8548.d0, &
+                                                        -7888.d0, &
+                                                        -6766.d0, &
+                                                        -5163.d0, &
+                                                        4987.d0, &
+                                                        4036.d0, &
+                                                        3994.d0, &
+                                                        3861.d0, &
+                                                        3665.d0, &
+                                                        -2689.d0, &
+                                                        -2602.d0, &
+                                                        2390.d0, &
+                                                        -2348.d0, &
+                                                        2236.d0, &
+                                                        -2120.d0, &
+                                                        -2069.d0, &
+                                                        2048.d0, &
+                                                        -1773.d0, &
+                                                        -1595.d0, &
+                                                        1215.d0, &
+                                                        -1110.d0, &
+                                                        -892.d0, &
+                                                        -810.d0, &
+                                                        759.d0, &
+                                                        -713.d0, &
+                                                        -700.d0, &
+                                                        691.d0, &
+                                                        596.d0, &
+                                                        549.d0, &
+                                                        537.d0, &
+                                                        520.d0, &
+                                                        -487.d0, &
+                                                        -399.d0, &
+                                                        -381.d0, &
+                                                        351.d0, &
+                                                        -340.d0, &
+                                                        330.d0, &
+                                                        327.d0, &
+                                                        -323.d0, &
+                                                        299.d0, &
+                                                        294.d0, &
+                                                        0.d0/)
+
+  real(8), parameter, private :: LON_COS_COEF(NPER) = (/-20905355.d0, &
+                                                        -3699111.d0, &
+                                                        -2955968.d0, &
+                                                        -569925.d0, &
+                                                        48888.d0, &
+                                                        -3149.d0, &
+                                                        246158.d0, &
+                                                        -152138.d0, &
+                                                        -170733.d0, &
+                                                        -204586.d0, &
+                                                        -129620.d0, &
+                                                        108743.d0, &
+                                                        104755.d0, &
+                                                        10321.d0, &
+                                                        0.d0, &
+                                                        79661.d0, &
+                                                        -34782.d0, &
+                                                        -23210.d0, &
+                                                        -21636.d0, &
+                                                        24208.d0, &
+                                                        30824.d0, &
+                                                        -8379.d0, &
+                                                        -16675.d0, &
+                                                        -12831.d0, &
+                                                        -10445.d0, &
+                                                        -11650.d0, &
+                                                        14403.d0, &
+                                                        -7003.d0, &
+                                                        0.d0, &
+                                                        10056.d0, &
+                                                        6322.d0, &
+                                                        -9884.d0, &
+                                                        5751.d0, &
+                                                        0.d0, &
+                                                        -4950.d0, &
+                                                        4130.d0, &
+                                                        0.d0, &
+                                                        -3958.d0, &
+                                                        0.d0, &
+                                                        3258.d0, &
+                                                        2616.d0, &
+                                                        -1897.d0, &
+                                                        -2117.d0, &
+                                                        2354.d0, &
+                                                        0.d0, &
+                                                        0.d0, &
+                                                        -1423.d0, &
+                                                        -1117.d0, &
+                                                        -1571.d0, &
+                                                        -1739.d0, &
+                                                        0.d0, &
+                                                        -4421.d0, &
+                                                        0.d0, &
+                                                        0.d0, &
+                                                        0.d0, &
+                                                        0.d0, &
+                                                        1165.d0, &
+                                                        0.d0, &
+                                                        0.d0, &
+                                                        8752.d0/)
+  integer, private, parameter :: LATMEU(NPER) = int(abs(LATARG(:, 2)))
+  integer, private, parameter :: LONMEU(NPER) = int(abs(LONARG(:, 2)))
+
+  private :: CAL_EPMUL, E_MUL_COEF, A1_DEG, A2_DEG, A3_DEG, &
+             MOON_COORDINATES_SUB0, MOON_COORDINATES_SUB1
+
+  interface MOON_COORDINATES
+    module procedure MOON_COORDINATES_SUB0, MOON_COORDINATES_SUB1
+  end interface MOON_COORDINATES
+contains
+
+  ! Coefficient muitplying sine and cosine arguments. page 338
+  real(8) elemental function E_MUL_COEF(T) result(E)
+    implicit none
+    real(8), intent(IN) :: T
+    E = 1.d0 + T*(-0.002516d0 + T*(-0.0000074d0))
+  end function E_MUL_COEF
+
+  ! Page. 338
+  real(8) elemental function A1_DEG(T) result(A1)
+    implicit none
+    real(8), intent(IN) :: T
+    A1 = 119.75d0 + 131.849d0*T
+  end function A1_DEG
+
+  ! Page. 338
+  real(8) elemental function A2_DEG(T) result(A2)
+    implicit none
+    real(8), intent(IN) :: T
+    A2 = 53.09d0 + 479264.290d0*T
+  end function A2_DEG
+
+  ! Page. 338
+  real(8) elemental function A3_DEG(T) result(A3)
+    implicit none
+    real(8), intent(IN) :: T
+    A3 = 313.45d0 + 481266.484d0*T
+  end function A3_DEG
+
+  ! Coefficients for terms contains angle M. See description on
+  ! Page 338
+  function CAL_EPMUL(MEU, E) result(EPMUL)
+    implicit none
+
+    real(8) :: EPMUL(NPER)
+    real(8), intent(IN) :: E
+    integer, intent(IN) :: MEU(:)
+
+    integer :: I, J
+
+    epmul = 1.d0
+    do I = 1, NPER
+      do J = 1, MEU(I)
+        epmul(I) = epmul(I)*E
+      end do
+    end do
+
+  end function CAL_EPMUL
+
+  ! Chaper 47.
+  ! Output:
+  !     RA = Right ascendsion (in Degrees)
+  !     DEC = Declination (in Degrees)
+  !     Delta = Distance from the Earth to the Moon (in kilometers)
+  ! Input:
+  !     JD = Julain days
+  !     ASVAL (optional): derived data type storing precomputed
+  !                       values for the moon orbit at the time JD
+  !
+  !     ASVAL%LP = Moon's mean longitude
+  !     ASVAL%D  = Moon's mean elongation
+  !     ASVAL%M  = Sun's mean anomaly
+  !     ASVAL%MP = Moon's mean anomaly
+  !     ASVAL%F  = Moon's argument of latitude (mean distance of the Moon
+  !          from it ascending node)
+  !     ASVAL%E  = coefficeint for correcting terms containg M
+  !     ASVAL%A1, A2, A3 = coefficeint for additve term accounting
+  !                  action of Venus and Jupiter
+  ! Intended as a driver subroutine.
+  ! it call as a function MOON_COORDINATES_SUB0
+  !
+  subroutine MOON_COORDINATES_SUB1(RA, DEC, Delta, JD, ASVAL, NUTATION)
+    use mod_astronomic, only: t_astronomic_values, JULIAN_CENTURIES, LP_DEG, D_DEG, M_DEG, &
+                              MP_DEG, F_DEG, OMEGA_DEG, L0_DEG, DeltaPsiL, DeltaVarepsL, &
+                              varepsilon0_ecliptic, ECLIP2EQ
+    implicit none
+
+    real(8), intent(OUT) :: RA, DEC, Delta
+    real(8), intent(IN) :: JD
+    type(t_astronomic_values), optional, intent(IN) :: ASVAL
+    logical, optional :: NUTATION
+
+    ! local !
+    real(8) :: lambda, beta
+    real(8) :: T, LP, D, M, MP, F, A1, A2, A3, E
+    real(8) :: L0, OG, DPsi, Dvareps, vareps, vareps0
+    logical :: have_asval = .false.
+    logical :: use_nutation = .false.
+    real(8) :: nutation_mul
+
+    ! Check if the astroval
+    if (present(ASVAL)) then
+      if (abs(JD - ASVAL%JD) < 1.e-9) have_asval = .true.
+    end if
+    if (present(NUTATION)) use_nutation = NUTATION
+
+    if (.not. have_asval) then
+      T = JULIAN_CENTURIES(JD)
+      LP = modulo(LP_DEG(T), 360.d0)
+      D = modulo(D_DEG(T), 360.d0)
+      M = modulo(M_DEG(T), 360.d0)
+      MP = modulo(MP_DEG(T), 360.d0)
+      F = modulo(F_DEG(T), 360.d0)
+
+      OG = modulo(OMEGA_DEG(T), 360.d0)
+      L0 = modulo(L0_DEG(T), 360.d0)
+      DPsi = DeltaPsiL(OG, L0, LP)
+
+      vareps0 = varepsilon0_ecliptic(T)
+      DVareps = DeltaVarepsL(OG, L0, LP)
+      vareps = vareps0 + Dvareps
+    else
+      T = ASVAL%T
+      LP = modulo(ASVAL%LP, 360.d0)
+      D = modulo(ASVAL%D, 360.d0)
+      M = modulo(ASVAL%M, 360.d0)
+      MP = modulo(ASVAL%MP, 360.d0)
+      F = modulo(ASVAL%F, 360.d0)
+
+      DPsi = ASVAL%DPsi
+      vareps = ASVAL%vareps
+    end if
+
+    A1 = modulo(A1_DEG(T), 360.d0)
+    A2 = modulo(A2_DEG(T), 360.d0)
+    A3 = modulo(A3_DEG(T), 360.d0)
+    E = E_MUL_COEF(T)
+
+    call MOON_COORDINATES_SUB0(lambda, beta, Delta, LP, D, M, MP, F, E, A1, A2, A3)
+
+    ! PRINT*, "-------- RA & DEC --------"
+    ! Apperent right ascension & declination
+    nutation_mul = 1.d0
+    if (.not. use_nutation) nutation_mul = 0.d0
+
+    call ECLIP2EQ(RA, DEC, lambda + nutation_mul*DPsi, beta, vareps)
+
+    ! Geometric right ascension & declination
+    ! CALL ECLIP2EQ( RA, DEC, lambda, beta, vareps )
+
+  end subroutine MOON_COORDINATES_SUB1
+
+  ! Chaper 47.
+  ! Output:
+  !     lambda = Longtitude (in Degrees)
+  !     beta = Latitude (in Degrees)
+  !     Delta = Distance from the Earth to the Moon (in kilometers)
+  ! Input:
+  !     LP = Moon's mean longitude
+  !     D  = Moon's mean elongation
+  !     M  = Sun's mean anomaly
+  !     MP = Moon's mean anomaly
+  !     F  = Moon's argument of latitude (mean distance of the Moon
+  !          from it ascending node)
+  !     E  = coefficeint for correcting terms containg M
+  !     A1, A2, A3 = coefficeint for additve term accounting
+  !                  action of Venus and Jupiter
+  ! - Don't account for nutation
+  ! - Intended as a lower level subroutine to be called by
+  !   higher level functions and subroutine
+  subroutine MOON_COORDINATES_SUB0(lambda, beta, Delta, LP, D, M, MP, F, E, A1, A2, A3)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+
+    real(8), intent(OUT) :: lambda, beta, Delta
+    real(8), intent(IN) :: LP, D, M, MP, F
+    real(8), intent(IN) :: E, A1, A2, A3
+
+    integer :: I, J
+    real(8) :: suml, sumr, sumb
+    real(8) :: vec(4), argval(NPER), epmul(NPER)
+
+    ! Convert from degree to radian
+    vec = DEG2RAD*(/D, M, MP, F/)
+
+    ! 1. Compute mean longitude !
+    argval = matmul(LONARG, vec)
+    epmul = cal_epmul(LONMEU, E)
+
+    ! sine argument
+    !  \sum l
+    argval = epmul*LON_SIN_COEF*sin(argval)
+    suml = sum(argval) + additive_suml()
+
+    ! 2. Compute distance       !
+    argval = matmul(LONARG, vec)
+
+    ! cosine argument
+    !  \Sum r
+    argval = epmul*LON_COS_COEF*cos(argval)
+    sumr = sum(argval)
+
+    ! 3. Compute mean latitude !
+    argval = matmul(LATARG, vec)
+    epmul = cal_epmul(LATMEU, E)
+
+    ! sine argument
+    !  \Sum b
+    argval = epmul*LAT_SIN_COEF*sin(argval)
+    sumb = sum(argval) + additive_sumb()
+
+    ! output
+    lambda = LP + suml/1.0d6  ! Longitude in Degree
+    beta = sumb/1.d6         ! Lattitude in Degree
+    Delta = 385000.56d0 + sumr/1.0d3  ! Distance in km
+
+  contains
+
+    real(8) function additive_suml() result(asuml)
+      implicit none
+      asuml = 3958.d0*sin(DEG2RAD*A1) &
+              + 1962.d0*sin(DEG2RAD*(LP - F)) &
+              + 318.d0*sin(DEG2RAD*A2)
+    end function additive_suml
+
+    real(8) function additive_sumb() result(asumb)
+      implicit none
+      asumb = -2235.d0*sin(DEG2RAD*LP) &
+              + 382.d0*sin(DEG2RAD*A3) &
+              + 175.d0*sin(DEG2RAD*(A1 - F)) &
+              + 175.d0*sin(DEG2RAD*(A1 + F)) &
+              + 127.d0*sin(DEG2RAD*(LP - MP)) &
+              - 115.d0*sin(DEG2RAD*(LP + MP))
+
+    end function additive_sumb
+
+  end subroutine MOON_COORDINATES_SUB0
+
+end module mod_moon_position

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -172,6 +172,7 @@ Casey 180318: Added NWS=13
 #endif
 !JLW: add subgrid 
       USE subgrid, only: subgridFilename, level0, level1
+      use mod_tidepotential, only: tidePotential, t_tidePotential
 
       IMPLICIT NONE
       INTEGER NIBP,IBN1,IK,NDISC,NBBN,NVEL2
@@ -188,6 +189,17 @@ C
       character(len=100) :: densityRunType ! diagnostic or prognostic
       character(len=100) :: densityDimensions ! 2DDI or 3D
       character(len=100) :: densityForcingType ! sigmaT, salinity, etc
+
+      ! I/O variables for tide potential namelist
+      logical :: UseFullTIPFormula = .false.
+      integer :: TIPOrder = -1
+      character(len=24) :: TIPStartDate = ""
+      character(len=24) :: MoonSunPositionComputeMethod = "JM"
+      character(len=80) :: MoonSunCoordFile = "none"
+      logical :: IncludeNutation = .false.
+      real(8) :: k2Value = 0.302D0
+      real(8) :: h2Value = 0.609D0
+      logical :: UniformResMoonSunTimeData = .false.
 
       CHARACTER(len=1000) namelistSpecifier ! used in log messages
 #if defined CSWAN || defined ADCSWAN
@@ -233,9 +245,28 @@ C.... DMW
 
       NAMELIST /WindGrib2NetCdf/ read_NWS14_NetCdf_using_core_0
 
+C---- DW/AC, for full tidal pontential formula
+C     UseFullTIPFormula = T/F (default F)
+C     TIPOrder = 2 (P2), 3(p3), >= 4(exact)  (default 2)
+C     TIPStartDate = 'BaseDate'/'YYYY-MM-DD HH:SS'
+C     MoonSunPostionMethod = 'JM'/'External' (defaul 'JM') 
+C           'JM' = Jean Meeus's approach 
+C           'External' = User supplied Moon's, Sun's RA, DEC and
+C                        distances 
+C     MoonSunCoordFile = filename of an external file storting the
+C                        coordinates of the Moon and the Sun         
+C     IncludeNutation = T/F , Include/exclude the nutation in JM formula
+C     k2value = Love number
+C     h2value = Love number     
+C     UniformResMoonSunTimeData = T/F, Use uniform resolution time data 
+      NAMELIST /TidalPotentialControl/ UseFullTIPFormula, TIPOrder,
+     &    TIPStartDate, MoonSunPositionComputeMethod, MoonSunCoordFile,
+     &    IncludeNutation, k2Value, h2Value, UniformResMoonSunTimeData
+         
       CHARACTER(len=160) :: origLine     ! raw line of input from fort.15
       CHARACTER(len=200) :: modifiedLine ! converted to namelist
       CHARACTER(len=2000) :: origLineTVW
+      CHARACTER(len=256) :: ios_nml_error_msg
       INTEGER :: commentStart            ! location of fort.15 comment start
       INTEGER :: ios = 0                 ! i/o status of read operation
 
@@ -368,8 +399,8 @@ C...  After this search and read, we will close the file and then reopen it
 c...  for further processing the traditional non-namelist components.
 C...
       namelistSpecifier = 'TimeBathyControl'
-      READ(UNIT = 15,NML = TimeBathyControl,IOSTAT = IOS_NDDT) 
-      call logNamelistReadStatus(namelistSpecifier, ios_nddt)     
+      READ(UNIT = 15,NML = TimeBathyControl,IOSTAT = IOS_NDDT, IOMSG=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios_nddt, ios_nml_error_msg)     
 c     it is possible for the namelist to be present in the file and 
 C     occuring at the end of the file with no line breaks after the 
 C     ending "\" which causes the iostat to return a negative value.
@@ -402,13 +433,13 @@ c     a non-default value we can determine this was the case.
       ! jgf50.60.08: Add a namelist for the user to turn SWAN output
       ! on and off. Similar to tcm's timevaryingbathy namelist.
       namelistSpecifier = 'SWANOutputControl'
-      read(unit=15,nml=SWANOutputControl,iostat=ios)
+      read(unit=15,nml=SWANOutputControl,iostat=ios,iomsg=ios_nml_error_msg)
       IF(IOS.GT.0)THEN
         SWAN_OutputHS=.TRUE.
         SWAN_OutputTPS=.TRUE.
         SWAN_OutputDIR=.TRUE.
       ENDIF
-      call logNamelistReadStatus(namelistSpecifier, ios)     
+      call logNamelistReadStatus(namelistSpecifier, ios, ios_nml_error_msg)
       call logMessage(ECHO,
      &    "The values of SWANOutputControl are as follows:")
       write(scratchMessage,*) "SWAN_OutputHS=",SWAN_OutputHS,
@@ -425,8 +456,8 @@ c     a non-default value we can determine this was the case.
       ! jgf51.42: Add a namelist for the user to control subdomain
       ! modeling.
       namelistSpecifier = 'subdomainModeling'
-      read(unit=15,nml=subdomainModeling,iostat=ios)
-      call logNamelistReadStatus(namelistSpecifier, ios)
+      read(unit=15,nml=subdomainModeling,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios, ios_nml_error_msg)
       write(scratchMessage,*) "subdomainOn=",subdomainOn
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
@@ -434,8 +465,8 @@ c     a non-default value we can determine this was the case.
       ! jgf50.60.13: Add a namelist for the user to control met forcing.
       ! Similar to tcm's timevaryingbathy namelist.
       namelistSpecifier = 'metControl'
-      read(unit=15,nml=metControl,iostat=ios)
-      call logNamelistReadStatus(namelistSpecifier, ios)
+      read(unit=15,nml=metControl,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios, ios_nml_error_msg)
       write(scratchMessage,*) "WindDragLimit=",WindDragLimit,
      & " DragLawString=",DragLawString, " rhoAir=",rhoAir,
      & ' invertedBarometerOnElevationBoundary=',
@@ -448,8 +479,8 @@ c     a non-default value we can determine this was the case.
 #ifdef ADCNETCDF
 Casey 180318: Added NWS=13
       namelistSpecifier = 'owiWindNetcdf'
-      read(unit=15,nml=owiWindNetcdf,iostat=ios)
-      call logNamelistReadStatus(namelistSpecifier, ios)
+      read(unit=15,nml=owiWindNetcdf,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios, ios_nml_error_msg)
       write(scratchMessage,*) "NWS13File=",trim(adjustl(NWS13File)),
      & " NWS13ColdStartString=",trim(adjustl(NWS13ColdStartString)),
      & " NWS13WindMultiplier=",trim(adjustl(NWS13WindMultiplier)),
@@ -461,8 +492,8 @@ Casey 180318: Added NWS=13
 
 #ifdef DATETIME
       namelistSpecifier = 'WindGrib2NetCdf' 
-      read( unit = 15, nml=WindGrib2NetCdf,iostat=ios ) ;
-      call logNamelistReadStatus(namelistSpecifier, ios)
+      read( unit = 15, nml=WindGrib2NetCdf,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios,ios_nml_error_msg)
       write(scratchMessage,*) "NWS 14: use core 0"//
      &   "to read grib2/netcdf data = ",
      &   read_NWS14_NetCdf_using_core_0 
@@ -501,8 +532,8 @@ Casey 180318: Added NWS=13
 
 Casey 121019: Added multiplication factor to be used before sending winds to coupled wave models.
       namelistSpecifier = 'waveCoupling'
-      read(unit=15,nml=waveCoupling,iostat=ios)
-      call logNamelistReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=waveCoupling,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,*) "WaveWindMultiplier=",WaveWindMultiplier
       call logMessage(ECHO,trim(scratchMessage))
 !TCM 2024 -- added wave stress gradient limiter      
@@ -520,8 +551,8 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
       ! tcm v52. added StatPartWetFix and How2FixStatPartWet for handling
       !  station output in partially wet/dry elements for elevation stations
       namelistSpecifier = 'wetDryControl'
-      read(unit=15,nml=wetDryControl,iostat=IOS)
-      call logNameListReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=wetDryControl,iostat=IOS,iomsg=ios_nml_error_msg)
+      call logNameListReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,'(a,l)') "outputNodeCode=",outputNodeCode
       call logMessage(ECHO,trim(scratchMessage))
       write(scratchMessage,'(a,l)') "outputNOFF=",outputNOFF
@@ -549,8 +580,8 @@ C.... DMW
       ! jgf52.08.01: Add a namelist for the user to control
       ! output of detailed inundation data.
       namelistSpecifier = 'inundationOutputControl'
-      READ(UNIT=15,NML=inundationOutputControl,IOSTAT=IOS)
-      call logNamelistReadStatus(namelistSpecifier,ios)
+      READ(UNIT=15,NML=inundationOutputControl,IOSTAT=IOS,IOMSG=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,'(a,l)') "inundationOutput=",inundationOutput
       call logMessage(ECHO,trim(scratchMessage))
       write(scratchMessage,'(a,e15.8)') "inunThresh=",inunThresh
@@ -560,8 +591,8 @@ C.... DMW
 !JLW: adding subgrid namelist variable
       !JLW: adding subgrid name list variable
       namelistSpecifier = 'subgridControl'
-      read(unit=15,nml=subgridControl,iostat=IOS)
-      call logNameListReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=subgridControl,iostat=IOS,iomsg=ios_nml_error_msg)
+      call logNameListReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,*)
      &   "subgridFilename=",TRIM(ADJUSTL(subgridFilename))
       call logMessage(ECHO,trim(scratchMessage))
@@ -583,8 +614,8 @@ c...  for further processing the traditional non-namelist components.
 C...
       namelistSpecifier = 'Smag_Control'
       IOS_Smag = 0
-      READ(UNIT = 15,NML = Smag_Control,IOSTAT = IOS_Smag)
-      call logNamelistReadStatus(namelistSpecifier, ios_Smag)
+      READ(UNIT = 15,NML = Smag_Control,IOSTAT = IOS_Smag,IOMSG=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios_Smag,ios_nml_error_msg)
 c
 c     it is possible for the namelist to be present in the file and
 C     occuring at the end of the file with no line breaks after the
@@ -622,8 +653,8 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       ! jgf: for water level offset
 
       namelistSpecifier = 'dynamicWaterLevelCorrectionControl'
-      read(unit=15,nml=dynamicWaterLevelCorrectionControl,iostat=ios)
-      call logNamelistReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=dynamicWaterLevelCorrectionControl,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,'(a,a)') "dynamicWaterLevelCorrectionFileName=",
      &  trim(dynamicWaterLevelCorrectionFileName)
       write(scratchMessage,'(a,a)') "dynamicWaterLevelCorrectionMethod=",
@@ -666,8 +697,8 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C     Channel wet perimeter for bottom friction 11/06/2023 sb
       namelistSpecifier = 'VEW1DChannelControl'
       activateVEW1DChannelWetPerimeter = .false.
-      READ(UNIT=15,NML=VEW1DChannelControl,IOSTAT=ios)
-      call logNamelistReadStatus(namelistSpecifier, ios)
+      READ(UNIT=15,NML=VEW1DChannelControl,IOSTAT=ios,IOMSG=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios,ios_nml_error_msg)
       write(scratchMessage,'(a,l1)') "activateVEW1DChannelWetPerimeter=",
      &   activateVEW1DChannelWetPerimeter
       call logMessage(ECHO,trim(scratchMessage))
@@ -685,8 +716,8 @@ C     DMW 202401 Add check for velocity warning level
       WarnVel = 100.d0
 C     WJP add namelist
       namelistSpecifier = 'WarnElevControl'
-      read(unit=15,nml=WarnElevControl,iostat=IOS)
-      call logNameListReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=WarnElevControl,iostat=IOS,IOMSG=ios_nml_error_msg)
+      call logNameListReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,'(a,f15.7)') "WarnElev=",WarnElev
       call logMessage(ECHO,trim(scratchMessage))
       write(scratchMessage,'(a,l)') "WarnElevDump=",WarnElevDump
@@ -700,8 +731,8 @@ C     WJP add namelist
 !     WJP add namelist for Ali's dispersion
 !     Defaults are already in global 
       namelistSpecifier = 'AliDispersionControl'
-      read(unit=15,nml=AliDispersionControl,iostat=IOS)
-      call logNameListReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=AliDispersionControl,iostat=IOS,iomsg=ios_nml_error_msg)
+      call logNameListReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
 !     Process the speed of sound squared
       if (Cs.le.0.0D0) then
          Cs2 = huge(0.0D0)
@@ -728,8 +759,8 @@ C     WJP add namelist
       densityTimeIterator = 1;
 !     read the namelist
       namelistSpecifier = 'densityControl'
-      read(unit=15,nml=densityControl,iostat=IOS)
-      call logNameListReadStatus(namelistSpecifier,ios)
+      read(unit=15,nml=densityControl,iostat=IOS,iomsg=ios_nml_error_msg)
+      call logNameListReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
       write(scratchMessage,'(a,a)') "densityRunType=",
      &      trim(densityRunType)
       call logMessage(ECHO,trim(scratchMessage))
@@ -774,8 +805,32 @@ C     WJP add namelist
 !     Make sure to include the sign
       IDEN = IDEN*IDENsign
       if (IDEN.ne.0) CBaroclinic = .true.
+
 C...
 
+      namelistSpecifier = 'TidalPotentialControl'
+      read(unit=15,nml=TidalPotentialControl,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier,ios,ios_nml_error_msg)
+      write(scratchMessage,*) "USeFullTIPFormula=", UseFullTIPFormula
+      call logMessage(ECHO,trim(scratchMessage)) 
+      write(scratchMessage,*)"TIPOrder=", TIPOrder 
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "TIPStartDate=", trim(TIPStartDate)
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*)"MoonSunPositionComputeMethod=",
+     &                        trim(MoonSunPositionComputeMethod)
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "MoonSunCoordFile=", trim(MoonSunCoordFile)
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "IncludeNutation=", IncludeNutation
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "k2Value=", k2Value
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "h2Value=", h2Value
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "UniformResMoonSunTimeData=",UniformResMoonSunTimeData
+      call logMessage(ECHO,trim(scratchMessage))
+      rewind(15)
 
 C...
 C...  INPUT FROM UNIT 15 AND OUTPUT TO UNIT 16 RUN DESCRIPTION AND RUN
@@ -5026,6 +5081,27 @@ C
 #endif
       ENDIF
 
+      ! Check if we have been provided a base date for the tide potential calculations
+      if(UseFullTIPFormula.and.trim(TipStartDate)=="none")then
+         if(useNetCDF)then
+            TipStartDate = trim(base_date)
+            WRITE(scratchMessage,'(2A)') "The TipStartDate parameter was not set in the TidalPotentialControl namelist."//
+     &                                   " Using the base_date netCDF metadata value instead: ", TipStartDate
+            call allMessage(WARNING,scratchMessage)
+         else
+            scratchMessage = "The TipStartDate parameter must be set either in the netCDF metadata "//
+     &                       "or the tide potential namelist."
+            call allMessage(ERROR,scratchMessage)
+            call adcirc_terminate()
+         endif
+      endif
+
+      ! Initialize the tidal potential calculation
+      tidePotential = t_tidePotential(np, rnday, UseFullTIPFormula,
+     &                                TIPOrder, TIPStartDate,  
+     &                                MoonSunPositionComputeMethod, 
+     &                                MoonSunCoordFile, IncludeNutation, 
+     &                                k2Value, h2Value)
 C...
 C...  CLOSE FORT.15
 C...
@@ -6520,12 +6596,13 @@ C-----------------------------------------------------------------------
 C     jgf52.08.02: Record the i/o status associated with reading the
 C     namelist using the negative, zero, or positive value of ios.
 C-----------------------------------------------------------------------
-      subroutine logNamelistReadStatus(nmlname, ios)
+      subroutine logNamelistReadStatus(nmlname, ios, msg)
       use global, only : logMessage, scratchMessage, DEBUG, ECHO, INFO,
      &   WARNING, ERROR, setMessageSource, unsetMessageSource,
      &   allMessage
       implicit none
-      character(len=1000), intent(in) :: nmlname
+      character(len=*), intent(in) :: nmlname
+      character(len=*), intent(in) :: msg
       integer, intent(in) :: ios
 
       call setMessageSource("logNameListReadStatus")
@@ -6545,11 +6622,13 @@ C-----------------------------------------------------------------------
          call logMessage(INFO,
      &      'The '//trim(nmlName)//' namelist was found.')
       ! positive values indicate some sort of i/o error, other than
-      ! reaching the end-file before finding the namelist
+      ! reaching the end-file before finding the namselist
       case(1:)
          write(scratchMessage,'(a,i0,a)')
      &      'Could not read '//trim(nmlName)//
      &     ' namelist. The Fortran i/o error code was ',ios,'.'
+         call allMessage(ERROR,scratchMessage)
+         write(scratchMessage, '(a,a)') "Error Message: ", trim(msg)
          call allMessage(ERROR,scratchMessage)
       end select
 

--- a/src/sun.F90
+++ b/src/sun.F90
@@ -1,0 +1,245 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+module mod_sun_coordinates
+
+  use mod_astronomic, only: t_astronomic_values
+
+  implicit none
+
+  interface SUN_COORDINATES
+    module procedure SUN_COORDINATES_SUB0, SUN_COORDINATES_SUB1
+  end interface SUN_COORDINATES
+
+  private :: SUN_COORDINATES_SUB0, SUN_COORDINATES_SUB1, &
+             SUN_CENTER, SUN_LON, SUN_NU, SUN_RADIUS, &
+             SOLAR_DEC, SOLAR_RA
+
+contains
+
+  ! Sun's equation of the center. Page 164
+  !  T - Julain centuries of 36525 ephemeris from epoch J2000
+  !  M - The mean anomaly of the sun
+  real(8) elemental function SUN_CENTER(T, M) result(C)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+    real(8), intent(IN) :: T, M
+    real(8) :: M_R
+
+    M_R = M*DEG2RAD
+
+    C = (1.914602d0 + T*(-0.004817d0 - 0.000014d0*T))*sin(M_R) + &
+        (0.019993d0 - 0.000101d0*T)*sin(2.d0*M_R) + &
+        0.000289d0*sin(3.d0*M_R)
+
+  end function SUN_CENTER
+
+  ! The Sun's true longitude. Page 164.
+  !  L0 = the geometric mean longitude of the Sun
+  !  C  = the Sun's eq1.495978707×1011uation of the center
+  !  Dpsi (optional) = nutation
+  real(8) elemental function SUN_LON(C, L0, DPsi) result(SLON)
+    implicit none
+    real(8), intent(IN) :: L0, C
+    real(8), optional, intent(IN) :: Dpsi
+
+    SLON = L0 + C    ! Sun's true longtiude
+
+    if (present(DPsi)) then
+      SLON = SLON - 0.00569 + Dpsi
+    end if
+  end function SUN_LON
+
+  ! True anomaly of the Sun longitude. Page 164.
+  !  M  = the mean anomaly of the Sun
+  !  C  = the Sun's equation of the center
+  real(8) elemental function SUN_NU(M, C) result(nu)
+    implicit none
+    real(8), intent(IN) :: M, C
+    nu = M + C     ! its true anomerly
+  end function SUN_NU
+
+  ! The Sun's radius. Disance bewteen the centers of the Sub and
+  ! the Earth in astronomical units
+  !   nu = True anomaly of the Sun's true longitude
+  !   eccen = eccentricity of the Earth's orbit
+  real(8) elemental function SUN_RADIUS(nu, eccen) result(R)
+    use ADC_CONSTANTS, only: DEG2RAD
+    implicit none
+    real(8), intent(IN) :: nu, eccen
+    real(8) :: NUM, DEN, nu_rad
+
+    nu_rad = nu*DEG2RAD
+
+    DEN = 1.d0 + eccen*cos(nu_rad)
+    NUM = 1.000001018d0*(1.d0 - eccen*eccen)
+
+    R = NUM/DEN
+
+  end function SUN_RADIUS
+
+  ! Solar's declination. Page 165.
+  !  - SLON = the Sun's longtitude
+  !  - VarEps = the obliquity of the ecliptic
+  real(8) elemental function SOLAR_DEC(SLON, VarEps) result(DEC)
+    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
+    implicit none
+
+    real(8), intent(IN) :: SLON, VarEps
+
+    real(8) :: SLON_RAD, VarEps_RAD
+
+    SLON_RAD = SLON*DEG2RAD
+    VarEps_RAD = VarEps*DEG2RAD
+
+    DEC = sin(SLON_RAD)*sin(VarEps_RAD)
+
+    DEC = asin(DEC)*RAD2DEG
+  end function SOLAR_DEC
+
+  ! Solar's right ascension. Page 165.
+  !  - SLON = the Sun's longtitude
+  !  - VarEps = the obliquity of the ecliptic
+  real(8) elemental function SOLAR_RA(SLON, VarEps) result(RA)
+    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
+    implicit none
+
+    real(8), intent(IN) :: SLON, VarEps
+
+    real(8) :: NUM, DEN
+    real(8) :: SLON_RAD, VarEps_RAD
+
+    SLON_RAD = SLON*DEG2RAD
+    VarEps_RAD = VarEps*DEG2RAD
+
+    NUM = cos(VarEps_RAD)*sin(SLON_RAD)
+    DEN = cos(SLON_RAD)
+
+    RA = mod(atan2(NUM, DEN)*RAD2DEG, 360.d0)
+  end function SOLAR_RA
+
+  !
+  ! Chapter 25. Solar coordinates. Page. 163-169
+  ! Sun's coordinates.
+  ! INPUT:
+  !   RA  - Sun's right ascension (Degrees)
+  !   DEC - Sun's declination (degrees)
+  !   Delta  - Distance between the Earth and the Sun
+  ! OUTPUT:
+  !   JD - Julain days
+  !   ASVAL  (optional) - derived data type storing precomputed
+  !                       values for the moon orbit at the time JD
+  subroutine SUN_COORDINATES_SUB1(RA, DEC, Delta, JD, ASVAL, NUTATION)
+    use mod_astronomic, only: JULIAN_CENTURIES, M_DEG, LP_DEG, OMEGA_DEG, &
+                              eccentricity_earth_orbit, L0_DEG, DeltaPsiL, &
+                              DeltaVarepsL, varepsilon0_ecliptic, ECLIP2EQ
+    implicit none
+
+    real(8), intent(OUT) :: RA, DEC, Delta
+
+    real(8), intent(IN) :: JD
+    type(t_astronomic_values), optional, intent(IN) :: ASVAL
+    logical, optional :: NUTATION
+
+    real(8) :: lambda, beta, T, LP, OG, L0, M, C, snu, eccen
+    real(8) :: DPsi, vareps0, DVareps, vareps
+    logical :: have_asval = .false., use_nutation = .true.
+
+    if (present(ASVAL)) then
+      if (abs(ASVAL%JD - JD) < 1.0e-9) then
+        have_asval = .true.
+      end if
+    end if
+
+    if (present(NUTATION)) then
+      use_nutation = NUTATION
+    end if
+
+    if (.not. have_asval) then
+      T = JULIAN_CENTURIES(JD)
+      M = modulo(M_DEG(T), 360.d0)
+      LP = modulo(LP_DEG(T), 360.d0)
+      eccen = eccentricity_earth_orbit(T)
+
+      OG = modulo(OMEGA_DEG(T), 360.d0)
+      L0 = modulo(L0_DEG(T), 360.d0)
+      DPsi = DeltaPsiL(OG, L0, LP)
+      DVareps = DeltaVarepsL(OG, L0, LP)
+
+      vareps0 = varepsilon0_ecliptic(T)
+      vareps = vareps0 + Dvareps
+    else
+      T = ASVAL%T
+      M = modulo(ASVAL%M, 360.d0)
+      L0 = modulo(ASVAL%L0, 360.d0)
+      eccen = ASVAL%eccen
+      DPsi = ASVAL%DPsi
+      vareps = ASVAL%vareps
+    end if
+    C = SUN_CENTER(T, M)
+
+    if (use_nutation) then
+      call SUN_COORDINATES_SUB0(lambda, beta, Delta, L0, M, eccen, C, DPsi)
+    else
+      call SUN_COORDINATES_SUB0(lambda, beta, Delta, L0, M, eccen, C)
+    end if
+
+    ! Apperent right ascension & declination
+    call ECLIP2EQ(RA, DEC, lambda, beta, vareps)
+
+  end subroutine SUN_COORDINATES_SUB1
+
+  !
+  ! Chapter 25. Solar coordinates. Page. 163-169
+  ! Sun's coordinates.
+  ! INPUT:
+  !   lambda - Sun's longtitude in ecliptic
+  !   beta   - Sun's latitude (degrees)
+  !   Delta  - Distance between the Earth and the Sun
+  ! OUTPUT:
+  !   L0 - Mean longitude of the Sun
+  !   M  - Mean anomaly of the Sun
+  !   C  -  The Sun's equation of the center
+  !   eccen - The eccentricity of the Earth's orbit
+  !   DPsi (optional) -  The nutation in longitude.
+  !                      If present, lambda is the
+  !                      aparent lon.
+  subroutine SUN_COORDINATES_SUB0(lambda, beta, Delta, L0, M, eccen, C, DPsi)
+    implicit none
+
+    real(8), intent(OUT) :: lambda, beta, Delta
+    real(8), intent(IN) :: L0, M, C, eccen
+    real(8), optional, intent(IN) :: DPsi
+
+    real(8) :: snu
+
+    beta = 0.d0
+    if (.not. present(DPsi)) then
+      lambda = SUN_LON(C, L0)
+    else
+      lambda = SUN_LON(C, L0, DPsi)
+    end if
+
+    snu = SUN_NU(M, C)
+    Delta = SUN_RADIUS(snu, eccen)  ! Distance between centers
+    ! of the Earth and Sun
+    return
+  end subroutine SUN_COORDINATES_SUB0
+
+end module mod_sun_coordinates

--- a/src/sun_moon_system.F90
+++ b/src/sun_moon_system.F90
@@ -1,0 +1,93 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+! Driver subroutine
+module mod_moon_sun_coors
+  use mod_astronomic, only: t_astronomic_values
+
+  implicit none
+
+  type t_moon_sun
+    logical, private :: include_nutation = .true.
+    type(t_astronomic_values) :: astronomic_values
+  contains
+    procedure, public, pass(self) :: set_nutation
+    procedure, public, pass(self) :: heavenly_objs_coords_jm
+    procedure, public, pass(self) :: gmst_deg_fn
+  end type t_moon_sun
+
+  private :: set_nutation, heavenly_objs_coords_jm, gmst_deg_fn
+
+contains
+
+  subroutine set_nutation(self, nutation)
+    implicit none
+    class(t_moon_sun), intent(inout) :: self
+    logical, intent(in) :: NUTATION
+    self%INCLUDE_NUTATION = NUTATION
+  end subroutine set_nutation
+
+  !
+  ! Compute the geocentric coodinates of the Moon, Sun
+  !
+  ! Output:
+  !   MOON_POS = Moon coordinates and distance
+  !            = (/ RA, DEC, Delta /)
+  !   SUN_POS  = Sun coordinates and distance
+  !            = (/ RA, DEC, Delta /)
+  ! Input:
+  !   JD = Julian days
+  !
+  ! NOTE:
+  !   - By default, the nutation is accounted for and tthe output
+  !     coodinates are the apparent coordinates.
+  !
+  !   - To ignore the nutation and get the geometrical
+  !     coordinates, call the subroutine
+  !
+  !         CALL SET_NUTATION( .FALSE. )
+  !
+  !     prior to the use of this subroutine.
+  !
+  subroutine HEAVENLY_OBJS_COORDS_JM(self, MOON_POS, SUN_POS, JD, IERR)
+    use mod_moon_position, only: MOON_COORDINATES
+    use mod_sun_coordinates, only: SUN_COORDINATES
+    implicit none
+    class(t_moon_sun), intent(inout) :: self
+    real(8), intent(IN) :: JD
+    real(8), intent(OUT) :: MOON_POS(3), SUN_POS(3)
+    integer, intent(OUT) :: IERR
+    type(t_astronomic_values) :: astronomic_values
+
+    call self%astronomic_values%compute_astronomic_values(JD)
+    call MOON_COORDINATES(MOON_POS(1), MOON_POS(2), MOON_POS(3), JD, self%astronomic_values, self%INCLUDE_NUTATION)
+    call SUN_COORDINATES(SUN_POS(1), SUN_POS(2), SUN_POS(3), JD, self%astronomic_values, self%INCLUDE_NUTATION)
+
+    IERR = 0
+  end subroutine HEAVENLY_OBJS_COORDS_JM
+
+  real(8) function GMST_DEG_FN(self, JDE) result(GMST)
+    use mod_astronomic, only: GMST_DEG
+    implicit none
+    class(t_moon_sun), intent(IN) :: self
+    real(8), intent(IN) :: JDE
+    gmst = GMST_DEG(JDE, self%INCLUDE_NUTATION, self%astronomic_values)
+  end function GMST_DEG_FN
+
+end module mod_moon_sun_coors

--- a/src/tidalpotential.F90
+++ b/src/tidalpotential.F90
@@ -1,0 +1,586 @@
+!-------------------------------------------------------------------------------!
+!
+! ADCIRC - The ADvanced CIRCulation model
+! Copyright (C) 1994-2023 R.A. Luettich, Jr., J.J. Westerink
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!-------------------------------------------------------------------------------!
+!
+! Fortran module for computing the full luna-solar equilibrium tides of
+! different orders of approximation,
+!
+! Ref:
+!   J,-M. Hervouet, Free surface flows: modelling with the finite
+!      element method. John Wiley & Sons, Ltd, 2007
+!
+!   Z. Kowalik and J. L. Luick, Modern theory and practice of tide
+!      analysis and tidal power, Austides consulting, 2019
+!      https://austides.com/downloads/
+!
+! DW/AC, 2024
+!
+module mod_tidepotential
+  use mod_astronomic, only: MassRatioSunEarth, MassRatioMoonEarth, EarthRadiusAU, EarthRadiuskm
+  use mod_moon_sun_coors, only: t_moon_sun
+  use mod_ephemerides, only: t_ephemerides
+  implicit none
+  !
+  !  UseFullTIPFormula = T/F (default F)
+  !  TIPOrder = 2 (P2), 3(p3), >= 4(exact)  (default 2)
+  !  TIPStartDate = 'BaseDate'/'YYYY-MM-DD HH:mm:SS'
+  !  MoonSunPostionMethod = 'JM'/'External' (defaul 'JM')
+  !           'JM' = Jean Meeus's approach
+  !           'External' = User supplied epherides (Moon's, Sun's RA, DEC and
+  !                        distances)
+  !  MoonSunCoordFile = filename of an external file storting the
+  !                        coordinates of the Moon and the Sun
+  !  UniformResMoonSunTimeData = T/F (deafult F). Logical flag
+  !                indicating the time intervals of the MoonSunCoordFile.
+  !                T = Uniform interval (locating the intervals
+  !                    from which the Moon/Sun coordinates are
+  !                    interpolate is trivial).
+  !                F = non uniform interval (using a binary search
+  !                    to locate the intervals from which the
+  !                    Moon/Sun coordiantes are interpolated).
+  !  IncludeNutation = T/F, Include/exclude the nutation in JM formula
+  !  k2value = Love number
+  !  h2value = Love number
+  !
+  real(8), private, parameter :: massratio(2) = (/MassRatioMoonEarth, MassRatioSunEarth/)
+  real(8), private, parameter :: significant_radiusearth(2) = (/EarthRadiuskm(1), EarthRadiusAu(1)/)
+  real(8), private, parameter :: exponent_radiusearth(2) = (/EarthRadiuskm(2), EarthRadiusAu(2)/)
+
+  integer, private, parameter :: ComputeMethod_FT = 0
+  integer, private, parameter :: ComputeMethod_JM = 1
+  integer, private, parameter :: ComputeMethod_External = 2
+
+  type t_tidePotential
+    private
+    logical :: m_UseFullTIPFormula = .false.
+    integer :: m_TIPOrder = 2
+    character(LEN=24) :: m_TIPStartDate = 'Basedate'
+    integer :: m_MoonSunPositionComputeMethod = ComputeMethod_JM
+    logical :: m_UniformResMoonSunTimeData = .false.
+    logical :: m_IncludeNutation = .true.
+    real(8) :: m_k2value = 0.302d0
+    real(8) :: m_h2value = 0.609d0
+    real(8) :: m_JDE_BEG
+    real(8) :: m_JDE_CURRENT
+    real(8), dimension(:), allocatable :: m_AH
+    real(8), dimension(:), allocatable :: m_cosZA
+    real(8), dimension(:), allocatable :: m_workarr
+    real(8), dimension(:), allocatable :: m_workarr1
+    real(8), dimension(:), allocatable :: m_CSFEA
+    real(8), dimension(:), allocatable :: m_SSFEA
+    real(8), dimension(:), allocatable :: m_S2SFEA
+    type(t_moon_sun) :: m_moon_sun_position
+    type(t_ephemerides) :: m_ephemerides
+
+  contains
+    procedure, pass(self), public :: compute => compute_full_tip
+    procedure, pass(self), public :: active => useFullTIPFormula
+    procedure, pass(self), private :: COMP_FULL_TIP_SUB0
+    procedure, pass(self), private :: init => tidalPotentialConstructor
+    procedure, pass(self), private :: init_full_tip
+  end type t_tidePotential
+
+  interface t_tidePotential
+    module procedure createTidalPotential
+  end interface t_tidePotential
+
+  type(t_tidePotential), public :: tidePotential
+
+  private :: AINTPOWER, COMP_FULL_TIP_SUB0, compute_full_tip, &
+             INIT_FULL_TIP, StringUpper, tidalPotentialConstructor, &
+             useFullTIPFormula
+
+contains
+
+  !> @brief Initializes a tidal potential object with the given parameters.
+  !>
+  !> This subroutine constructs a tidal potential object and initializes its member variables
+  !> with the provided input parameters.
+  !>
+  !> @param self The tidal potential object to be initialized.
+  !> @param np The number of points in the computational grid.
+  !> @param rnday The number of days in the simulation
+  !> @param in_UseFullTIPFormula A logical value indicating whether to use the full TIP formula.
+  !> @param in_TIPOrder The order of the TIP formula.
+  !> @param in_TIPStartDate The start date for the TIP calculations.
+  !> @param in_MoonSunPositionComputeMethod The method used to compute the positions of the Moon and Sun.
+  !> @param in_MoonSunCoordFile The file containing the coordinates of the Moon and Sun.
+  !> @param in_IncludeNutation A logical value indicating whether to include nutation in the calculations.
+  !> @param in_k2value The k2 love number used in the TIP calculations.
+  !> @param in_h2value The h2 love number used in the TIP calculations.
+  !>
+  !> @note This subroutine initializes the tidal potential object by setting its member variables
+  !>       with the provided input parameters. It also calls the INIT_FULL_TIP subroutine to initialize
+  !>       the full TIP calculations and creates an ephemri object for computing the positions of the
+  !>       Moon and Sun from an external file.
+  !>
+  subroutine tidalPotentialConstructor(self, np, rnday, in_UseFullTIPFormula, in_TIPOrder, in_TIPStartDate, &
+                                       in_MoonSunPositionComputeMethod, in_MoonSunCoordFile, &
+                                       in_IncludeNutation, in_k2value, in_h2value)
+    use global, only: allMessage, WARNING
+    implicit none
+
+    class(t_tidePotential), intent(INOUT) :: self
+    integer, intent(IN) :: np
+    real(8), intent(IN) :: rnday
+    logical, intent(IN) :: in_UseFullTIPFormula
+    integer, intent(IN) :: in_TIPOrder
+    character(LEN=*), intent(IN) :: in_TIPStartDate
+    character(LEN=*), intent(IN) :: in_MoonSunPositionComputeMethod
+    character(LEN=*), intent(IN) :: in_MoonSunCoordFile
+    logical, intent(IN) :: in_IncludeNutation
+    real(8), intent(IN) :: in_k2value, in_h2value
+    character(len=len_trim(in_MoonSunPositionComputeMethod)) :: moonSunPositionString
+
+    self%m_UseFullTIPFormula = in_UseFullTIPFormula
+
+    if (.not. self%m_UseFullTIPFormula) return
+
+    self%m_TIPOrder = in_TIPOrder
+    self%m_TIPStartDate = in_TIPStartDate
+    self%m_IncludeNutation = in_IncludeNutation
+    self%m_k2value = in_k2value
+    self%m_h2value = in_h2value
+
+    moonSunPositionString = StringUpper(in_MoonSunPositionComputeMethod)
+    if (trim(adjustl(in_MoonSunPositionComputeMethod)) == 'JM') then
+      self%m_MoonSunPositionComputeMethod = ComputeMethod_JM
+    elseif (trim(adjustl(in_MoonSunPositionComputeMethod)) == 'EXTERNAL') then
+      self%m_MoonSunPositionComputeMethod = ComputeMethod_External
+    else
+      call allMessage(WARNING, "Invalid MoonSunPositionComputeMethod: "//trim(adjustl(in_MoonSunPositionComputeMethod)))
+      call allMessage(WARNING, "Defaulting to JM")
+      self%m_MoonSunPositionComputeMethod = ComputeMethod_JM
+    end if
+
+    call self%INIT_FULL_TIP(np)
+
+    if (self%m_MoonSunPositionComputeMethod == ComputeMethod_External) then
+      self%m_ephemerides = t_ephemerides(rnday, in_moonsuncoordfile)
+    end if
+
+  end subroutine tidalPotentialConstructor
+
+  !> @brief Creates a tidal potential object.
+  !>
+  !> @param np Number of processors.
+  !> @param in_rnday Number of days in the tidal potential record.
+  !> @param in_UseFullTIPFormula Flag indicating whether to use the full Tidal Inverse Problem (TIP) formula.
+  !> @param in_TIPOrder Order of the TIP formula.
+  !> @param in_TIPStartDate Start date of the TIP formula.
+  !> @param in_MoonSunPositionComputeMethod Method for computing the positions of the Moon and Sun.
+  !> @param in_MoonSunCoordFile File containing the coordinates of the Moon and Sun.
+  !> @param in_IncludeNutation Flag indicating whether to include nutation in the tidal potential calculations.
+  !> @param in_k2value Value of the k2 Love number.
+  !> @param in_h2value Value of the h2 Love number.
+  !>
+  !> @return tp Tidal potential object.
+  type(t_tidePotential) function createTidalPotential(np, in_rnday, in_UseFullTIPFormula, in_TIPOrder, in_TIPStartDate, &
+                                                      in_MoonSunPositionComputeMethod, in_MoonSunCoordFile, &
+                                                      in_IncludeNutation, in_k2value, in_h2value) result(tp)
+    implicit none
+
+    integer, intent(IN) :: np
+    real(8), intent(IN) :: in_rnday
+    logical, intent(IN) :: in_UseFullTIPFormula
+    integer, intent(IN) :: in_TIPOrder
+    character(LEN=*), intent(IN) :: in_TIPStartDate
+    character(LEN=*), intent(IN) :: in_MoonSunPositionComputeMethod
+    character(LEN=*), intent(IN) :: in_MoonSunCoordFile
+    logical, intent(IN) :: in_IncludeNutation
+    real(8), intent(IN) :: in_k2value, in_h2value
+
+    call tp%init(np, in_rnday, in_UseFullTIPFormula, in_TIPOrder, in_TIPStartDate, &
+                 in_MoonSunPositionComputeMethod, in_MoonSunCoordFile, &
+                 in_IncludeNutation, in_k2value, in_h2value)
+
+  end function createTidalPotential
+
+  !> @brief Returns the value of the UseFullTIPFormula flag.
+  !> @param self The tidal potential object.
+  !> @return The value of the UseFullTIPFormula flag. (Used in self%active)
+  logical function useFullTIPFormula(self)
+    class(t_tidePotential), intent(IN) :: self
+    useFullTIPFormula = self%m_UseFullTIPFormula
+  end function useFullTIPFormula
+
+  ! subroutine computing the tidal potential. It is a private
+  ! subroutine called by the higher level subroutines
+  function COMP_FULL_TIP_SUB0(self, tocgmst, np, slam, MoonSunCoor) result(tipval)
+    use ADC_CONSTANTS, only: sec2day, DEG2RAD, RAD2DEG
+    use mod_astronomic, only: EarthRadiusm
+    implicit none
+
+    class(t_tidePotential), intent(INOUT) :: self
+    integer, intent(IN) :: np
+    real(8), intent(IN) :: tocgmst      ! Time in seconds since TIPStartDate !
+    real(8), intent(IN) :: MoonSunCoor(3, 2)
+    real(8), intent(IN) :: SLAM(:)
+
+    integer :: IOBJ, iexp
+    real(8) :: RA, DEC, DELTA
+    real(8) :: radius_div_Delta, KP, C0
+
+    real(8) :: TIPVAL(np)
+
+    TIPVAL = 0.d0
+    do IOBJ = 1, 2
+      ! Hour angle !
+      self%m_AH = DEG2RAD*tocgmst + SLAM - MoonSunCoor(1, IOBJ)
+      ! AH = modulo( tocgmst + SLAM*RAD2DEG, 360.D0 )*DEG2RAD -  MoonSunCoor(1,IOBJ)
+      RA = MoonSunCoor(1, IOBJ)  ! right ascendsion
+      DEC = MoonSunCoor(2, IOBJ)  ! declination
+      DELTA = MoonSunCoor(3, IOBJ)  ! distance (km for the Moon,
+      ! AU for the sun
+
+      ! Ratio of the radius of the earth and the Moon/Sun
+      radius_div_delta = significant_radiusearth(IOBJ)/DELTA
+      radius_div_delta = radius_div_delta*exponent_radiusearth(IOBJ)
+
+      !c cosZA = cos( Z )
+      self%m_cosZA = self%m_SSFEA*sin(DEC)
+      self%m_cosZA = self%m_cosZA + self%m_CSFEA*cos(DEC)*cos(self%m_AH)
+
+      select case (self%m_TIPOrder)
+      case (2, 3)
+        ! P2  term. Degree 2 or 3 tidal potential !
+        self%m_workarr = 3.d0*self%m_cosZA*self%m_cosZA
+        self%m_workarr = self%m_workarr - 1.d0
+        self%m_workarr = 0.5d0*self%m_workarr
+
+        KP = AINTPOWER(radius_div_delta, 3)
+        KP = KP*EarthRadiusm(1)*EarthRadiusm(2)
+        KP = KP*massratio(IOBJ)
+
+        TIPVAL = TIPVAL + KP*self%m_workarr
+
+        ! if include P3 term
+        if (self%m_TIPOrder == 3) then
+          self%m_workarr = 5.d0*self%m_cosZA*self%m_cosZA*self%m_cosZA
+          self%m_workarr = self%m_workarr - 3.d0*self%m_cosZA
+          self%m_workarr = 0.5d0*self%m_workarr
+
+          KP = AINTPOWER(radius_div_delta, 4)
+          KP = KP*EarthRadiusm(1)*EarthRadiusm(2)
+          KP = KP*massratio(IOBJ)
+          ! Offset values is zero for this term c!
+
+          TIPVAL = TIPVAL + KP*self%m_workarr
+        end if
+      case (22)
+        !   P2 - Only dirunal + semi-dirunal. A special case of
+        !   the degree 2 tidal potential,
+        !
+        ! Dirunal
+        self%m_workarr = (3.d0/4.d0)*self%m_S2SFEA*sin(2.d0*DEC)*cos(self%m_AH)
+
+        ! Semi-Diurnal
+        self%m_workarr1 = self%m_CSFEA
+        self%m_workarr = self%m_workarr + (3.d0/4.d0)*self%m_workarr1*self%m_workarr1*cos(DEC)*cos(DEC)*cos(2.d0*self%m_AH)
+
+        KP = AINTPOWER(radius_div_delta, 3)
+        KP = KP*EarthRadiusm(1)*EarthRadiusm(2)
+        KP = KP*massratio(IOBJ)
+
+        TIPVAL = TIPVAL + KP*self%m_workarr
+      case DEFAULT
+        ! Exact form without any truncation !
+        self%m_workarr = 1.d0 + AINTPOWER(radius_div_delta, 2)
+        self%m_workarr = self%m_workarr - 2.d0*radius_div_delta*self%m_cosZA
+
+        self%m_workarr = sqrt(self%m_workarr)
+        self%m_workarr = 1.d0/self%m_workarr
+
+        self%m_workarr = self%m_workarr - radius_div_delta*self%m_cosZA
+
+        ! Offset value, use Proudman's approach, see Kowalik,
+        ! page 14.
+        C0 = 1.d0 + AINTPOWER(radius_div_delta, 2)
+        C0 = sqrt(C0 + 2.d0*radius_div_delta) - &
+             sqrt(C0 - 2.d0*radius_div_delta)
+        C0 = -0.5d0*C0/radius_div_delta
+
+        ! NOTE:
+        ! The constant of integration C0 equals to
+        !
+        ! C0 = -1/2*(1/e)*(sqrt(1 + e**2  + 2*e) - sqrt(1 + e**2 - 2*e))
+        ! e =  a/r = radius_div_delta
+        !
+        ! For radius_div_delta (a/r) << 1, it can be shown
+        ! through the use of the Taylor series that
+        !
+        !    sqrt(1 + (a/r)^2 + 2*(a/r)) \sim  1 + (a/r) + High order terms
+        !    sqrt(1 + (a/r)^2 + 2*(a/r)) \sim  1 - (a/r) + High order terms
+        !
+        ! As a result, a good approximate value of the offset is
+        !
+        !    C0 \sim -1
+        !
+        self%m_workarr = self%m_workarr + C0
+
+        KP = AINTPOWER(radius_div_delta, 1)
+        KP = KP*EarthRadiusm(1)*EarthRadiusm(2)
+        KP = KP*massratio(IOBJ)
+
+        TIPVAL = TIPVAL + KP*self%m_workarr
+      end select
+    end do
+
+    TIPVAL = (1.d0 + self%m_k2value - self%m_h2value)*TIPVAL
+
+  end function COMP_FULL_TIP_SUB0
+
+  function compute_full_tip(self, TimeLoc, NP, SLAM) result(tip)
+    use ADC_CONSTANTS, only: sec2day, DEG2RAD
+    use global, only: setMessageSource, unsetMessageSource, allMessage, DEBUG
+    use mod_ephemerides, only: HEAVENLY_OBJS_COORDS_FROM_TABLE
+    implicit none
+
+    class(t_tidePotential), intent(INOUT) :: self
+    real(8), intent(IN) :: TimeLoc  ! Time in seconds since TIPStartDate !
+    integer, intent(IN) :: NP
+    real(8), intent(IN), dimension(:) :: SLAM
+    real(8) :: tip(np)
+
+    ! local !
+    real(8) :: JDELoc, tocgmst
+    real(8) :: MoonSunCoor(3, 2)
+    integer :: IERR
+
+    call setMessageSource("comp_full_tip")
+#if defined(ALL_TRACE)
+    call allMessage(DEBUG, "Enter.")
+#endif
+
+    ! Julian day
+    JDELoc = self%m_JDE_BEG + TimeLoc*sec2day
+
+    ! Compute the postions of the Moon and Sun !
+    if (self%m_MoonSunPositionComputeMethod == ComputeMethod_JM) then
+      ! use algorithms in Jean Meeus's book !
+      call self%m_moon_sun_position%HEAVENLY_OBJS_COORDS_JM(MoonSunCoor(:, 1), MoonSunCoor(:, 2), JDELoc, IERR)
+    elseif (self%m_MoonSunPositionComputeMethod == ComputeMethod_External) then
+      ! interpolate from an external look up table !
+      call self%m_ephemerides%HEAVENLY_OBJS_COORDS_FROM_TABLE(MoonSunCoor, JDELoc, IERR, self%m_UniformResMoonSunTimeData)
+    else
+      IERR = 1
+    end if
+    call check_tip_err(IERR)
+
+    ! Convert RA, DEC from deg --> rad
+    MoonSunCoor(1:2, :) = MoonSunCoor(1:2, :)*DEG2RAD
+
+    ! Sidereal time at Greenwich !
+    tocgmst = self%m_moon_sun_position%GMST_DEG_FN(JDELoc)
+
+    tip = self%COMP_FULL_TIP_SUB0(tocgmst, np, slam, MoonSunCoor)
+
+#if defined(ALL_TRACE)
+    call allMessage(DEBUG, "Return.")
+#endif
+    call unsetMessageSource()
+
+  end function compute_full_tip
+
+  subroutine check_tip_err(IERR)
+    use global, only: screenMessage, ERROR
+    implicit none
+    integer, intent(IN) :: IERR
+
+    if (IERR > 1) then
+      select case (IERR)
+      case (1)
+        call screenMessage(ERROR, "Error in the calculation"// &
+                           " the postion of the Moon and Sun. ADCIRC is not "// &
+                           " built with the -DADCNETCDF flag.")
+      case (2)
+        call screenMessage(ERROR, "Error in the calculation"// &
+                           " the postion of the Moon and Sun. Date not within"// &
+                           "  database.")
+      end select
+    end if
+
+  end subroutine check_tip_err
+
+  function StringUpper(string) result(outString)
+    implicit none
+
+    character(LEN=*), intent(IN) :: string
+    character(LEN=len_trim(string)) :: outString
+
+    integer :: I, asciinum
+
+    do I = 1, len(string)
+      asciinum = iachar(string(I:I))
+      select case (asciinum)
+      case (97:122)
+        outString(I:I) = char(asciinum - 32)
+      end select
+    end do
+  end function StringUpper
+
+  ! A^{N}
+  elemental function AINTPOWER(A, N) result(AP)
+    implicit none
+
+    real(8) :: AP
+    real(8), intent(IN) :: A
+    integer, intent(IN) :: N
+
+    integer :: I
+
+    AP = 1.d0
+    do I = 1, N
+      AP = AP*A
+    end do
+
+  end function AINTPOWER
+
+  subroutine INIT_FULL_TIP(self, NP)
+    use ADC_CONSTANTS, only: sec2day, hour2day, min2day
+    use mod_astronomic, only: JULIANDAY
+    use mesh, only: SFEA, SLAM
+    implicit none
+
+    class(t_tidePotential), intent(INOUT) :: self
+    integer, intent(IN) :: NP
+
+    real(8) :: DDD
+    integer :: YYYY, MM, DD, HH, MMM, SS
+    integer :: argval(3)
+
+    integer :: ii, cpos(2), ivec(3)
+    character(LEN=80) :: tmparr
+    character :: delimter(2) = (/'-', ':'/)
+
+    ! Extract date from base_date
+    tmparr = adjustl(self%m_TIPStartDate)
+
+    ! Default J2000 epoch !
+    YYYY = 2000
+    MM = 1
+    DD = 1
+
+    HH = 0
+    MMM = 0
+    SS = 0
+
+    argval = (/YYYY, MM, DD/)
+    call extractvalues(argval, delimter(1))
+    YYYY = argval(1)
+    MM = argval(2)
+    DD = argval(3)
+
+    argval = (/HH, MMM, SS/)
+    call extractvalues(argval, delimter(2))
+    HH = argval(1)
+    MMM = argval(2)
+    DD = argval(3)
+
+    DDD = dble(DD) + dble(HH)*hour2day + dble(MMM)*min2day + dble(SS)*sec2day
+
+    ! Get  correspond Julian days !
+    self%m_JDE_BEG = JULIANDAY(DDD, MM, YYYY)
+    self%m_JDE_CURRENT = self%m_JDE_BEG
+
+    if (self%m_MoonSunPositionComputeMethod == ComputeMethod_JM) then
+      call self%m_moon_sun_position%SET_NUTATION(self%m_IncludeNutation)
+    end if
+
+    call ALLOCATEWORKARR(self%m_AH, NP)
+    call ALLOCATEWORKARR(self%m_cosZA, NP)
+    call ALLOCATEWORKARR(self%m_workarr, NP)
+    call ALLOCATEWORKARR(self%m_CSFEA, NP)
+    call ALLOCATEWORKARR(self%m_SSFEA, NP)
+
+    if (self%m_TIPOrder == 22) then
+      call ALLOCATEWORKARR(self%m_S2SFEA, NP)
+    end if
+
+    if (self%m_TIPOrder > 3) then
+      call ALLOCATEWORKARR(self%m_workarr1, NP)
+    end if
+
+    self%m_CSFEA = cos(SFEA)
+    self%m_SSFEA = sin(SFEA)
+    if (self%m_TIPOrder == 22) then
+      self%m_S2SFEA = sin(2.d0*SFEA)
+    end if
+
+    return
+  contains
+
+    subroutine ALLOCATEWORKARR(arr, N)
+      implicit none
+
+      integer :: N
+      real(8), allocatable :: arr(:)
+
+      if (allocated(arr)) then
+        deallocate (arr)
+      end if
+      allocate (arr(1:N))
+      arr = 0.d0
+
+      return
+    end subroutine ALLOCATEWORKARR
+
+    subroutine extractvalues(arg, delimc)
+      implicit none
+
+      character :: delimc
+      integer :: arg(3)
+
+      logical :: earlystop
+      integer :: ii, cpos(3), ivec(3)
+
+      earlystop = .false.
+
+      ivec = 0
+      cpos(1) = 1
+      do ii = 1, 3
+        if (len(trim(tmparr(cpos(1):))) == 0) exit
+
+        cpos(2) = index(tmparr, delimc)
+
+        if (cpos(2) == 0) then
+          cpos(2) = index(tmparr, ' ')
+
+          earlystop = .true.
+        end if
+
+        if (cpos(2) > 0) then
+          read (tmparr(cpos(1):cpos(2) - 1), *) ivec(ii)
+
+          tmparr = adjustl(tmparr(cpos(2) + 1:))
+        else
+          if (len(trim(tmparr(cpos(1):))) > 0) then
+            read (tmparr(cpos(1):), *) ivec(ii)
+          end if
+        end if
+
+        arg(ii) = ivec(ii)
+        if (earlystop) exit
+      end do
+    end subroutine extractvalues
+
+  end subroutine INIT_FULL_TIP
+
+end module mod_tidepotential
+

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -104,7 +104,7 @@ C
       USE WIND, ONLY : getMeteorologicalForcing, PRBCKGRND_MH2O, rsget,
      &    getdynamicWaterLevelCorrections,
      &    dynamicWaterLevelCorrectionMassAdjust,
-     &    CLOSE_MET_FILES 
+     &    CLOSE_MET_FILES
 
       USE ADCIRC_MOD, ONLY : ADCIRC_Terminate
 C.... TCM V49.64.01 ADDITIONS FOR ICE
@@ -152,6 +152,9 @@ Casey 100205: Add a variable for writing of SWAN hot-start files.
 
       USE subgrid, ONLY: level0, getVertLookup
 
+      ! full luni-solar tidal potential !
+      USE mod_tidepotential, only: tidePotential
+
       IMPLICIT NONE
       INTEGER, intent(in) :: IT
 C
@@ -159,7 +162,7 @@ c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D 
       INTEGER IE, I, J, K, JJ                  !local loop counters
       INTEGER NM1, NM2, NM3
       INTEGER NC1, NC2, NC3, NCEle
-      INTEGER NCyc, NA
+      INTEGER NCyc
       INTEGER :: itest
       INTEGER :: kemax
       INTEGER :: kvmax
@@ -172,7 +175,6 @@ c. RJW merged 08/26/2008 from Casey 071219:Added the following variables for 3D 
       INTEGER :: warnElevExceeded
       logical, save ::  EtaDisc_Fill = .TRUE.
 
-      REAL(8) ArgT, ArgTP, ArgSAlt
       REAL(8) CCSFEA
       REAL(8) ElMax
       REAL(8) PIPE_FLUX
@@ -855,45 +857,9 @@ Casey 140701: Ending the IF statement.
          END IF
       END IF
 
-C...
-C...  Tidal Potential Forcing
-C...  Note, the Earth tide potential reduction factor, ETRF(J) has been
-C...        incorporated into this calculation.
-C...
-C...  WJP 02.21.2018 Rewriting for general formula for all species,
-C     cleaner code, and correct identification of 0,1,2 or higher species
-      IF(CTIP) THEN
-         TIPLOOP: DO J=1,NTIF
-            IF (PERT(J).EQ.0.) THEN
-               NCYC=0
-            ELSE
-#ifdef IBM
-               NCYC=INT(timeh/PERT(J),KIND(0.0d0))
-#else
-               NCYC=INT(timeh/PERT(J))
-#endif
-            ENDIF
 
-            ARGT=AMIGT(J)*(timeh-NCYC*PERT(J))+FACET(J)
-            TPMUL=RampTip*ETRF(J)*TPK(J)*FFT(J)
-            SALTMUL=RampTip*FFT(J)
-C           WJP: We actually want to compare against diurnal and get 0,1,2
-C           or higher species (was opposite beforehand)
-#ifdef IBM
-            NA = MIN(NINT(AMIGT(J)/7d-5,KIND(0.0d0)),2)
-#else
-            NA = MIN(NINT(AMIGT(J)/7d-5),2)
-#endif
-C           WJP: Rewritten so that we have a general formula for all
-C           species
-            DO I = 1,NP
-                ARGTP   = ARGT + NA*SLAM(I)
-                ARGSALT = ARGT - SALTPHA(J,I)
-                TIP2(I) = TIP2(I) + TPMUL * L_N(NA,I) * COS(ARGTP)
-     &                  + SALTMUL * SALTAMP(J,I) * COS(ARGSALT)
-            ENDDO
-         ENDDO TIPLOOP
-      ENDIF
+! Apply the tide potential forcing subroutine      
+      call applyTidePotentialForcing(TimeLoc, TimeH)
 
 C...
 C...  Depth Averaged Baroclinic Forcing needed by GWCE and 2DDI Momentum
@@ -1100,6 +1066,7 @@ C...
       if(subdomainOn.and.enforceBN.eq.2) call readFort020(it)  ! NCSU Subdomain
       if(subdomainOn.and.enforceBN.eq.2) call readFort021(it)  ! NCSU Subdomain
 
+
 !----------------------SOLVE GWCE---------------------------------------
 C...
 C...  Compute new water surface elevation 
@@ -1126,13 +1093,15 @@ C...  Compute new water surface elevation
 
 !--------------------WETTING AND DRYING--------------------------------
       ENDIF
- 
+
+
+
 !.....DMW202401 Add update for flow depth at current timestep
 !......We do this after wetting/drying since bathy could change with subgrid barriers.
       DO I = 1,NP
          H2(I) = DP(I)+IFNLFA*ETA2(I)
       ENDDO
-C...
+C...   
 C---------------2DDI Momentum Equation Solution-------------------------
 C...
       call solveMomentumEq()
@@ -1537,8 +1506,77 @@ C      ENDIF
       RETURN
 
 C******************************************************************************
+
       END SUBROUTINE TIMESTEP
 C******************************************************************************
+
+
+!****************************************************************************************
+! Subroutine to compute tide potential at the nodes                                     
+!                                                                                       
+! Tidal Potential Forcing
+! Note, the Earth tide potential reduction factor, ETRF(J) has been
+!       incorporated into this calculation.
+!
+! WJP 02.21.2018 Rewriting for general formula for all species,
+! cleaner code, and correct identification of 0,1,2 or higher species
+!****************************************************************************************
+      subroutine applyTidePotentialForcing(TimeLoc, TimeH)
+         use mod_tidepotential, only: tidePotential
+         use global, only: NTIP, TIP1, TIP2, CTIP, NTIF, RampTip, PERT, FACET,
+     &                     AMIGT, FFT, TPK, ETRF, SALTPHA, SALTAMP, L_N
+         use mesh , only: np, SLAM
+         implicit none
+         real(8), intent(IN) :: TimeLoc, TimeH
+         real(8) :: ArgT, ArgTP, ArgSAlt, SALTMUL, TPMUL
+         integer :: i, j, na, ncyc
+
+         IF(CTIP) THEN
+
+            ! use the full formula 
+            IF ( tidePotential%active() ) THEN
+               TIP2 = tidePotential%compute(TimeLoc, NP, SLAM) * RampTip
+            ENDIF  
+
+            ! The traditional approach: a sum of different constituents
+            ! TIP & SAL - for tidePotential%active() = .TRUE.  
+            ! SAL       - for tidePotential%active() = .FALSE.
+            IF(NTIP.EQ.2.or..not.tidePotential%active())THEN 
+               DO J=1,NTIF
+                  IF (PERT(J).EQ.0D0) THEN
+                     NCYC=0
+                  ELSE
+                     NCYC=INT(timeh/PERT(J))
+                  ENDIF
+
+                  ARGT=AMIGT(J)*(timeh-NCYC*PERT(J))+FACET(J)
+                  TPMUL=RampTip*ETRF(J)*TPK(J)*FFT(J)
+                  SALTMUL=RampTip*FFT(J)
+
+   !              WJP: We actually want to compare against diurnal and get 0,1,2
+   !              or higher species (was opposite beforehand)
+                  NA = MIN(NINT(AMIGT(J)/7d-5),2)
+
+   !              WJP: Rewritten so that we have a general formula for all
+   !              species
+                  IF(tidePotential%active())THEN
+                     DO I = 1, NP
+                        ARGSALT = ARGT - SALTPHA(J,I) ; 
+                        TIP2(I) = TIP2(I) + SALTMUL * SALTAMP(J,I) * COS(ARGSALT)
+                     END DO
+                  ELSE
+                     DO I = 1,NP
+                        ARGTP   = ARGT + NA*SLAM(I)
+                        ARGSALT = ARGT - SALTPHA(J,I)
+                        TIP2(I) = TIP2(I) + TPMUL * L_N(NA,I) * COS(ARGTP)
+     &                            + SALTMUL * SALTAMP(J,I) * COS(ARGSALT)
+                     ENDDO
+                  ENDIF
+
+               ENDDO
+            ENDIF   
+         ENDIF
+      end subroutine applyTidePotentialForcing
 
 
 C****************************************************************************************

--- a/src/wind.F
+++ b/src/wind.F
@@ -37,7 +37,8 @@ C
      &                      rhoWat0, Rearth, rhoAir, one2ten,
      &                      windReduction
 #ifdef CMPI
-      use messenger, only : msg_fini
+      use mpi
+      use messenger, only : msg_fini, msg_Rscalar_Reduce
 #endif
 #ifdef DATETIME
       use datetime_module, only: datetime, timedelta, strptime
@@ -292,6 +293,10 @@ C
         END FUNCTION p_computeWindDrag
       END INTERFACE
       PROCEDURE(p_computeWindDrag),POINTER :: f_computeWindDrag => null()
+
+
+      ! for record time  
+      REAL(8), private:: io_elapsed_time = 0.0D0, nws_elapsed_time = 0.0D0
 
 C------------------------end of data declarations-----------------------
       CONTAINS
@@ -933,11 +938,11 @@ C----------------------------------------------------------------------
       integer :: i ! node loop counter
       real(8) :: wtratio_12, wtratio_14 ! used to time interpolated between met datasets
 
+
       call setMessageSource("getMeteorologicalForcing")
 #if defined(WIND_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Enter.")
 #endif
-
 
 C------------------------MET FORCING---------------------------------------
 C
@@ -1794,6 +1799,7 @@ C      DW/WJP: rotate wind stresses if coordinate transform
        ENDIF
 
 C--------------------END MET FORCING---------------------------------------
+ 
 
 #if defined(WIND_TRACE) || defined(ALL_TRACE)
       call allMessage(DEBUG,"Return.")
@@ -1836,6 +1842,7 @@ Casey 180318: Added for NWS=13
       integer :: nhg ! node number temp
       real(8) :: bf ! blend factor for multiple sets of wind data
       integer :: i ! node loop counter
+
 
       call setMessageSource("coldStartMeteorologicalForcing")
 #if defined(WIND_TRACE) || defined(ALL_TRACE)
@@ -3293,7 +3300,8 @@ C      DW/WJP: rotate wind stresses if coordinate transform
           CALL DRVMAP2DSPVEC( WSX2, WSY2,
      &              UVECTMP, VVECTMP, NP, FWD = .TRUE. ) ;
        ENDIF
-      
+
+
 #if defined(WIND_TRACE) || defined(ALL_TRACE)
        call allMessage(DEBUG,"Return.")
 #endif
@@ -9212,11 +9220,14 @@ C----------------------------------------------------------------------
       real(8),intent(out),optional :: CICE2(NP)
       integer :: i, NTkeep
       real,allocatable,dimension(:,:) :: Pmsl, U10, V10, Cice
+
+      !
       CALL setMessageSource('NWS14GET')
       ! Show the date in str_date format
       call logMessage(ECHO,'CurDT strng: '//
      &                CurDT%strftime("%Y-%m-%d %H:%M"))
-      
+
+
       ! Get the Pressure
       !':PRMSL:mean sea level:'
       call READNWS14(Pfile,Pmsl,Pinv,Pvar,PfileNCID)
@@ -9234,22 +9245,6 @@ C----------------------------------------------------------------------
          NT = NTkeep
       endif
 
-!      ! Get the Pressure
-!      !':PRMSL:mean sea level:'
-!      call READNWS14(Pfile,Pinv,Pvar,Pmsl)
-!
-!      ! Get the U-winds
-!      call READNWS14(Wfile,Winv,Uvar,U10)
-!
-!      ! Get the V-winds
-!      call READNWS14(Wfile1,Winv,Vvar,V10)
-!
-!      ! Get the ice concentration if required
-!      if (present(CICE2)) then
-!         NTkeep = NT; NT = NTC
-!         call READNWS14(Cfile,Cinv,Cvar,Cice)
-!         NT = NTkeep
-!      endif      
 
       ! Doing the interpolation from their grid to ours
       do i = 1,np
@@ -9770,7 +9765,7 @@ C---------------------------------------------------------------------
       END SUBROUTINE CLOSE_MET_FILES        
 C---------------------------------------------------------------------
 
-
+ 
 
 C-----------------------------------------------------------------------
 C     S U B R O U T I N E   W I N D L I M I T E R 

--- a/work/cmplrflags.mk
+++ b/work/cmplrflags.mk
@@ -193,64 +193,64 @@ ifeq ($(compiler),intel)
   PPFC          :=  ifort
   FC            :=  ifort
   PFC           ?=  mpif90
-  FFLAGS1       := $(INCDIRS) -O2 -g -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+  FFLAGS1       := $(INCDIRS) -O2 -g -traceback -assume byterecl -132 -xSSE4.2 -assume buffered_io
   CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
   FLIBS         :=
   ifeq ($(DEBUG),full)
      CFLAGS        := $(INCDIRS) -g -O0 -m64 -mcmodel=medium -DLINUX
   endif
   ifeq ($(DEBUG),full)
-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -ftrapuv -fpe0 -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -ftrapuv -fpe0 -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
   endif
   ifeq ($(DEBUG),full-not-fpe)
-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
   endif
   ifeq ($(DEBUG),trace)
-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
   endif
   ifeq ($(DEBUG),buserror)
-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES -check bounds
+     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES -check bounds
   endif
   ifeq ($(DEBUG),netcdf_trace)
-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
   endif
   #
   ifeq ($(MACHINENAME),stampede2)
-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
+     FFLAGS1 := $(INCDIRS) -O3 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
      CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
      FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
      ifeq ($(DEBUG),trace)
-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
+        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
         FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
      endif
   endif
   ifeq ($(MACHINENAME),frontera) 
-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
+     FFLAGS1 := $(INCDIRS) -O3 -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
      CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX512 
      FLIBS   := $(INCDIRS) -xCORE-AVX512 
      ifeq ($(DEBUG),trace)
-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
+        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
         FLIBS   := $(INCDIRS) -xCORE-AVX512 
      endif
   endif
   ifeq ($(MACHINENAME),queenbee)
-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+     FFLAGS1 := $(INCDIRS) -O3 -assume byterecl -132 -xSSE4.2 -assume buffered_io
      CFLAGS  := $(INCDIRS) -O3 -DLINUX -xSSE4.2
      FLIBS   := $(INCDIRS) -xSSE4.2
      ifeq ($(DEBUG),trace)
-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xSSE4.2 -assume buffered_io
         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2
         FLIBS   := $(INCDIRS) -xSSE4.2
      endif
   endif
   ifeq ($(MACHINENAME),supermic) 
-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
+     FFLAGS1 := $(INCDIRS) -O3 -assume byterecl -132 -xAVX -assume buffered_io
      CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
      FLIBS   := $(INCDIRS) -xAVX
      ifeq ($(DEBUG),trace)
-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
+        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xAVX -assume buffered_io
         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
         FLIBS   := $(INCDIRS) -xAVX
      endif
@@ -371,7 +371,7 @@ ifeq ($(compiler),intel-ND)
 #      FFLAGS1     :=  $(INCDIRS) -O0 -g -traceback -check bounds -xSSE4.2 -assume byterecl -132 -mcmodel=medium -shared-intel -assume buffered_io
   endif
   ifeq ($(DEBUG),full)
-     FFLAGS1    :=  $(INCDIRS) -g -O0 -traceback -debug -check all -FI -assume byterecl -132 -DEBUG -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+     FFLAGS1    :=  $(INCDIRS) -g -O0 -traceback -debug -check all -assume byterecl -132 -DEBUG -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
   endif
   FFLAGS2       :=  $(FFLAGS1)
   FFLAGS3       :=  $(FFLAGS1)

--- a/work/makefile
+++ b/work/makefile
@@ -196,7 +196,7 @@ ifeq ($(BUILDTYPE),$(PARALLEL_ADCIRC))
     LIBS  := -L$(NETCDFHOME)/lib -lnetcdf -lnetcdff $(FLIBS)
   endif
   #MSG_MOBJ:= $(O_DIR)messenger.o $(O_DIR)writer.o
-  MSG_MOBJ:=
+  MSG_MOBJ:= $(O_DIR)messenger.o
 endif
 #Casey 090302: Add rules for the parallel SWAN+ADCIRC.
 #                                      padcswan
@@ -212,7 +212,7 @@ ifeq ($(BUILDTYPE),padcswan)
     LIBS  := -L$(NETCDFHOME)/lib -lnetcdf -lnetcdff $(FLIBS)
   endif
   #MSG_MOBJ:= $(O_DIR)messenger.o $(O_DIR)writer.o
-  MSG_MOBJ:=
+  MSG_MOBJ:=  
   ifneq ($(wildcard $(SRCDIR)/work/.swanlastcompile),)
     include $(SRCDIR)/work/.swanlastcompile
     ifneq ($(SWANLASTCOMPILE),parallel)
@@ -383,6 +383,7 @@ SPG_MSRC = quadrature.F sponge_layer.F
 BC3D_MSRC = couple2baroclinic3D.F
 # CPB baroclinic internal tide updates
 GL2LOC_MSRC = gl2loc_mapping.F
+TIDE_MSRC = astronomic.F90 sun.F90 moon.F90 sun_moon_system.F90 ephemerides.F90 tidalpotential.F90
 ITTIDE_MSRC = internaltide.F
 
 HASH_MOBJ:= $(patsubst %.F, $(O_DIR)%.o, $(HASH_MSRC) )
@@ -409,7 +410,6 @@ WIND_MOBJ := $(patsubst %.F, $(O_DIR)%.o, $(WIND_MSRC)  )
 NA_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(NA_MSRC)  )
 SG_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(SG_MSRC)  )
 NC_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(NC_MSRC)  )
-NCE_MOBJ  := $(patsubst %.F90, $(O_DIR)%.o, $(NCE_MSRC)  )
 GIO_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(GIO_MSRC)  )
 #Casey 090302: Add rules for coupling to unstructured SWAN.
 COUP_MOBJ  := $(patsubst %.F, $(O_DIR)%.o, $(COUP_MSRC)  )
@@ -423,6 +423,8 @@ BC3D_MOBJ :=  $(patsubst %.F, $(O_DIR)%.o, $(BC3D_MSRC) )
 # CPB
 GL2LOC_MOBJ :=  $(patsubst %.F, $(O_DIR)%.o, $(GL2LOC_MSRC) )
 ITTIDE_MOBJ :=  $(patsubst %.F, $(O_DIR)%.o, $(ITTIDE_MSRC) )
+TIDE_MOBJ := $(patsubst %.F90, $(O_DIR)%.o, $(TIDE_MSRC) )
+NCE_MOBJ := $(patsubst %.F90, $(O_DIR)%.o, $(NCE_MSRC) )
 
 ############################# Source & Object Files ######################
 #meb 04/20/2004 - added machdep.F onto POST_SRC
@@ -581,10 +583,10 @@ else
    adccmp:  $(O_DIR)
 
 ifeq ($(NETCDF),enable)
-   adcprep ::  $(METIS_OBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(NC_MOBJ) $(WIND_MOBJ) $(PREP_OBJ) $(MESH_MOBJ) $(NA_MOBJ) $(SUBP_MOBJ) $(HASH_MOBJ)
+   adcprep ::  $(METIS_OBJ) $(NCE_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(NC_MOBJ) $(WIND_MOBJ) $(PREP_OBJ) $(MESH_MOBJ) $(NA_MOBJ) $(SUBP_MOBJ) $(HASH_MOBJ)
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(LDFLAGS)
 else
-   adcprep ::  $(METIS_OBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(PREP_OBJ) $(MESH_MOBJ) $(NA_MOBJ) $(SUBP_MOBJ) $(HASH_MOBJ)
+   adcprep ::  $(METIS_OBJ) $(NCE_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(PREP_OBJ) $(MESH_MOBJ) $(NA_MOBJ) $(SUBP_MOBJ) $(HASH_MOBJ)
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(LDFLAGS)
 endif
 ifeq ($(NETCDF),enable)
@@ -597,8 +599,8 @@ endif
    adcpost ::  $(POST_OBJ) $(HARM_MOBJ)
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(LDFLAGS)
 
-ADCIRC_DEP := $(ADC_MOBJ) $(HAS_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(O_DIR)driver.o
-ADCSWAN_DEP := $(ADC_MOBJ) $(HAS_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(SWAN_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(SWAN_OBJ) $(O_DIR)driver.o
+ADCIRC_DEP := $(ADC_MOBJ) $(HAS_MOBJ) $(NCE_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(O_DIR)driver.o
+ADCSWAN_DEP := $(ADC_MOBJ) $(HAS_MOBJ) $(NCE_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(SWAN_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(SWAN_OBJ) $(O_DIR)driver.o
 ifeq ($(NETCDF),enable)
    ADCIRC_DEP := $(ADCIRC_DEP) $(NC_MOBJ)
    ADCSWAN_DEP := $(ADCSWAN_DEP) $(NC_MOBJ)
@@ -611,21 +613,21 @@ endif
    adcirc ::  $(ADCIRC_DEP)
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(LDFLAGS)
 
-   $(PARALLEL_ADCIRC) :: $(ADC_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(MSG_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(O_DIR)driver.o
+   $(PARALLEL_ADCIRC) :: $(ADC_MOBJ) $(HASH_MOBJ) $(MSG_MOBJ) $(NCE_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(O_DIR)driver.o
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(MSGLIBS)
 
 ifeq ($(NETCDF),enable)
-   $(LIBADC) :: $(O_DIR) $(ADC_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(MSG_MOBJ) \
+   $(LIBADC) :: $(O_DIR) $(ADC_MOBJ) $(HASH_MOBJ) $(MSG_MOBJ) $(NCE_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) \
 	        $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(GIO_MOBJ) $(AGIO_MOBJ) $(ADC_OBJ)
-	ar $(ARFLAGS) $@  $(ADC_MOBJ) $(3D_MOBJ) $(MSG_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) \
+	ar $(ARFLAGS) $@  $(ADC_MOBJ) $(3D_MOBJ) $(MSG_MOBJ) $(HASH_MOBJ) $(TIDE_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) \
 	         $(NA_MOBJ) $(GIO_MOBJ) $(AGIO_MOBJ) $(KDTREE_MOBJ) \
                  $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(BND_MOBJ) $(HARM_MOBJ) $(WRIT_MOBJ) \
                  $(WRITER_MOBJ) $(SUBD_MOBJ) $(NC_MOBJ) $(VORT_MOBJ) $(SOLV_MOBJ) $(ADC_OBJ) 
 	ar -ts $@
 else
-   $(LIBADC) :: $(O_DIR) $(ADC_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(MSG_MOBJ) \
+   $(LIBADC) :: $(O_DIR) $(ADC_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(NA_MOBJ) $(MSG_MOBJ) \
 	        $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(GIO_MOBJ) $(AGIO_MOBJ) $(ADC_OBJ)
-	ar $(ARFLAGS) $@  $(ADC_MOBJ) $(3D_MOBJ) $(MSG_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) \
+	ar $(ARFLAGS) $@  $(ADC_MOBJ) $(3D_MOBJ) $(MSG_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) \
 	         $(NA_MOBJ) $(GIO_MOBJ) $(AGIO_MOBJ) $(KDTREE_MOBJ) \
                  $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(BND_MOBJ) $(HARM_MOBJ) $(WRIT_MOBJ) \
                  $(WRITER_MOBJ) $(SUBD_MOBJ) $(VORT_MOBJ) $(SOLV_MOBJ) $(ADC_OBJ) 
@@ -639,7 +641,7 @@ endif
 	if [ "`echo *.mod`" != '*.mod' ]; then mv *.mod $(O_DIR); fi
 
    padcswan :: $(O_DIR)
-   padcswan :: $(NA_MOBJ) $(ADC_MOBJ) $(HASH_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(MSG_MOBJ) $(SWAN_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(SWAN_OBJ) $(O_DIR)driver.o
+   padcswan :: $(NA_MOBJ) $(ADC_MOBJ) $(HASH_MOBJ) $(NCE_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(MSG_MOBJ) $(SWAN_MOBJ) $(KDTREE_MOBJ) $(SPG_MOBJ) $(BC3D_MOBJ) $(WIND_MOBJ) $(ADC_OBJ) $(SWAN_OBJ) $(O_DIR)driver.o
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(MSGLIBS) $(LDFLAGS)
 	if [ "`echo *.mod`" != '*.mod' ]; then mv *.mod $(O_DIR); fi
 
@@ -678,7 +680,7 @@ endif
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o) $(LIBS) $(LDFLAGS)
 
    aswip ::   $(ADCIRC_DEP) $(ASW_OBJ)
-	$(CF) $(FFLAGS) -o $@ $(ADC_MOBJ) $(HAS_MOBJ) $(MESH_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(WIND_MOBJ) $(NCE_MOBJ) $(NA_MOBJ) $(SG_MOBJ) $(PREC_MOBJ) $(CONS_MOBJ) $(VORT_MOBJ) $(LSQ_MOBJ) $(FITP_MOBJ) $(ASW_OBJ) $(KDTREE_MOBJ) $(HASH_MOBJ) $(BND_MOBJ) $(LIBS) $(LDFLAGS)
+	$(CF) $(FFLAGS) -o $@ $(ADC_MOBJ) $(HAS_MOBJ) $(MESH_MOBJ) $(TIDE_MOBJ) $(GL2LOC_MOBJ) $(ITTIDE_MOBJ) $(WIND_MOBJ) $(NCE_MOBJ) $(NA_MOBJ) $(SG_MOBJ) $(PREC_MOBJ) $(CONS_MOBJ) $(VORT_MOBJ) $(LSQ_MOBJ) $(FITP_MOBJ) $(ASW_OBJ) $(KDTREE_MOBJ) $(HASH_MOBJ) $(BND_MOBJ) $(LIBS) $(LDFLAGS)
 
    adccmp :  $(O_DIR) $(CMP_OBJ)
 	$(CF) $(FFLAGS) -o $@ $(wildcard $(O_DIR)*.o)
@@ -774,9 +776,9 @@ $(O_DIR)internaltide.o : internaltide.F $(O_DIR)sizes.o $(O_DIR)global.o
 $(O_DIR)gl2loc_mapping.o : gl2loc_mapping.F $(O_DIR)sizes.o $(O_DIR)global.o
 
 ifeq ($(BUILDTYPE),$(filter $(BUILDTYPE),$(PARALLEL_ADCIRC) padcswan))
-$(O_DIR)nodalattr.o   :  nodalattr.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)mesh.o $(O_DIR)hashtable.o $(O_DIR)messenger.o $(O_DIR)internaltide.o $(O_DIR)netcdf_error.o $(O_DIR)subgridLookup.o
+$(O_DIR)nodalattr.o   :  nodalattr.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)messenger.o $(O_DIR)netcdf_error.o $(O_DIR)mesh.o $(O_DIR)hashtable.o $(O_DIR)messenger.o $(O_DIR)internaltide.o $(O_DIR)subgridLookup.o
 else
-$(O_DIR)nodalattr.o   :  nodalattr.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)mesh.o $(O_DIR)hashtable.o $(O_DIR)internaltide.o $(O_DIR)netcdf_error.o $(O_DIR)subgridLookup.o
+$(O_DIR)nodalattr.o   :  nodalattr.F  $(O_DIR)sizes.o $(O_DIR)global.o $(O_DIR)netcdf_error.o $(O_DIR)mesh.o $(O_DIR)hashtable.o $(O_DIR)internaltide.o $(O_DIR)subgridLookup.o
 endif
 
 $(O_DIR)gwce.o        :  gwce.F $(O_DIR)itpackv.o $(O_DIR)nodalattr.o $(O_DIR)vew1d.o $(O_DIR)sponge_layer.o $(O_DIR)subdomain.o $(O_DIR)momentum.o
@@ -833,11 +835,7 @@ $(O_DIR)write_output.o : $(WRITE_OUTPUT_DEP)
 $(O_DIR)xdmfio.o      : xdmfio.F $(O_DIR)mesh.o $(O_DIR)global.o $(O_DIR)boundaries.o $(O_DIR)control.o
 $(O_DIR)hashtable.o   : hashtable.F
 $(O_DIR)control.o     : control.F
-ifeq ($(BUILDTYPE),$(filter $(BUILDTYPE),$(PARALLEL_ADCIRC) padcswan))
-$(O_DIR)subdomain.o   : subdomain.F $(O_DIR)mesh.o $(O_DIR)messenger.o
-else
-$(O_DIR)subdomain.o   : subdomain.F $(O_DIR)mesh.o
-endif
+$(O_DIR)subdomain.o   : subdomain.F $(O_DIR)mesh.o 
 $(O_DIR)global_3dvs.o : global_3dvs.F $(O_DIR)global.o $(O_DIR)boundaries.o
 # DW
 $(O_DIR)sponge_layer.o : sponge_layer.F $(O_DIR)quadrature.o $(ADC_MOBJ)


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR was initiated as #406 by @dwirasae, but has undergone revisions and is now reopened here to keep things tidy.

Add an implementation of the full luna-solar tidal potential (see an attachment for more detail).  The implementation includes of the truncated formulas (degree 2, 3, and  partial degree 2 approximation) and the non-truncated formula.   Parameters for this implementation are specified in fort.15 through a namelist called `TidalPotentialControl` using the variables:

* `UseFullTIPFormula`:  a logical variable
    * default: `F`
    * `T` - use the full TIP formula
    * `F` - use the existing approach 
* `TIPOrder`: an integer  number
     * default: `2`
     * `2` - degree 2 TIP
     * `3` - degree 3 TIP
     * `22` - partial degree 2
     * `4` - exact
* `TIPStartDate`: a string with the  `YYYY-MM-DD HH:mm:SS`  format corresponding to the starting date of the cold start run
    * default: `2000-01-01 00:00:00`
* `MoonSunPostionMethod`: defines the approach used to determine the position of the Moon/Sun
    * `JM` = Jean Meeus's approach 
    * `External` = User supplied epherides (Moon's, Sun's RA, DEC and distances).  Required NetCDF. 
* `MoonSunCoordFile`:  filename of an external file storing the coordinates of the Moon and the Sun.
* `UniformResMoonSunTimeData`: a logical variable indicating the time intervals of the `MoonSunCoordFile`
    * default: `F`
    * `T`: Uniform interval (locating the intervals from which the Moon/Sun coordinates are interpolate is trivial  
    * `F`: Non uniform interval (using a binary search to locate the intervals from which the Moon/Sun coordinates are interpolated)
* `IncludeNutation`: a logical value to the nutation in `JM` formula
* `k2value`: k2 Love number  `~ 0.302`
* `h2value`: h2 Love number  `~ 0.609`
        
Below is an example of the namelist (assuming that TIP in fort.15 is set 1 or 2) telling ADCIRC to run with the exact full tidal potential where the analytical JM approach is used to determined the position of the Moon/Sun,  the starting date of the cold start corresponds to 2018-01-02  00:00:00 UTC, and the nutation is considered in the calculation of the geocentric coordinates of the Moon/Sun.   

```
 &TidalPotentialControl
      UseFullTIPFormula = T, 
      TIPOrder = 4,
      TIPStartDate = "2018-01-02 00:00:00", 
      MoonSunPositionComputeMethod = "JM", 
      MoonSunCoordFile = "JPL_de430_position.nc",
      UniformResMoonSunTimeData =   T,
      IncludeNutation = T, 
      k2Value = 0.302, 
      h2Value = 0.609 /
```

## Type of change
Details can be found in the attached slide deck: [ADCIRC_JUN_2024.pdf](https://github.com/user-attachments/files/16315581/ADCIRC_JUN_2024.pdf)

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

Parsing TIPStartDate could use some improvement.  Might not work as intended if TIPStartDate or BaseData is not specified exactly in the YYYY-MM-DD HH:mm:ss format. 

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

The Intel compiler version 2021.8.0 20221119 was used to compile the code. A few global domain runs were used to test the implementation (see the attached document). 

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->