### PR TITLE
Allowing NTIF=0 when using analytical TIP solution

### DIFF
--- a/prep/metis.F
+++ b/prep/metis.F
@@ -27,6 +27,7 @@
 
       SUBROUTINE METIS()
       USE PRE_GLOBAL
+      USE MEMORY_USAGE, ONLY: memory_usage_string
       IMPLICIT NONE
 C----------------------------------------------------------------------
 C  INTERFACE ROUTINE FOR PADCIRC TO USE THE METIS 4.0 LIBRARY 
@@ -348,7 +349,8 @@ C
  
       print *, ""
       print *, "Grid Partition Data"
-      print *, "METIS 4.0 will require approximately ",nbytes," bytes"
+      print *, "METIS 4.0 will require approximately ",
+     &          trim(memory_usage_string(nbytes))
 C
       CALL metis_partgraphkway( MNP,XADJ,ADJNCY,VWGTS,EWGTS,
      &      WEIGHTFLAG,NUMFLAG,NPARTS,OPTIONS,EDGECUT,PROC)

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -38,12 +38,36 @@
 
 
       subroutine memory_status( )
-        print *, " "
-        print *, "memory currently allocated = ", mem_descript % currmem, " bytes"
-        print *, "memory high water mark     = ", mem_descript % highmem, " bytes"
-        print *, " "
+        write(*,'(A)') ""
+        write(*,'(A, A)') "memory currently allocated = ", 
+     &      trim(memory_usage_string(mem_descript%currmem))
+        write(*,'(A, A)') "memory high water mark     = ", 
+     &      trim(memory_usage_string(mem_descript%highmem))
+        write(*,'(A)') ""
       end subroutine memory_status
 
+      character(200) function memory_usage_string(bytes) result(out_str)
+        implicit none
+
+        integer(8), parameter  :: gigabytes = 1e9
+        integer(8), parameter  :: megabytes = 1e6
+        integer(8), parameter  :: kilobytes = 1e3
+        integer(8), intent(in) :: bytes 
+
+        if(bytes>=gigabytes)then
+            write(out_str, '(F0.3,X,A)') dble(bytes)/dble(gigabytes),
+     &          "gigabytes"
+        elseif(bytes>=megabytes)then
+            write(out_str, '(F0.3,X,A)') dble(bytes)/dble(megabytes),
+     &          "megabytes"
+        elseif(bytes>=kilobytes)then
+            write(out_str, '(F0.3,X,A)') dble(bytes)/dble(kilobytes),
+     &          "kilobytes"
+        else
+            write(out_str, '(I0,X,A)') bytes, "bytes"
+        endif
+
+      end function memory_usage_string  
 
       subroutine memory_alloc(nbytes)
       integer(8),intent(in) :: nbytes

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -3486,33 +3486,8 @@ C...
       DO I=1,NTIF
          FACET(I)=FACET(I)*DEG2RAD
       END DO
