### PR TITLE
Updating tide potential calculations to explicitly use double precision

### DIFF
--- a/src/astronomic.F90
+++ b/src/astronomic.F90
@@ -33,11 +33,11 @@ module mod_astronomic
                         MIN2DEG = 0.01666666666666d0
 
   ! Astronomical unit in km
-  real(8), parameter :: AUDIST = 1.495978707e+8
+  real(8), parameter :: AUDIST = 1.495978707d+8
   real(8), parameter :: km2AU = 1.d0/AUDIST
 
   ! Ratio of Sun/Moon mass to Earth mass: Wikipedia !
-  real(8), parameter :: MassRatioSunEarth = 332946.0487
+  real(8), parameter :: MassRatioSunEarth = 332946.0487d0
   real(8), parameter :: MassRatioMoonEarth = 1.d0/81.3005678d0
 
   ! Keep the value in two saperate numbers: significant and exponent
@@ -114,9 +114,9 @@ contains
     integer :: A, B
     real(8) :: D, M, Y
     character(LEN=9) :: CTYPE = 'Gregorian'
-    D = DD
-    M = MM
-    Y = YYYY
+    D = dble(DD)
+    M = dble(MM)
+    Y = dble(YYYY)
 
     if (present(CALENDAR_TYPE)) then
       select case (trim(CALENDAR_TYPE))
@@ -131,13 +131,13 @@ contains
     end if
 
     A = floor(Y/100.d0)
-    B = 2 - A + floor(A/4.d0)
+    B = 2 - A + floor(dble(A)/4.d0)
     select case (trim(CTYPE))
     case ('Julian')
       B = 0
     end select
 
-    JD = floor(365.25d0*(Y + 4716)) + floor(30.6001d0*(M + 1)) + D + B - 1524.50
+    JD = dble(floor(365.25d0*(Y + 4716d0))) + dble(floor(30.6001d0*(M + 1d0))) + dble(D) + dble(B) - 1524.50d0
 
   end function JULIANDAY
 
@@ -171,25 +171,25 @@ contains
     logical :: include_nutation = .false.
 
     ! If nutation is require !
-    real(8) :: LP, L0, OG, DPsi, Dvareps, vareps
+    real(8) :: LP, L0, OG, DPsi, vareps
     logical :: have_asval = .false.
     ! Find JD of the date at UT 0h
-    RM = JD - floor(JD)
+    RM = JD - dble(floor(JD))
 
     JD0 = JD
-    if (RM < 0.5d0 - 1.0e-10) then
-      JD0 = floor(JD) - 0.5
-    else if (RM > 0.5d0 + 1.0e-10) then
-      JD0 = floor(JD) + 0.5
+    if (RM < 0.5d0 - 1.0d-10) then
+      JD0 = dble(floor(JD)) - 0.5d0
+    else if (RM > 0.5d0 + 1.0d-10) then
+      JD0 = dble(floor(JD)) + 0.5d0
     end if
     RM = JD - JD0
 
     ! Compute T at UT 0h
-    T = (JD0 - 2451545.0)/36525.d0
+    T = (JD0 - 2451545.0d0)/36525.d0
 
     ! \Theta0 EQ. (12.2) page 87
-    gmst = 100.46061837d0 + 36000.770053608*T &
-           + T*T*(0.000387933 - T/38710000.d0)
+    gmst = 100.46061837d0 + 36000.770053608d0*T &
+           + T*T*(0.000387933d0 - T/38710000.d0)
 
     ! Mean sidereal time at Greenwich for JD. Page 87
     gmst = gmst + 1.00273790935d0*RM*360.d0
@@ -198,7 +198,7 @@ contains
 
     if (include_nutation) then
       if (present(ASVAL)) then
-        if (abs(JD - ASVAL%JD) < 1.0e-9) have_asval = .true.
+        if (abs(JD - ASVAL%JD) < 1.0d-9) have_asval = .true.
       end if
 
       if (.not. have_asval) then
@@ -261,7 +261,7 @@ contains
     real(8) :: M
     real(8), intent(IN) :: T
 
