### PR TITLE
Adding check for station output type in packTwo

### DIFF
--- a/src/globalio.F
+++ b/src/globalio.F
@@ -233,14 +233,6 @@ C! CMPI
                   if ( descript % isStation.eqv..false. ) then
                      if ( nodecode(i).eq.0 ) then
                         buf(iglobal-ioffset) = descript % alternate_value
-#ifdef ADCNETCDF
-#ifdef WDVAL_NETCDF
-! DW to prevent NaN in matlab
-
-                        buf(iglobal-ioffset) = descript % alternate_value
-     &                      + sign(100.0, descript%alternate_value)
-#endif
-#endif
                      endif
                   endif
                endif
@@ -332,19 +324,11 @@ C! CMPI
         iglobal = descript % imap(i)
         if (istart <= iglobal .and. iglobal <= iend) then
           j = 2*(iglobal - ioffset) - 1
-          if(descript%considerWetDry.and.nodecode(i).eq.0)then
+          if (descript%considerWetDry .and. 
+     &         (.not.descript%isStation) .and. 
+     &         (nodecode(i).eq.0) ) then
             buf(j)     = descript % alternate_value
             buf(j + 1) = descript % alternate_value
-
-#ifdef ADCNETCDF
-#ifdef WDVAL_NETCDF
-            buf(j)     = descript % alternate_value +
-     &             sign(100.0,descript%alternate_value)
-            buf(j + 1) = descript % alternate_value +
-     &             sign(100.0,descript%alternate_value)
-#endif
-#endif
-
           else
             buf(j)     = descript % array(i)
             buf(j + 1) = descript % array2(i)


### PR DESCRIPTION
Resolves #427. This will be released as v56.0.3

> [!note] 
> We expect tests using velocity stations to fail, however, the main branch has the corrected solutions

# Description

Resolving #427 in the release branch

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Issue Number

#427

# How Has This Been Tested?

Solutions tested

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->