-C...
-C...  CHECK CONSISTENCY OF INPUT PARAMETERS NTIF AND NTIP
-C...
-      IF(((NTIP.EQ.0).AND.(NTIF.NE.0)).OR.((NTIP.NE.0).AND.
-     &     (NTIF.EQ.0))) THEN
-         IF(NSCREEN.NE.0.AND.MYPROC.EQ.0) WRITE(ScreenUnit,9961)
-         WRITE(16,9961)
- 9961    FORMAT(////,1X,'!!!!!!!!!!  WARNING - NONFATAL ',
-     &        'INPUT ERROR  !!!!!!!!!',
-     &        //,1X,'YOUR SELECTION OF NTIF AND NTIP (UNIT 15 INPUT ',
-     &        'PARAMETERS) IS INCONSISTENT',
-     &        /,1X,'PLEASE CHECK THESE VALUES')
-         IF(NFOVER.EQ.1) THEN
-            IF(NSCREEN.NE.0.AND.MYPROC.EQ.0) WRITE(ScreenUnit,9987)
-            WRITE(16,9987)
- 9987       FORMAT(/,1X,'PROGRAM WILL OVERRIDE THE SPECIFIED ',
-     &           'INPUT AND NEGLECT TIDAL POTENTIAL TERMS',
-     &           /,1X,' AND/OR RESET NTIP = 0',
-     &           //,1X,'!!!!!! EXECUTION WILL CONTINUE !!!!!!',//)
-            NTIP=0
-         ELSE
-            IF(NSCREEN.NE.0.AND.MYPROC.EQ.0) WRITE(ScreenUnit,9973)
-            WRITE(16,9973)
-            CALL ADCIRC_Terminate()
-         ENDIF
 
-      ELSE IF(NTIP.GE.1) THEN
+      IF(NTIP.GE.1) THEN
 C...
 C...  PRINT OUT LAT/LON VALUES TO BE USED IN COMPUTING TIDAL POTENTIAL
 C...  IF NOT ALREADY DONE SO IN CORIOLIS SECTION AND TIDAL POTENTIAL IS
@@ -5096,6 +5071,21 @@ C
          endif
       endif
 
+!...  CHECK CONSISTENCY OF INPUT PARAMETERS NTIF AND NTIP
+      if((.not.UseFullTIPFormula.and.(NTIP.EQ.0.AND.NTIF.NE.0)).OR.
+     &   (.not.UseFullTIPFormula.and.(NTIP.NE.0.AND.NTIF.EQ.0)).OR.
+     &   (NTIP.GT.1.AND.NTIF.EQ.0))then
+        if(NSCREEN.NE.0.AND.MYPROC.EQ.0) write(ScreenUnit,9961)
+        write(16,9961)
+ 9961   format(////,1X,'!!!!!!!!!!  WARNING - FATAL ',
+     &      'INPUT ERROR  !!!!!!!!!',
+     &      //,1X,'YOUR SELECTION OF NTIF AND NTIP (UNIT 15 INPUT ',
+     &      'PARAMETERS) IS INCONSISTENT',
+     &      /,1X,'PLEASE CHECK THESE VALUES')
+        if(NSCREEN.NE.0.AND.MYPROC.EQ.0)write(ScreenUnit,9973)
+        write(16,9973)
+        call ADCIRC_Terminate()
+      endif
       ! Initialize the tidal potential calculation
       tidePotential = t_tidePotential(np, rnday, UseFullTIPFormula,
      &                                TIPOrder, TIPStartDate,  

--- a/thirdparty/metis/Lib/estmem.c
+++ b/thirdparty/metis/Lib/estmem.c
@@ -19,16 +19,16 @@
 * This function computes how much memory will be required by the various
 * routines in METIS
 **************************************************************************/
-void METIS_EstimateMemory(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, int *nbytes)
+void METIS_EstimateMemory(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, long *nbytes)
 {
-  int i, j, k, nedges, nlevels;
+  long i, j, k, nedges, nlevels;
   float vfraction, efraction, vmult, emult;
-  int coresize, gdata, rdata;
+  long coresize, gdata, rdata;
 
   if (*numflag == 1)
     Change2CNumbering(*nvtxs, xadj, adjncy);
 
-  nedges = xadj[*nvtxs];
+  nedges = (long)xadj[*nvtxs];
 
   InitRandom(-1);
   EstimateCFraction(*nvtxs, xadj, adjncy, &vfraction, &efraction);
@@ -38,22 +38,22 @@ void METIS_EstimateMemory(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numfl
     coresize = nedges;
   else
     coresize = 0;
-  coresize += nedges + 11*(*nvtxs) + 4*1024 + 2*(NEG_GAINSPAN+PLUS_GAINSPAN+1)*(sizeof(ListNodeType *)/sizeof(idxtype));
-  coresize += 2*(*nvtxs);  /* add some more fore other vectors */
+  coresize += nedges + (long)(11*(*nvtxs)) + (long)(4*1024) + (long)(2*(NEG_GAINSPAN+PLUS_GAINSPAN+1)*(sizeof(ListNodeType *)/sizeof(idxtype)));
+  coresize += (long)(2*(*nvtxs));  /* add some more fore other vectors */
 
   gdata = nedges;   /* Assume that the user does not pass weights */
 
-  nlevels = (int)(log(100.0/(*nvtxs))/log(vfraction) + .5);
+  nlevels = (long)(log(100.0/(*nvtxs))/log(vfraction) + .5);
   vmult = 0.5 + (1.0 - pow(vfraction, nlevels))/(1.0 - vfraction);
   emult = 1.0 + (1.0 - pow(efraction, nlevels+1))/(1.0 - efraction);
 
-  gdata += vmult*4*(*nvtxs) + emult*2*nedges;
+  gdata += (long)(vmult*4*(*nvtxs) + emult*2*nedges);
   if ((vmult-1.0)*4*(*nvtxs) + (emult-1.0)*2*nedges < 5*(*nvtxs))
     rdata = 0;
   else
-    rdata = 5*(*nvtxs);
+    rdata = (long)(5*(*nvtxs));
 
-  *nbytes = sizeof(idxtype)*(coresize+gdata+rdata+(*nvtxs));
+  *nbytes = (long)(sizeof(idxtype)*(coresize+gdata+rdata+(*nvtxs)));
 
   if (*numflag == 1)
     Change2FNumbering2(*nvtxs, xadj, adjncy);

--- a/thirdparty/metis/Lib/frename.c
+++ b/thirdparty/metis/Lib/frename.c
@@ -219,19 +219,19 @@ void metis_meshtodual__(int *ne, int *nn, idxtype *elmnts, int *etype, int *numf
 }
 
 
-void METIS_ESTIMATEMEMORY(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, int *nbytes)
+void METIS_ESTIMATEMEMORY(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, long *nbytes)
 {
   METIS_EstimateMemory(nvtxs, xadj, adjncy, numflag, optype, nbytes);
 }
-void metis_estimatememory(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, int *nbytes)
+void metis_estimatememory(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, long *nbytes)
 {
   METIS_EstimateMemory(nvtxs, xadj, adjncy, numflag, optype, nbytes);
 }
-void metis_estimatememory_(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, int *nbytes)
+void metis_estimatememory_(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, long *nbytes)
 {
   METIS_EstimateMemory(nvtxs, xadj, adjncy, numflag, optype, nbytes);
 }
-void metis_estimatememory__(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, int *nbytes)
+void metis_estimatememory__(int *nvtxs, idxtype *xadj, idxtype *adjncy, int *numflag, int *optype, long *nbytes)
 {
   METIS_EstimateMemory(nvtxs, xadj, adjncy, numflag, optype, nbytes);
 }

--- a/thirdparty/metis/Lib/proto.h
+++ b/thirdparty/metis/Lib/proto.h
@@ -44,7 +44,7 @@ int CheckNodePartitionParams(GraphType *);
 int IsSeparable(GraphType *);
 
 /* estmem.c */
-void METIS_EstimateMemory(int *, idxtype *, idxtype *, int *, int *, int *);
+void METIS_EstimateMemory(int *, idxtype *, idxtype *, int *, int *, long *);
 void EstimateCFraction(int, idxtype *, idxtype *, float *, float *);
 int ComputeCoarseGraphSize(int, idxtype *, idxtype *, int, idxtype *, idxtype *, idxtype *);
 
@@ -105,10 +105,10 @@ void METIS_MESHTODUAL(int *, int *, idxtype *, int *, int *, idxtype *, idxtype 
 void metis_meshtodual(int *, int *, idxtype *, int *, int *, idxtype *, idxtype *);
 void metis_meshtodual_(int *, int *, idxtype *, int *, int *, idxtype *, idxtype *);
 void metis_meshtodual__(int *, int *, idxtype *, int *, int *, idxtype *, idxtype *);
-void METIS_ESTIMATEMEMORY(int *, idxtype *, idxtype *, int *, int *, int *);
-void metis_estimatememory(int *, idxtype *, idxtype *, int *, int *, int *);
-void metis_estimatememory_(int *, idxtype *, idxtype *, int *, int *, int *);
-void metis_estimatememory__(int *, idxtype *, idxtype *, int *, int *, int *);
+void METIS_ESTIMATEMEMORY(int *, idxtype *, idxtype *, int *, int *, long *);
+void metis_estimatememory(int *, idxtype *, idxtype *, int *, int *, long *);
+void metis_estimatememory_(int *, idxtype *, idxtype *, int *, int *, long *);
+void metis_estimatememory__(int *, idxtype *, idxtype *, int *, int *, long *);
 void METIS_MCPARTGRAPHRECURSIVE(int *, int *, idxtype *, idxtype *, idxtype *, idxtype *, int *, int *, int *, int *, int *, idxtype *);
 void metis_mcpartgraphrecursive(int *, int *, idxtype *, idxtype *, idxtype *, idxtype *, int *, int *, int *, int *, int *, idxtype *);
 void metis_mcpartgraphrecursive_(int *, int *, idxtype *, idxtype *, idxtype *, idxtype *, int *, int *, int *, int *, int *, idxtype *);


### PR DESCRIPTION
# Description

1. Updating logic in code so that the user may set `NTIF=0` when using the analytical TIP solution and when `NTIP=1` since there is no need to specify the tidal potential harmonics in that case. Note that if `NTIP=2`, the harmonic constituents still are required.
2. Specifying `NTIF>0` and `NTIP==0` is now an error
> [!WARNING] 
Previously, the code used to ignore these values, however, it seems more likely that someone could accidentally set `NTIP=0` erroneously while specifying the tidal potential values and receive a subtly incorrect result, therefore, the code will now fail when this is the case.
 
3. Updating the reporting by Metis to use bytes/megabytes/gigabytes for more user interpretable display

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes