### PR TITLE
Adding automated Docker container build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ parameters:
 executors:
   intel_executor:
     docker:
-      - image: zcobell/adcirc-ci-container:v56
+      - image: adcircorg/adcirc-ci:2025.0.1-intel
   gcc_executor:
     docker:
-      - image: zcobell/adcirc-ci-container:latest-gcc
+      - image: adcircorg/adcirc-ci:2025.0.1-gcc
 
 # #############################
 # Aliases for the environments

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -1,0 +1,42 @@
+name: Build ADCIRC Workflow Template
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_LOGIN_USERNAME:
+        required: true
+      DOCKERHUB_LOGIN_TOKEN:
+        required: true
+
+jobs:
+  adcirc-container:
+    name: Build ADCIRC container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LOGIN_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and push ADCIRC Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./containers/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: adcircorg/adcirc:${{ inputs.tag }}
+          labels: org.adcircorg.adcirc

--- a/.github/workflows/container_nightly.yaml
+++ b/.github/workflows/container_nightly.yaml
@@ -1,0 +1,13 @@
+name: Nightly ADCIRC Container Build
+
+# Trigger the workflow every day at 5 AM (UTC).
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  push-build:
+    uses: ./.github/workflows/build_container.yaml
+    with:
+      tag: nightly 
+    secrets: inherit

--- a/.github/workflows/container_release.yaml
+++ b/.github/workflows/container_release.yaml
@@ -1,0 +1,10 @@
+name: Release ADCIRC Container Build
+on:
+  release:
+    types: [published]
+jobs:
+  release-version-build-and-deploy:
+    uses: ./.github/workflows/build_container.yaml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ADCIRC
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/adcirc/adcirc/tree/main.svg?style=shield&circle-token=468312e3a9341f3a519bbdfb4df0cda07c98bd91)](https://dl.circleci.com/status-badge/redirect/gh/adcirc/adcirc/tree/main)
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/adcircorg/adcirc/v56.0.3?logo=docker&label=adcircorg%2Fadcirc)](https://hub.docker.com/r/adcircorg/adcirc)
+
 
 ADCIRC is a system of computer programs for solving time dependent, free surface circulation and transport problems in
 two and three dimensions. These programs utilize the finite element method in space allowing the use of highly flexible,

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,58 @@
+FROM zcobell/adcirc-ci-container:v56 AS builder
+
+USER root
+
+RUN mkdir -p /home/adcirc/adcirc-build/build
+COPY src /home/adcirc/adcirc-build/src
+COPY prep /home/adcirc/adcirc-build/prep
+COPY scripts /home/adcirc/adcirc-build/scripts
+COPY util /home/adcirc/adcirc-build/util
+COPY wind /home/adcirc/adcirc-build/wind
+COPY cmake /home/adcirc/adcirc-build/cmake
+COPY thirdparty /home/adcirc/adcirc-build/thirdparty
+COPY CMakeLists.txt /home/adcirc/adcirc-build/CMakeLists.txt 
+
+RUN cd /home/adcirc/adcirc-build/build && \
+    source /opt/spack-environment/activate.sh && \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/opt/adcirc \
+        -DCMAKE_C_COMPILER=icx \
+        -DCMAKE_CXX_COMPILER=icx \
+        -DCMAKE_Fortran_COMPILER=ifx \
+        -DBUILD_ADCIRC=ON \
+        -DBUILD_PADCIRC=ON \
+        -DBUILD_ADCSWAN=ON \
+        -DBUILD_PADCSWAN=ON \
+        -DBUILD_ADCPREP=ON \
+        -DBUILD_ASWIP=ON \
+        -DENABLE_OUTPUT_NETCDF=ON \
+        -DENABLE_OUTPUT_XDMF=ON \
+        -DENABLE_DATETIME=ON \
+        -DENABLE_GRIB2=ON \
+        -DCMAKE_Fortran_FLAGS_RELEASE="-O2 -fp-model=precise" \
+        -DCMAKE_C_FLAGS_RELEASE="-O2 -DNDEBUG -fp-model=precise" \
+        -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG -fp-model=precise" \
+        -DNETCDF_F90_ROOT=$NETCDF_FORTRAN_HOME \
+        -DNETCDFHOME=$NETCDFHOME \
+        -DXDMFHOME=$XDMFHOME \
+        -G Ninja && \
+        ninja && \
+        ninja install 
+
+FROM zcobell/adcirc-ci-container:v56 AS adcirc
+
+USER root 
+COPY --from=builder /opt/adcirc /opt/adcirc 
+RUN echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/opt/views/view/lib64" >> /opt/spack-environment/activate.sh
+RUN echo "export PATH=\$PATH:/opt/adcirc/bin" >> /opt/spack-environment/activate.sh
+
+USER adcirc
+WORKDIR /home/adcirc
+
+LABEL "maintainer"="Zach Cobell <zcobell@gmail.com>"
+LABEL "io.k8s.description"="ADCIRC Docker Container"
+LABEL "io.openshift.expose-services"="None"
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]
+

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,4 +1,4 @@
-FROM zcobell/adcirc-ci-container:v56 AS builder
+FROM adcircorg/adcirc-ci:2025.0.1-intel AS builder
 
 USER root
 
@@ -39,7 +39,7 @@ RUN cd /home/adcirc/adcirc-build/build && \
         ninja && \
         ninja install 
 
-FROM zcobell/adcirc-ci-container:v56 AS adcirc
+FROM adcircorg/adcirc-ci:2025.0.1-intel AS adcirc
 
 USER root 
 COPY --from=builder /opt/adcirc /opt/adcirc 


### PR DESCRIPTION
# Description

Adding Docker container builds to ADCIRC which will be stored at `docker:adcircorg/adcirc`. These builds are presently for `amd64` machines only, though, we expect to add `arm64/aarch64` as well. The builds are fully featured, including MPI, netCDF, XDMF, and GRIB2. They may be used with Docker or Singularity and may also be used on Windows via Docker/Docker Desktop.

Builds are generated automatically from the main branch each night with the `nightly` tag as well as any time a version of the code is released. The code utilizes the same infrastructure developed to support the CI testing. The `amd64` version of the container is build using the `IntelLLVM` compiler and we expect that the GCC compilers will be used for the `arm64` flavor of the container. 

Upon logging in, the ADCIRC executables (i.e. `adcirc`, `adcprep`, `padcirc`, `padcswan`, `aswip`, etc) will be in the user's path. Note that if running automated scripts using the containers, the user will need to source the file `/opt/spack-environment/activate.sh` to correctly set the environment variables. For normal interactive logins, this is done via the entry point script automatically. 

The hope is that these containers lower the bar for new users to get up and running with the model without needing to worry about compilers/mpi libraries/netcdf/etc. 

## Type of change

<!--- Select the type of change -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`