### PR TITLE
Limiting scope of Github Actions workflows

### DIFF
--- a/.github/workflows/container_latest.yaml
+++ b/.github/workflows/container_latest.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   push-build:
+    if: github.repository == 'adcirc/adcirc'
     uses: ./.github/workflows/build_container.yaml
     with:
       tag: latest 

--- a/.github/workflows/container_release.yaml
+++ b/.github/workflows/container_release.yaml
@@ -4,6 +4,7 @@ on:
     types: [published]
 jobs:
   release-version-build-and-deploy:
+    if: github.repository == 'adcirc/adcirc'
     uses: ./.github/workflows/build_container.yaml
     with:
       tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,33 +11,51 @@ on:
       - main
     paths:
       - 'docs/**'
-  
+
 jobs:
-  build-and-deploy:
+  build:
+    if: github.repository == 'adcirc/adcirc'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install sphinx sphinx_rtd_theme
           # Add any other dependencies your documentation requires
-          
+
       - name: Build documentation
         run: |
           cd docs
           make html
           # Create .nojekyll file to disable Jekyll processing
           touch _build/html/.nojekyll
-          
-      - name: Deploy to GitHub Pages
+
+      - name: Upload build artifacts
         if: github.event_name == 'push'
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs-html
+          path: docs/_build/html/
+
+  deploy:
+    if: github.event_name == 'push' && github.repository == 'adcirc/adcirc'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: docs-html
+          path: ./docs/_build/html/
+
+      - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   pre-commit:
+    if: github.repository == 'adcirc/adcirc'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Limiting the scope of GitHub actions workflows so that they do not try to run for forks. This could cause failures since outside repos will not have appropriate credentials for pushing documentation and Docker containers

## Type of change

<!--- Select the type of change -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
