### PR TITLE
Added option to remove dphidt from computations

### DIFF
--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -325,6 +325,7 @@ Casey 180318: Added NWS=13
       character(200) :: subgridFilename = 'null'
       logical :: level0 = .true. 
       logical :: level1 = .false.
+      logical :: phi_time_derivative = .false.
 
       ! jgf52.08.02: For inundation output control. Wanted to just
       ! use the variables of the same name from the write_output module,

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2362,7 +2362,8 @@ Casey 180318: Added NWS=13
      &         "&subgridControl",
      &         " subgridFilename='",trim(adjustl(subgridFilename)),
      &         "' level0=",level0,
-     &         " level1=",level1," /"
+     &         " level1=",level1,
+     &         " phi_time_derivative=",phi_time_derivative," /"
          endif
 
 

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -563,7 +563,7 @@ C.... "new" formula for computing vel in wetting/drying routine
 C.... DMW
 !JLW: adding subgrid control namelist
       integer :: ios_subgrid
-      namelist /subgridControl/ subgridFilename, level0, level1
+      namelist /subgridControl/ subgridFilename, level0, level1, phi_time_derivative
       ! jgf52.08.02 : For inundation output files.
       namelist /inundationOutputControl/ inundationOutput, inunThresh
 

--- a/src/cstart.F
+++ b/src/cstart.F
@@ -1770,6 +1770,7 @@ C----------------------------------------------------------------------
      &                   , numPhi
      &                   , wetDepthVertETA2
      &                   , gridDepthVertTab
+     &                   , phi_time_derivative, dphidt
       implicit none
       integer :: nm1, nm2, nm3  ! node numbers around the element
       integer :: nc1, nc2, nc3  ! nodecodes around the element
@@ -1845,6 +1846,12 @@ C----------------------------------------------------------------------
          nnodecode(:)=1
          ! set all elements to wet by default.
          noff(:)=1
+!JLW: set dphidt term
+         if(phi_time_derivative)then
+            dphidt = 1
+         else
+            dphidt = 0
+         endif
 !JLW: call subgrid lookup table read in
          call readSubgridLookup()
          if(nolifa.eq.2)then

--- a/src/gwce.F
+++ b/src/gwce.F
@@ -294,6 +294,7 @@ C... SB
      &   , gridDepthVertETA1, gridDepthVertETA2
      &   , wetFracVertETA1, wetFracVertETA2
      &   , cadvVertETA2
+     &   , dphidt
 
       IMPLICIT NONE
 
@@ -538,10 +539,11 @@ C
                MsFacLOffDiag=OffDiag*AreaIE*(1.d0/DT+Tau0Avg_S/2.d0)/DT/12.d0
 !JLW: adding subgrid to the on and off diagonal terms
                IF(level0)THEN
+!JLW: adding option to turn off dphidt term
                   MSFacLOnDiag = MSFacLOnDiag*PHIAVG2 + OnDiag
-     &               *AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
+     &               *dphidt*AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
                   MSFacLOffDiag = MSFacLOffDiag*PHIAVG2 + OffDiag
-     &               *AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
+     &               *dphidt*AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
                ENDIF
 C
 C.......... DW
@@ -1429,9 +1431,11 @@ C
 !JLW: adding the wet area fraction to the time derivative terms and the
 !water surface gradient term
          IF(level0)THEN
+!JLW: adding dphidt option
             MSFacR = PHIAVG2*MSFacR - 
-     &         AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
-            GOAreaIE4 = GOAreaIE4*PHIAVG2
+     &         dphidt*AreaIE*((PHIAVG2-PHIAVG1)/2.d0)/DT/12.d0
+!JLW: removing the following subgrid addition because incorrect
+!            GOAreaIE4 = GOAreaIE4*PHIAVG2
          ENDIF
          Tau0SpaVar=(QX1Avg*Tau0XGrad2A+QY1Avg*Tau0YGrad2A)/6.d0
          A00pB00=A00+B00

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -172,7 +172,7 @@ Casey 180318: Added NWS=13
      &                          NWS13WindMultiplier
 #endif
 !JLW: add subgrid 
-      USE subgrid, only: subgridFilename, level0, level1
+      USE subgrid, only: subgridFilename, level0, level1, phi_time_derivative
       use mod_tidepotential, only: tidePotential, t_tidePotential
 
       IMPLICIT NONE
@@ -242,7 +242,8 @@ C.... DMW
      &    NWS13WindMultiplier,NWS13GroupForPowell
 #endif
 !JLW: adding subgrid namelist
-      NAMELIST /subgridControl/ subgridFilename, level0, level1
+      NAMELIST /subgridControl/ subgridFilename, level0, level1,
+     &    phi_time_derivative
 
       NAMELIST /WindGrib2NetCdf/ read_NWS14_NetCdf_using_core_0
 !Aman Tejaswi
@@ -620,6 +621,8 @@ C.... DMW
       write(scratchMessage,*) "level0=",level0
       call logMessage(ECHO,trim(scratchMessage))
       write(scratchMessage,*) "level1=",level1
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,*) "phi_time_derivative=",phi_time_derivative
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 

--- a/src/subgridLookup.F
+++ b/src/subgridLookup.F
@@ -43,6 +43,9 @@
       LOGICAL :: level0
       ! Flag for subgrid corrections to bottom friction and advection
       LOGICAL :: level1
+!JLW: adding logical for dphidt to be turned off - set default to off
+      LOGICAL :: phi_time_derivative = .false.
+      INTEGER :: dphidt ! used to 0 out the term
       ! Number of surface elevations used in subgrid preprocessor
 !      INTEGER :: numSurLevs
 !      ! Number of possible phi values


### PR DESCRIPTION
The dphidt term came out of the averaging of the GWCE. At high timesteps, this term can become negatively large and violate the hyperbolicity criteria of the GWCE causing a failure. Added a namelist 'dphidtoff' that when set to true will turn off this term allowing for higher time steps.