### PR TITLE
Fixing behavior for warning elevation debug file when activated through namelist

### DIFF
--- a/src/read_input.F
+++ b/src/read_input.F
@@ -728,6 +728,31 @@ C     WJP add namelist
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 
+      if(iWarnElevDump.ne.0) WarnElevDump = .True.
+      write(scratchMessage,'(A,e16.8)') 'A warning will be issued '//
+     &                     'if elevation exceeds WarnElev = ',WarnElev
+      call logMessage(INFO,scratchMessage)
+      if(WarnElevDump)then
+          write(scratchMessage,'(A,e16.8,A)') 
+     &     'A global elevation file (fort.69)'//
+     &     ' will be written if WarnElev (',WarnElev,') is exceeded'
+          call logMessage(INFO,scratchMessage)
+          write(scratchMessage,'(A,I0,A)') 
+     &     'Execution will be terminated '//
+     &     'if ',WarnElevDumpLimit,' global elevation snaps have been '//
+     &     'written as warning.'
+          call logMessage(INFO,scratchMessage)
+      else
+          write(scratchMessage,'(A,e16.8,A)') 
+     &     'A global elevation file (fort.69)'//
+     &     ' will NOT be written if WarnElev (',WarnElev,') is exceeded'
+          call logMessage(INFO,scratchMessage)
+      endif    
+      write(scratchMessage,'(A,e16.8)') 
+     &     'Execution will be terminated if elevation exceeds ',
+     &     ErrorElev 
+      call logMessage(INFO,scratchMessage)
+
 !     WJP add namelist for Ali's dispersion
 !     Defaults are already in global 
       namelistSpecifier = 'AliDispersionControl'
@@ -881,20 +906,6 @@ C
  1952    FORMAT(/,5X,'NFOVER = ',I3,
      &        /,9X,'NON-FATAL INPUT ERRORS WILL STOP EXECUTION ',/)
       ENDIF
-#ifdef DEBUG_WARN_ELEV
-      IF (iWarnElevDump .ne. 0) WarnElevDump = .True.
-      WRITE(16,1953) WarnElev,WarnElevDump,WarnElevDumpLimit,ErrorElev
- 1953 FORMAT(//,5X,
-     &     'A warning will be issued if elevation exceeds WarnElev = ',
-     &     e16.8,
-     &     /,5X,'A global elevation file (fort.69) will be written if '
-     &     /,5X,'WarnElev is exceeded and WarnElevDump is true: ',L2,
-     &     /,5X,'Execution will be terminated if ',
-     &     '(WarnElevDumpLimit = 'I3,') ',
-     &     /,5X,'global elevation files have been written as warning.'
-     &     /,5X,'Execution will be terminated if elevation exceeds'
-     &     ' ErrorElev =',e16.8)
-#endif
 C...
 C...  READ AND PROCESS NABOUT - ABBREVIATED UNIT 16 OUTPUT OPTION
 C...

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -1306,12 +1306,13 @@ C     output the global node number to debug the local PE fort.14s
      &           3X,'** WARNING: Elevation.gt.WarnElev **')
             IF (WarnElevDump) WarnElevExceeded=1
          ENDIF
-#ifdef DEBUG_WARN_ELEV
-         call WarnElevSum(WarnElevExceeded)
-         IF (WarnElevExceeded.ne.0) THEN
-            CALL WriteWarnElev(TimeLoc, IT)
+
+         IF(WarnElevDump)THEN
+             call WarnElevSum(WarnElevExceeded)
+             IF (WarnElevExceeded.ne.0) THEN
+                CALL WriteWarnElev(TimeLoc, IT)
+             ENDIF
          ENDIF
-#endif
          ErrorElevExceeded = 0                ! Clint's Zombie Slyaer
          IF(ELMAX.GT.ErrorElev) THEN
 
@@ -1382,9 +1383,7 @@ C     output the global node number to debug the local PE fort.14s
      &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
      &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
      &           2X,'** WARNING: Elevation.gt.WarnElev **')
-#ifdef DEBUG_WARN_ELEV
             IF (WarnElevDump) CALL WriteWarnElev(TimeLoc, IT)
-#endif
          ENDIF
          IF(ELMAX.GT.ErrorElev) THEN
             write(6,*) 'elmax, errorelev',elmax, errorelev !jgf


### PR DESCRIPTION
# Description

The `fort.69` warning elevation debug file was not written when the behavior was toggled through the `WarnElevControl` namelist unless the deprecated flag `-DDEBUG_WARN_ELEV` was used during compilation

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