-    M = 357.5291092d0 + T*(35999.0502909 &
+    M = 357.5291092d0 + T*(35999.0502909d0 &
                            + T*(-0.0001536d0 &
                                 + T*(1.d0/24490000.d0)))
   end function M_DEG
@@ -287,8 +287,8 @@ contains
     real(8), intent(IN) :: T
 
     F = 93.2720950d0 + T*(483202.0175233d0 &
-                          + T*(-0.0036539 &
-                               + T*(-1.d0/3526000 &
+                          + T*(-0.0036539d0 &
+                               + T*(-1.d0/3526000d0 &
                                     + T*(1.d0/863310000.d0))))
   end function F_DEG
 
@@ -315,7 +315,7 @@ contains
     implicit none
     real(8), intent(IN) :: T
     eps = 0.016708634d0 + T*(-0.000042037d0 &
-                             - 0.0000001267*T)
+                             - 0.0000001267d0*T)
   end function eccentricity_earth_orbit
 
   ! The nutation in longitude. p. 144
@@ -367,7 +367,7 @@ contains
 
     varepsilon0 = 23.d0 + 26.d0*min2deg + 21.448d0*sec2deg
 
-    varepsilon0 = varepsilon0 + U*(-4680.93*sec2deg &
+    varepsilon0 = varepsilon0 + U*(-4680.93d0*sec2deg &
                                    + U*(-1.55d0 &
                                         + U*(1999.25d0 &
                                              + U*(-51.38d0 &

--- a/src/ephemerides.F90
+++ b/src/ephemerides.F90
@@ -48,9 +48,9 @@ module mod_ephemerides
     module procedure createEphemerides
   end interface t_ephemerides
 
-  private :: interpolate, L, adjust_RA, GET_RANK_SIMPLE_SEARCH, &
-             GET_RANK_UNIFORM, GET_RANK_BINARY_SEARCH, initialize_ephemerides, &
-             recache_data, reallocate_arrays
+  private
+
+  public :: t_ephemerides, heavenly_objs_coords_from_table
 
 contains
 
@@ -99,7 +99,7 @@ contains
 #endif
     call exit(1)
 #else
-    integer :: retval, j, ii
+    integer :: j, ii
     real(8) :: julian_datetime_2000, seconds_between
     logical :: UniformRankSearch = .false.
     real(8) :: ratmp(4)
@@ -185,13 +185,14 @@ contains
     logical, intent(in) :: UniformRankSearch
 
 #ifdef ADCNETCDF
-    integer, parameter :: NC_ERR = -1
-    integer :: time_dimid, ndimsp, dimlen
+    integer :: ndimsp, dimlen
     integer :: ncid, time_varid, lunar_distance_varid, solar_distance_varid
     integer :: lunar_ra_varid, solar_ra_varid, lunar_dec_varid, solar_dec_varid
     integer :: lenarr, iabeg, iaend
     integer :: dimids(nf90_max_dims)
     real(8), allocatable :: tmparr(:)
+
+    ierr = 0
 
     ! Open the NetCDF file
     call check_err(nf90_open(self%MoonSunCoordFile, nf90_nowrite, ncid))
@@ -332,35 +333,35 @@ contains
   end subroutine L
 
   ! Return a rank j in ARR such that arr(j-1) < val <= arr(j1) !
-  function GET_RANK_SIMPLE_SEARCH(val, arr, len) result(rank)
-    implicit none
-
-    integer :: rank
-    real(8), intent(IN) :: val
-    real(8), intent(IN) :: arr(:)
-    integer, intent(IN) :: len
-
-    integer :: J
-
-    if (val < arr(1)) then
-      rank = 0; 
-      return; 
-    end if
-
-    if (val > arr(len)) then
-      rank = len + 1; 
-      return; 
-    end if
-
-    RANK = 0; 
-    do J = 1, LEN
-      if (ARR(J) >= val) then
-        RANK = J; 
-        exit; 
-      end if
-    end do
-
-  end function GET_RANK_SIMPLE_SEARCH
+!  function GET_RANK_SIMPLE_SEARCH(val, arr, len) result(rank)
+!    implicit none
+!
+!    integer :: rank
+!    real(8), intent(IN) :: val
+!    real(8), intent(IN) :: arr(:)
+!    integer, intent(IN) :: len
+!
+!    integer :: J
+!
+!    if (val < arr(1)) then
+!      rank = 0;
+!      return;
+!    end if
+!
+!    if (val > arr(len)) then
+!      rank = len + 1;
+!      return;
+!    end if
+!
+!    RANK = 0;
+!    do J = 1, LEN
+!      if (ARR(J) >= val) then
+!        RANK = J;
+!        exit;
+!      end if
+!    end do
+!
+!  end function GET_RANK_SIMPLE_SEARCH
 
   ! Find a rank j in arr such that arr(j-1) < val < = arr(j)         !
   ! in a unifrom table, i,e, arr(i+1) - arr(i) = arr(i+2) - arr(i+1) !
@@ -413,7 +414,7 @@ contains
     high = len; 
     do
       mid = (low + high)/2; 
-      if (abs(val - arr(mid)) < 1.0e-12) then
+      if (abs(val - arr(mid)) < 1.0d-12) then
         ! Exact match is found !
         rank = mid; 
         exit; 

--- a/src/moon.F90
+++ b/src/moon.F90
@@ -443,7 +443,7 @@ contains
 
     ! Check if the astroval
     if (present(ASVAL)) then
-      if (abs(JD - ASVAL%JD) < 1.e-9) have_asval = .true.
+      if (abs(JD - ASVAL%JD) < 1.d-9) have_asval = .true.
     end if
     if (present(NUTATION)) use_nutation = NUTATION
 
@@ -521,11 +521,8 @@ contains
     real(8), intent(IN) :: LP, D, M, MP, F
     real(8), intent(IN) :: E, A1, A2, A3
 
-    integer :: I, J
     real(8) :: suml, sumr, sumb
     real(8) :: vec(4), argval(NPER), epmul(NPER)
-
-    LOGICAL, save:: first = .TRUE. ; 
 
     ! Convert from degree to radian
     vec = DEG2RAD*(/D, M, MP, F/)

--- a/src/netcdf_error.F90
+++ b/src/netcdf_error.F90
@@ -15,9 +15,11 @@ module netcdf_error
 !     fort.16 file.
 !-----------------------------------------------------------------------
     subroutine check_err(iret)
-      USE SIZES, ONLY : myproc
-      USE GLOBAL, ONLY : screenUnit, ERROR, DEBUG, allMessage, &
+      USE GLOBAL, ONLY : ERROR, allMessage, &
           setMessageSource, unsetMessageSource
+#if defined(NETCDF_TRACE) || defined(ALL_TRACE)
+      USE GLOBAL, ONLY : DEBUG
+#endif
 #ifdef CMPI
       USE MESSENGER, ONLY : MSG_FINI
 #endif
@@ -52,7 +54,7 @@ module netcdf_error
       IMPLICIT NONE
       LOGICAL, OPTIONAL :: NO_MPI_FINALIZE
 #if defined(NETCDF_TRACE) || defined(ALL_TRACE)
-      REAL, ALLOCATABLE :: dummy(:)
+      REAL(8), ALLOCATABLE :: dummy(:)
 #endif
 
       call setMessageSource("netcdfTerminate")
@@ -67,7 +69,8 @@ module netcdf_error
          ! a stack trace to determine the line number of the netcdf call
          ! that went bad ... this assumes that the code was compiled with
          ! debugging symbols, bounds checking, and stack trace turned on.
-         dummy(1) = 99.9d0
+         allocate(dummy(1)) ! Allocating (too small) so that -Wuninitialized doesn't complain
+         dummy(2) = 99.9d0
 #endif
 
 #ifdef CMPI

--- a/src/sun.F90
+++ b/src/sun.F90
@@ -28,8 +28,7 @@ module mod_sun_coordinates
   end interface SUN_COORDINATES
 
   private :: SUN_COORDINATES_SUB0, SUN_COORDINATES_SUB1, &
-             SUN_CENTER, SUN_LON, SUN_NU, SUN_RADIUS, &
-             SOLAR_DEC, SOLAR_RA
+             SUN_CENTER, SUN_LON, SUN_NU, SUN_RADIUS
 
 contains
 
@@ -62,7 +61,7 @@ contains
     SLON = L0 + C    ! Sun's true longtiude
 
     if (present(DPsi)) then
-      SLON = SLON - 0.00569 + Dpsi
+      SLON = SLON - 0.00569d0 + Dpsi
     end if
   end function SUN_LON
 
@@ -97,42 +96,42 @@ contains
   ! Solar's declination. Page 165.
   !  - SLON = the Sun's longtitude
   !  - VarEps = the obliquity of the ecliptic
-  real(8) elemental function SOLAR_DEC(SLON, VarEps) result(DEC)
-    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
-    implicit none
-
-    real(8), intent(IN) :: SLON, VarEps
-
-    real(8) :: SLON_RAD, VarEps_RAD
-
-    SLON_RAD = SLON*DEG2RAD
-    VarEps_RAD = VarEps*DEG2RAD
-
-    DEC = sin(SLON_RAD)*sin(VarEps_RAD)
-
-    DEC = asin(DEC)*RAD2DEG
-  end function SOLAR_DEC
+!  real(8) elemental function SOLAR_DEC(SLON, VarEps) result(DEC)
+!    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
+!    implicit none
+!
+!    real(8), intent(IN) :: SLON, VarEps
+!
+!    real(8) :: SLON_RAD, VarEps_RAD
+!
+!    SLON_RAD = SLON*DEG2RAD
+!    VarEps_RAD = VarEps*DEG2RAD
+!
+!    DEC = sin(SLON_RAD)*sin(VarEps_RAD)
+!
+!    DEC = asin(DEC)*RAD2DEG
+!  end function SOLAR_DEC
 
   ! Solar's right ascension. Page 165.
   !  - SLON = the Sun's longtitude
   !  - VarEps = the obliquity of the ecliptic
-  real(8) elemental function SOLAR_RA(SLON, VarEps) result(RA)
-    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
-    implicit none
-
-    real(8), intent(IN) :: SLON, VarEps
-
-    real(8) :: NUM, DEN
-    real(8) :: SLON_RAD, VarEps_RAD
-
-    SLON_RAD = SLON*DEG2RAD
-    VarEps_RAD = VarEps*DEG2RAD
-
-    NUM = cos(VarEps_RAD)*sin(SLON_RAD)
-    DEN = cos(SLON_RAD)
-
-    RA = mod(atan2(NUM, DEN)*RAD2DEG, 360.d0)
-  end function SOLAR_RA
+!  real(8) elemental function SOLAR_RA(SLON, VarEps) result(RA)
+!    use ADC_CONSTANTS, only: DEG2RAD, RAD2DEG
+!    implicit none
+!
+!    real(8), intent(IN) :: SLON, VarEps
+!
+!    real(8) :: NUM, DEN
+!    real(8) :: SLON_RAD, VarEps_RAD
+!
+!    SLON_RAD = SLON*DEG2RAD
+!    VarEps_RAD = VarEps*DEG2RAD
+!
+!    NUM = cos(VarEps_RAD)*sin(SLON_RAD)
+!    DEN = cos(SLON_RAD)
+!
+!    RA = mod(atan2(NUM, DEN)*RAD2DEG, 360.d0)
+!  end function SOLAR_RA
 
   !
   ! Chapter 25. Solar coordinates. Page. 163-169
@@ -157,12 +156,12 @@ contains
     type(t_astronomic_values), optional, intent(IN) :: ASVAL
     logical, optional :: NUTATION
 
-    real(8) :: lambda, beta, T, LP, OG, L0, M, C, snu, eccen
+    real(8) :: lambda, beta, T, LP, OG, L0, M, C, eccen
     real(8) :: DPsi, vareps0, DVareps, vareps
     logical :: have_asval = .false., use_nutation = .true.
 
     if (present(ASVAL)) then
-      if (abs(ASVAL%JD - JD) < 1.0e-9) then
+      if (abs(ASVAL%JD - JD) < 1.0d-9) then
         have_asval = .true.
       end if
     end if

--- a/src/sun_moon_system.F90
+++ b/src/sun_moon_system.F90
@@ -73,7 +73,6 @@ contains
     real(8), intent(IN) :: JD
     real(8), intent(OUT) :: MOON_POS(3), SUN_POS(3)
     integer, intent(OUT) :: IERR
-    type(t_astronomic_values) :: astronomic_values
 
     call self%astronomic_values%compute_astronomic_values(JD)
     call MOON_COORDINATES(MOON_POS(1), MOON_POS(2), MOON_POS(3), JD, self%astronomic_values, self%INCLUDE_NUTATION)

--- a/src/tidalpotential.F90
+++ b/src/tidalpotential.F90
@@ -224,7 +224,7 @@ contains
   ! subroutine computing the tidal potential. It is a private
   ! subroutine called by the higher level subroutines
   function COMP_FULL_TIP_SUB0(self, tocgmst, np, slam, MoonSunCoor) result(tipval)
-    use ADC_CONSTANTS, only: sec2day, DEG2RAD, RAD2DEG
+    use ADC_CONSTANTS, only: DEG2RAD
     use mod_astronomic, only: EarthRadiusm
     implicit none
 
@@ -234,7 +234,7 @@ contains
     real(8), intent(IN) :: MoonSunCoor(3, 2)
     real(8), intent(IN) :: SLAM(:)
 
-    integer :: IOBJ, iexp
+    integer :: IOBJ
     real(8) :: RA, DEC, DELTA
     real(8) :: radius_div_Delta, KP, C0
 
@@ -349,8 +349,13 @@ contains
 
   function compute_full_tip(self, TimeLoc, NP, SLAM) result(tip)
     use ADC_CONSTANTS, only: sec2day, DEG2RAD
-    use global, only: setMessageSource, unsetMessageSource, allMessage, DEBUG
+    use global, only: setMessageSource, unsetMessageSource, allMessage
     use mod_ephemerides, only: HEAVENLY_OBJS_COORDS_FROM_TABLE
+
+#ifdef ALL_TRACE
+    use global, only: DEBUG
+#endif
+
     implicit none
 
     class(t_tidePotential), intent(INOUT) :: self
@@ -457,7 +462,7 @@ contains
   subroutine INIT_FULL_TIP(self, NP)
     use ADC_CONSTANTS, only: sec2day, hour2day, min2day
     use mod_astronomic, only: JULIANDAY
-    use mesh, only: SFEA, SLAM
+    use mesh, only: SFEA
     implicit none
 
     class(t_tidePotential), intent(INOUT) :: self
@@ -466,7 +471,6 @@ contains
     real(8) :: DDD
     integer :: YYYY, MM, DD, HH, MMM, SS
 
-    integer :: ii, cpos(2), ivec(3)
     character(LEN=80) :: tmparr
     character :: delimter(2) = (/'-', ':'/)
 


### PR DESCRIPTION
# Description

Calculations of moon/sun system converted to use double precision without implicit conversions by the compiler. This has a small, but nonzero, impact on the solution. Example images of differences in water levels and velocities are shown from one of the test cases.

![test_zeta_max_contour](https://github.com/user-attachments/assets/fa8056e3-e813-4f68-85bd-7cc554bb1145)
![max_diff_zeta_max_contour](https://github.com/user-attachments/assets/3fc6c1e3-6609-43c1-8a72-fa6d93c22e85)
![max_diff_vel_max_contour](https://github.com/user-attachments/assets/68560789-efc0-47e0-b11e-8cbd333bff53)

GFortran flags used to detect issues: `-Wconversion -Wconversion-extra -Werror`

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Code was tested in the test suite and solution updated accordingly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

# Further comments

There may be value in having these sorts of flags turned on in the CI system in the future to detect these potential issues early.