### PR TITLE
Fixing uninitialized variables used in logic

### DIFF
--- a/cmake/developer.cmake
+++ b/cmake/developer.cmake
@@ -1,5 +1,7 @@
 macro(enable_developer_mode)
-  add_strict_compiler_flags(${ARGN})
+  if(ADCIRC_DEVELOPER_MODE)
+    add_strict_compiler_flags(${ARGN})
+  endif()
 endmacro()
 
 macro(add_strict_compiler_flags)
@@ -10,7 +12,7 @@ macro(add_strict_compiler_flags)
         "-Werror -Wall -Wextra -Wconversion -pedantic -fimplicit-none -Wuninitialized -Wsurprising -Wuse-without-only -Wimplicit-procedure -Winteger-division -Wconversion-extra"
     )
   else()
-    message(STATUS "No strict compiler flags defined for ${CMAKE_Fortran_COMPILER_ID}. No action taken.")
+    message(WARNING "No developer compiler flags defined for ${CMAKE_Fortran_COMPILER_ID}. No action taken.")
   endif()
 
   foreach(SOURCE_FILE ${ARGN})

--- a/src/global.F
+++ b/src/global.F
@@ -1091,7 +1091,7 @@ C     ----------------------------------------------------------------
 C     jgf49.1001 Function to get the distance along the surface of
 C     a sphere (the earth's surface in this case).
 C     ----------------------------------------------------------------
-      REAL(8) FUNCTION sphericalDistance(dx, dy, y1, y2)
+      PURE REAL(8) FUNCTION sphericalDistance(dx, dy, y1, y2)
       USE ADC_CONSTANTS,only: deg2rad, rearth
       IMPLICIT NONE
       REAL(8), intent(in) :: DX    ! longitude distance in radians

--- a/src/owiwind.F
+++ b/src/owiwind.F
@@ -769,16 +769,26 @@
 !-----------------------------------------------------------------------
             IMPLICIT NONE
             TYPE(OCEANWEATHER),INTENT(INOUT) :: this
+            LOGICAL :: do_allocate
             call setMessageSource("owi_allocate")
 #if defined(OWIWIND_TRACE) || defined(ALL_TRACE)
             call allMessage(DEBUG,"Enter.")
 #endif
-            IF((SIZE(this%p,1).NE.this%iLon).OR.(SIZE(this%p,2).NE.this%iLat))THEN
+            do_allocate = .false. 
+
+            IF(.not.allocated(this%p))then
+                do_allocate = .true.
+            ELSEIF((SIZE(this%p,1).NE.this%iLon).OR.(SIZE(this%p,2).NE.this%iLat))THEN
+                do_allocate = .true.
+            ENDIF
+
+            IF(do_allocate)THEN
                 CALL owi_deallocate(this)
                 ALLOCATE(this%p(this%ilon,this%ilat))
                 ALLOCATE(this%u(this%ilon,this%ilat))
                 ALLOCATE(this%v(this%ilon,this%ilat))
             ENDIF
+
 #if defined(OWIWIND_TRACE) || defined(ALL_TRACE)
             call allMessage(DEBUG,"Return.")
 #endif

--- a/src/wind.F
+++ b/src/wind.F
@@ -97,19 +97,19 @@ Casey 110518: Added for Mark Powell's sectorial wind drag.
       ! jgf49.1001 Variables for use in NWS=29, for embedding an asymmetric
       ! vortex from NWS19 into an OWI basin scale met field from NAM
       ! using NWS12
-      REAL(8) vortexRMW  ! Rmax of vortex data, nautical miles
-      REAL(8) vortexLat  ! @center of vortex, degrees west latitude
-      REAL(8) vortexLon  ! @center of vortex, degrees north longitude
+      REAL(8) :: vortexRMW = 0.0d0  ! Rmax of vortex data, nautical miles
+      REAL(8) :: vortexLat = 0.0d0  ! @center of vortex, degrees west latitude
+      REAL(8) :: vortexLon = 0.0d0  ! @center of vortex, degrees north longitude
       REAL(8), ALLOCATABLE :: vortexWVNX2(:) ! u wind vel from vortex model
       REAL(8), ALLOCATABLE :: vortexWVNY2(:) ! v wind vel from vortex model
       REAL(8), ALLOCATABLE :: vortexPRN2(:)  ! bar. press. from vortex model
       !
       ! radial extent of unblended vortex winds, normalized to current Rmax
-      REAL(8) pureVortex
+      REAL(8) :: pureVortex = 0.0d0
       !
       ! radial distance to point where vortex effects insignificant,
       ! normalized to current Rmax
-      REAL(8) pureBackground
+      REAL(8) :: pureBackground = 0.0d0
       !
       ! jgf50.32: The wind drag limit was originally set to 0.002d0
       ! in v46 ... the higher value of 0.0035d0 was used in ~v48 and
@@ -804,19 +804,23 @@ C     ----------------------------------------------------------------
 C     jgf49.1001 Subroutine to get the blending factor for combining
 C     NWS19 and NWS12 (from NAM) met data.
 C     ----------------------------------------------------------------
-      SUBROUTINE getBlendFactor(i, bf)
+      pure real(8) function getBlendFactor(i, vortex_rmw, 
+     &                                     vortex_distance, 
+     &                                     background_distance) result(bf)
       USE MESH, ONLY : SLAM, SFEA
       IMPLICIT NONE
       INTEGER, intent(in) :: i  ! node number
-      REAL(8), intent(out):: bf       ! blend factor, 0 to 1
-      REAL(8) XCOOR ! longitude of node in degrees
-      REAL(8) YCOOR ! latitude of node in degrees
+      REAL(8), intent(in) :: vortex_rmw
+      REAL(8), intent(in) :: vortex_distance
+      REAL(8), intent(in) :: background_distance
+      REAL(8) :: XCOOR ! longitude of node in degrees
+      REAL(8) :: YCOOR ! latitude of node in degrees
 C     distance from center of vortex to mesh node:
-      REAL(8) DX    ! longitude distance in radians
-      REAL(8) DY    ! latitude distance in radians
-      REAL(8) rad   ! point-to-point distance over a sphere, in meters
-      REAL(8) vortexOnly ! radial distance to edge of pure vortex, meters
-      REAL(8) backgroundOnly ! radial dist to undisturbed background, meters
+      REAL(8) :: DX    ! longitude distance in radians
+      REAL(8) :: DY    ! latitude distance in radians
+      REAL(8) :: rad   ! point-to-point distance over a sphere, in meters
+      REAL(8) :: vortexOnly ! radial distance to edge of pure vortex, meters
+      REAL(8) :: backgroundOnly ! radial dist to undisturbed background, meters
 C
       XCOOR=SLAM(I)*RAD2DEG
       YCOOR=SFEA(I)*RAD2DEG
@@ -829,25 +833,24 @@ C     node along a sphere
       rad = sphericalDistance(DX, DY, vortexLat, YCOOR)
 C
 C     compute the radial distances to the various regions, in meters
-      vortexOnly = pureVortex * vortexRMW
+      vortexOnly = vortex_distance * vortex_rmw
      &           * 1.852000003180799d0 * 1000.0d0
-      backgroundOnly = pureBackground * vortexRMW
+      backgroundOnly = background_distance * vortex_rmw
      &           * 1.852000003180799d0 * 1000.0d0
 C     determine which interpolation region this mesh node falls in
-      IF ( rad.le.vortexOnly ) bf = 1.0d0
-      IF ( rad.ge.backgroundOnly ) bf = 0.0d0
-C     interpolate linearly based on radial distance in the blended region
-      IF ( (rad.gt.vortexOnly).and.(rad.lt.backgroundOnly) ) THEN
+      IF ( rad.le.vortexOnly ) THEN
+        bf = 1.0d0
+      ELSEIF ( rad.ge.backgroundOnly )THEN 
+        bf = 0.0d0
+      ELSE
+C        interpolate linearly based on radial distance in the blended region
          bf = (backgroundOnly-rad)/(backgroundOnly-vortexOnly)
-Cjgfdebug         WRITE(16,*) "bf is ", bf
          IF ( (bf.gt.1.0d0).or.(bf.lt.0.0d0) ) THEN
             bf = 0.0d0
          ENDIF
       ENDIF
-Cjgfdebug      WRITE(16,*) vortexLat, vortexLon, vortexRMW, rad, bf
-      RETURN
 C     ----------------------------------------------------------------
-      END SUBROUTINE getBlendFactor
+      END FUNCTION getBlendFactor
 C     ----------------------------------------------------------------
 
 C----------------------------------------------------------------------
@@ -1591,7 +1594,7 @@ C     NWS19 into an OWI basin scale met field from NWS12 (derived from NAM).
             ENDIF
             IF (LoadCanopyCoef)
      &         CALL ApplyCanopyCoefficient(I,WindX,WindY)
-            CALL getBlendFactor(I, bf)
+            bf = getBlendFactor(I,vortexRMW, pureVortex, pureBackground)
             ! blend the wind stresses and barometric pressures
             WSX2(I) = bf*RampMete*airwaterdensityrat*WDragCo*WindX*WindMag
      &               +(1.0d0-bf)*WSX2(I)
@@ -2936,7 +2939,7 @@ C     from NAM data
             ENDIF
             IF (LoadCanopyCoef)
      &         CALL ApplyCanopyCoefficient(I,WindX,WindY)
-            CALL getBlendFactor(I, bf)
+            bf = getBlendFactor(I,vortexRMW, pureVortex, pureBackground)
             WSX2(I) = bf*RampMete2*airwaterdensityrat*WDragCo*WindX*WindMag
      &               +(1.0d0-bf)*WSX2(I)
             WSY2(I) = bf*RampMete2*airwaterdensityrat*WDragCo*WindY*WindMag
@@ -5802,8 +5805,8 @@ C***********************************************************************
       INTEGER, SAVE :: num_cycles ! num unique date/times in the fort.22
 
       REAL(8) :: rndaySeconds ! end time of the run in seconds
-      real(8) :: newVortexRMW ! average Rmax at icyc   (next fort.22 time value)
-      real(8) :: oldVortexRMW ! average Rmax at icyc-1 (previous fort.22 time value)
+      real(8) :: newVortexRMW = 0.0d0 ! average Rmax at icyc   (next fort.22 time value)
+      real(8) :: oldVortexRMW = 0.0d0 ! average Rmax at icyc-1 (previous fort.22 time value)
 
       call setMessageSource("nws20get")
 #if defined(WIND_TRACE) || defined(ALL_TRACE)


### PR DESCRIPTION
# Description

Fixes variables that could be used in logic before initialization. The fixes occur for NWS=12 and NWS=20. The fix in NWS=20 is the more impactful as it does alter the solution in the test suite (slightly). The issue is that `newVortexRMW` was always defined in terms of itself and no initial value was ever set. This could cause `NaN` values to appear in the blending factor for `NWS=20` or `NWS=30` under certain circumstances and compilers. 

From the CI perspective, this manifests as a solution that changes, seemingly randomly, when changes are made in a completely unrelated portion of the codebase. This is because the memory used by the uninitialized value likely points to memory freed earlier in the calculations, and this location may change based on different optimization decisions made by the compiler. So the value ends up containing a quasi-predictable random value, which can end up being used to make logic decisions. Therefore the solution can appear consistent even though it is not. 

This fix resolves the issue and a pass through `valgrind` confirms. Jitters in the NWS=30 test suite case (which relies on NWS=20) are removed. 

The attached graphics show the "control" solution (which is the old solution), and the "test" solution (which contains the fix). 

![station_1_zeta](https://github.com/user-attachments/assets/830bb696-b48a-4bbf-a374-b2576690c97c)
![station_2_zeta-2](https://github.com/user-attachments/assets/8252b483-cc28-4efa-9d8c-c4d8e9b14bf8)
![station_4_zeta](https://github.com/user-attachments/assets/263c5838-7d6e-4934-af0b-123858b93879)

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Tested using `valgrind` and re-running the test suite

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
