### PR TITLE
Checking and deallocating kdtree allocs

### DIFF
--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -2549,6 +2549,7 @@ C----------------------------------------------------------------------
       tree => kdtree2_create(bcxy,rearrange=.true.,sort=.true.)
 
 !     allocate space for the search results from the tree
+      IF(ALLOCATED(KDRESULTS)) DEALLOCATE(KDRESULTS)
       allocate(KDRESULTS(srchdp))
 
 
@@ -2624,7 +2625,8 @@ C----------------------------------------------------------------------
          ENDIF
       enddo !loop over station points
 
-!     Deallocate the tree
+!     Deallocate the tree and results 
+      IF(ALLOCATED(KDRESULTS)) DEALLOCATE(KDRESULTS)
       call kdtree2_destroy(tp=tree)
 
  1234 format(A30,1x,I4,1x,'does not lie in the grid.')

--- a/src/owiwind_netcdf.F
+++ b/src/owiwind_netcdf.F
@@ -1082,7 +1082,7 @@
       ENDDO
 
       CALL kdtree2_destroy(tp=kdTree)
-
+      IF(ALLOCATED(kdResult)) DEALLOCATE(kdResult)
 #if defined(OWIWIND_TRACE) || defined(ALL_TRACE)
         call allMessage(DEBUG,"Return.")
 #endif

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -3067,6 +3067,7 @@ C...  Create the search tree
 
 C...  allocate space for the search results from the tree
 C...  this space will be deallocated later in the subroutine
+      IF(ALLOCATED(KDRESULTS)) DEALLOCATE(KDRESULTS)
       ALLOCATE(KDRESULTS(SRCHDP))
 
       ! Making baroclinic terms zero initially
@@ -6243,6 +6244,8 @@ C
 
       Xsta = InputXCoordinate
       Ysta = InputYCoordinate
+      IF(ALLOCATED(KDRESULTS)) DEALLOCATE(KDRESULTS)
+      allocate(KDRESULTS(srchdp))
 
       call kdtree2_n_nearest(tp=tree,qv=(/Xsta,Ysta/),
      &                  nn=srchdp,results=KDRESULTS)
@@ -6315,6 +6318,8 @@ C...             the next element
             call ADCIRC_Terminate()
          ENDIF
       ENDIF
+       
+      IF(ALLOCATED(KDRESULTS)) DEALLOCATE(KDRESULTS)
 
  9892 FORMAT(///,1X,'!!!!!!!!!!  WARNING - NONFATAL ',
      &     'INPUT ERROR  !!!!!!!!!',//


### PR DESCRIPTION

# Description

Checking and deallocating kdtree allocatables before allocating and after using results/output.

We were experiencing random seg faulting, and only on Frontera, so we thought it was related to memory alignment of arrays Frontera's architecture specifically. Running with some traceback/debugging and tighter compiler flags, we found that it was complaining about allocating already allocated arrays.

We probably found this because we are also using the kdtree a bunch inside the NWS13 code, and the expectations of the original kdtree code about existing allocated arrays, and use in other parts of the code are now broken.

## Type of change

- [ x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Update to existing feature to add new functionality
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

Issue #427 references a model build that applies these changes, but is an issue for a different bug entirely. However, maybe our changes created this bug?

# How Has This Been Tested?

Shotgun testing for the conditions that randomly would cause the seg faults with our HSOFSR mesh and NWS13 inputs, and a Persian Gulf mesh with NWS13 inputs. Running as container with apptainer installed on TACCs Frontera cluster using 256 to 1120 MPI tasks. About 600 simulations.

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing tests pass locally with my changes
- [ ] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

Changes are based on the codebase as of release v56.0.1. Existing CI tests are not run on the specific hardware architecture that we found caused the issue. No documentation would be impacted.
