### PR TITLE
Better handle giving and receiving node activation along VEW boundaries

### DIFF
--- a/prep/pre_global.F
+++ b/prep/pre_global.F
@@ -347,6 +347,11 @@ Casey 180318: Added NWS=13
 C     VEW1D channel namelist 11/06/2023 sb
       logical :: foundVEW1DChannelControlNamelist = .false. 
       logical :: activateVEW1DChannelWetPerimeter
+      REAL(8)                 :: BARMIN64_SUBM=0.04D0   !...Minimum water depth above weir to consider submerged when the weir is already submerged
+      REAL(8)                 :: BARMIN64_NOSUBM=0.04D0  !...Minimum water depth above weir to consider submerged when the weir is not submerged
+      REAL(8)                 :: BARMIN64_SLIM=0.5D0    !...Minimum water depth above weir to consider submerged no matter the slope
+      REAL(8)                 :: BARSLIM64_ELEM=4D-4   !...Water level elemental slope threhold. A weir is considered not submerged if the water level slope is greater than this value
+      REAL(8)                 :: BARSLIM64_EDGE=1D-4   !...Water level edge slope threhold. A weir is considered not submerged if the water level slope is greater than this value
 
 C     Full luni-solar tidal potential namelist: 2024
       logical:: foundTidalPotentialControlNamelist = .false. 

--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2433,9 +2433,15 @@ c...     tcm v52.30.01 additions for Smag_Control Namelist
 
 C....    SB VEW1D channel control namelist
          if (foundVEW1DChannelControlNamelist) then
-            write(15,'(a,l,a)')
+            write(15,'(a,l,a,f15.8,a,f15.8,a,f15.8,a,f15.8,a,f15.8,a)')
      &       '&VEW1DChannelControl activateVEW1DChannelWetPerimeter=',
-     &       activateVEW1DChannelWetPerimeter," /"
+     &       activateVEW1DChannelWetPerimeter,
+     &       ', barmin64_subm=',BARMIN64_SUBM,
+     &       ', barmin64_nosubm=',BARMIN64_NOSUBM,
+     &       ', barmin64_slim=',BARMIN64_SLIM,
+     &       ', barslim64_elem=',BARSLIM64_ELEM,
+     &       ', barslim64_edge=',BARSLIM64_EDGE,
+     &       ' /'
          endif
 
 C...     wjp additions for WarnElev Namelist

--- a/prep/read_global.F
+++ b/prep/read_global.F
@@ -582,8 +582,10 @@ C.....tcm v52.30.01 added for Smag_Control
      &  dynamicWaterLevelCorrectionRampReferenceTime
 
 C.....Control for VEW1D channels 11/06/2023 sb
-      NAMELIST /VEW1DChannelControl/ activateVEW1DChannelWetPerimeter
-
+      NAMELIST /VEW1DChannelControl/ activateVEW1DChannelWetPerimeter,
+     &  BARMIN64_SUBM, BARMIN64_NOSUBM, BARMIN64_SLIM, 
+     &  BARSLIM64_ELEM, BARSLIM64_EDGE
+     
 c.....tcm v51.20.03 initialize external station location specifications
 C..... to false, meaning if locations are supplied they are in the fort.15
 C..... file.

--- a/src/boundaries.F
+++ b/src/boundaries.F
@@ -53,8 +53,10 @@ C.....for internal barrier boundaries with flowthrough pipes
       REAL(8),ALLOCATABLE ::   BARLANHT(:),BARLANCFSP(:)
       REAL(8),ALLOCATABLE ::   BARINHT(:),BARINCFSB(:),BARINCFSP(:)
       REAL(8),ALLOCATABLE ::   PIPEHT(:),PIPECOEF(:),PIPEDIAM(:)
-      INTEGER, ALLOCATABLE ::   IBCONN(:)
-      INTEGER, ALLOCATABLE ::   ISSUBMERGED64(:), ISSUBMERGED64P(:) ! used to identify submerged ibtype=64 weir  SB
+      INTEGER,ALLOCATABLE ::   IBCONN(:)
+      INTEGER,ALLOCATABLE ::   ISSUBMERGED64(:) ! used to identify submerged ibtype=64 weir  SB
+      INTEGER,ALLOCATABLE ::   BNDEDGE3RD(:) ! third node of element contaiining boundary edge
+      INTEGER,ALLOCATABLE ::   BNDEDGEELEM(:) ! element containing boundary edge
       ! these arrays will only be needed temporarily, between reading 
       ! the ascii mesh file and initializing the boundaries
       REAL(8),ALLOCATABLE ::   BARLANHTR(:,:),BARLANCFSPR(:,:)
@@ -283,8 +285,10 @@ C     ---------
       allocate ( pipeht(mnvel),pipecoef(mnvel),pipediam(mnvel))
       allocate ( ibconn(mnvel))
       allocate ( nbvv(mnbou,0:mnvel))
-      allocate ( issubmerged64(mnvel), issubmerged64p(mnvel))
+      allocate ( issubmerged64(mnvel))
       allocate ( bndlen2o3(mnvel))
+      allocate ( bndedge3rd(mnvel))
+      allocate ( bndedgeelem(mnvel))
       allocate ( ntran1(mnvel),ntran2(mnvel))
       allocate ( btran3(mnvel),btran4(mnvel),btran5(mnvel))
       allocate ( btran6(mnvel),btran7(mnvel),btran8(mnvel))
@@ -309,6 +313,8 @@ C     ---------
       ibconn = -99999
       nbvv = -99999
       bndlen2o3 = -99999.0
+      bndedge3rd = -99999
+      bndedgeelem = -99999
       bcrnbvv = -99999
       bcrnvell = -99999
       !------------------------------------------------------------------
@@ -597,7 +603,7 @@ C     ------------------------------------------------------------------
                bar2(k,i) = barlancfspr(k,i)
                p_ibconnr(k,:) = 0
             enddo
-         case(4,24)
+         case(4,24,64)
             do i=1,nvell(k)
                bar1(k,i) = barinhtr(k,i)
                bar2(k,i) = barincfsbr(k,i)

--- a/src/gwce.F
+++ b/src/gwce.F
@@ -1841,11 +1841,19 @@ C.................DMW202401 Use saved H1
 
             NCI=NodeCode(NBDI)
             NCJ=NodeCode(NBDJ)
-            BndLenO6NC=NCI*NCJ*BndLen2O3(J-1)/4.d0
-            GWCE_LV(NBDI)=GWCE_LV(NBDI)
+
+            IF(LBCODEI(J).EQ.64) THEN
+               ! Applying the flux at nodal basis to avoid imbalance between front and back side
+               BndLenO6NC=BndLen2O3(J-1)/4.d0
+               GWCE_LV(NBDI)=GWCE_LV(NBDI) + BndLenO6NC*3.d0*QForceI
+               GWCE_LV(NBDJ)=GWCE_LV(NBDJ) + BndLenO6NC*3.d0*QForceJ
+            ELSE
+               BndLenO6NC=NCI*NCJ*BndLen2O3(J-1)/4.d0
+               GWCE_LV(NBDI)=GWCE_LV(NBDI)
      &                              + BndLenO6NC*(2.d0*QForceI+QForceJ)
-            GWCE_LV(NBDJ)=GWCE_LV(NBDJ)
+               GWCE_LV(NBDJ)=GWCE_LV(NBDJ)
      &                              + BndLenO6NC*(2.d0*QForceJ+QForceI)
+            ENDIF
           ENDDO
         ENDIF
 

--- a/src/mesh.F
+++ b/src/mesh.F
@@ -2347,6 +2347,8 @@
                DELX = XGJ - XGI
                DELY = YGJ - YGI
                BNDLEN2O3(JGW) = 2.D0*(SQRT(DELX*DELX+DELY*DELY))/3.D0
+               call find_third_node_for_boundary_edge
+     &            (NBVI, NBVJ, BNDEDGE3RD(JGW), BNDEDGEELEM(JGW))
 
 !...           COMPUTE THE INCLUDED ANGLE AND TEST TO DETERMINE WHETHER TO ZERO
 !...           TANGENTIAL VELOCITIES
@@ -5649,6 +5651,68 @@ C
 
       !-----------------------------------------------------------------------
       end subroutine compute_csr_positions
+      !-----------------------------------------------------------------------
+
+      !-----------------------------------------------------------------------
+      ! Function to find third node using existing ADCIRC neighbor tables
+      !-----------------------------------------------------------------------
+      subroutine find_third_node_for_boundary_edge(node1, node2, node3, elem)
+      implicit none
+      integer, intent(in) :: node1, node2
+      integer, intent(inout) :: node3, elem
+      integer :: elem_idx, neighbor_elem, i
+      integer :: elem_node1, elem_node2, elem_node3
+      
+      ! Initialize node3 and elem to 0
+      node3 = 0
+      elem = 0
+      
+      ! Search through elements containing node1
+      do i = 1, NNeighEle(node1)
+          neighbor_elem = NeiTabEle(node1, i)
+          
+          ! Get the three nodes of this element
+          elem_node1 = nm(neighbor_elem, 1)
+          elem_node2 = nm(neighbor_elem, 2) 
+          elem_node3 = nm(neighbor_elem, 3)
+          
+          ! Check if this element contains both node1 and node2
+          if (contains_both_nodes(elem_node1, elem_node2, elem_node3, node1, node2)) then
+              ! Return the third node (the one that's neither node1 nor node2)
+              if (elem_node1 /= node1 .and. elem_node1 /= node2) then
+                  node3 = elem_node1
+                  elem = neighbor_elem
+              else if (elem_node2 /= node1 .and. elem_node2 /= node2) then
+                  node3 = elem_node2
+                  elem = neighbor_elem
+              else if (elem_node3 /= node1 .and. elem_node3 /= node2) then
+                  node3 = elem_node3
+                  elem = neighbor_elem
+              endif
+              return
+          endif
+      end do
+      
+      !-----------------------------------------------------------------------
+      end subroutine find_third_node_for_boundary_edge
+      !-----------------------------------------------------------------------
+  
+      !-----------------------------------------------------------------------
+      ! Helper function to check if element contains both specified nodes
+      !-----------------------------------------------------------------------
+      logical function contains_both_nodes(n1, n2, n3, target1, target2)
+      implicit none
+      integer, intent(in) :: n1, n2, n3, target1, target2
+      integer :: count
+      
+      count = 0
+      if (n1 == target1 .or. n1 == target2) count = count + 1
+      if (n2 == target1 .or. n2 == target2) count = count + 1  
+      if (n3 == target1 .or. n3 == target2) count = count + 1
+      
+      contains_both_nodes = (count == 2)
+      !-----------------------------------------------------------------------
+      end function contains_both_nodes
       !-----------------------------------------------------------------------
 
 !     ------------------------------------------------------------------

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -127,7 +127,9 @@ C-----------------------------------------------------------------------
       USE SUBDOMAIN, ONLY : subdomainOn
       USE WRITE_OUTPUT, ONLY : outputNodeCode, outputNOFF
       USE HARM
-      USE WEIR
+      USE WEIR, ONLY: BARMIN64_SUBM, BARMIN64_NOSUBM, BARMIN64_SLIM,
+     &   BARSLIM64_ELEM, BARSLIM64_EDGE
+
       USE TIME_VARYING_WEIR_BOUNDARY
       USE OWIWIND,ONLY: nPowellSearchDomains
       USE mod_nws08, only: setNws08f15Parameters, readNws08Namelist, getVortexModelStringNws8 => getVortexModelString
@@ -238,7 +240,9 @@ C.... "new" formula for computing vel in wetting/drying routine
      &  slim, windlim, directvelWD, useHF
       NAMELIST /inundationOutputControl/ inundationOutput, inunThresh
 C.... SB
-      NAMELIST /VEW1DChannelControl/ activateVEW1DChannelWetPerimeter
+      NAMELIST /VEW1DChannelControl/ activateVEW1DChannelWetPerimeter,
+     &  BARMIN64_SUBM, BARMIN64_NOSUBM, BARMIN64_SLIM, 
+     &  BARSLIM64_ELEM, BARSLIM64_EDGE
 C.... DMW
       NAMELIST /TVWControl/ USE_TVW,TVW_FILE,NOUT_TVW,TOUTS_TVW,
      &                      TOUTF_TVW,NSPOOL_TVW
@@ -770,6 +774,16 @@ C     Channel wet perimeter for bottom friction 11/06/2023 sb
       call logNamelistReadStatus(namelistSpecifier, ios,ios_nml_error_msg)
       write(scratchMessage,'(a,l1)') "activateVEW1DChannelWetPerimeter=",
      &   activateVEW1DChannelWetPerimeter
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "BARMIN64_SUBM=",BARMIN64_SUBM
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "BARMIN64_NOSUBM=",BARMIN64_NOSUBM
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "BARMIN64_SLIM=",BARMIN64_SLIM
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "BARSLIM64_ELEM=",BARSLIM64_ELEM
+      call logMessage(ECHO,trim(scratchMessage))
+      write(scratchMessage,'(a,f15.7)') "BARSLIM64_EDGE=",BARSLIM64_EDGE
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -100,7 +100,7 @@ C
      &    NFLUXF, NFLUXB, NFLUXGBC, NFLUXIB, NFLUXIBP, NFLUXRBC, CSII,
      &    NFLUXIB64,
      &    BARLANHT, BARLANCFSP, NVELL, IBCONN, BARINHT, BARINCFSP,
-     &    BARINCFSB, PIPEHT, PIPECOEF, PIPEDIAM, ISSUBMERGED64, ISSUBMERGED64P
+     &    BARINCFSB, PIPEHT, PIPECOEF, PIPEDIAM, ISSUBMERGED64
       USE GLOBAL_IO, ONLY : nddt2get
       USE HARM, ONLY : updateHarmonicAnalysis
       USE WIND, ONLY : getMeteorologicalForcing, PRBCKGRND_MH2O, rsget,
@@ -222,9 +222,6 @@ C....... DW
 C.......
       LOGICAL ISFRONT
       LOGICAL foundNaN
-      INTEGER NNBB1, NNBB2, NNBBNEI, NWETNEI
-      LOGICAL UNSUBMERGE
-      REAL(8) X1, X2, Y1, Y2, ET1, ET2, LEN, SLP, HTOT
       
       IF (IT .EQ. 1) THEN
 !.......DMW202401 On first timestep of a cold start, find H2 at start of timestepper since ETA2 = ETA1
@@ -994,8 +991,9 @@ C...  COBELL - MOVED TO WEIR_BOUNDARY.F
           END DO
         ENDIF
 
+C...  SETTING ISSUBMERGED FLAG ALONG VERTICAL ELEMENT WALL BOUNDARIES
+C...
       IF(NFLUXIB64.EQ.1) THEN
-         ! Setting ISSUBMERGED64 flag
          I = 0                         
          DO K = 1, NBOU  
             SELECT CASE(LBCODEI(I+1))
@@ -1005,79 +1003,12 @@ C...  COBELL - MOVED TO WEIR_BOUNDARY.F
                   DO J = 1,NVELL(K)
                      I = I + 1
                      CALL SET_SUBMERGED64_AT(I,J,K,TIMELOC)
-                     ISSUBMERGED64P(I) = ISSUBMERGED64(I)
                   ENDDO
                   I = I + NVELL(K)
                CASE DEFAULT
                   I = I + NVELL(K)
             END SELECT    
          ENDDO
-         ! Cancelling ISSUBMERGED64 flag if any of the adjacent nodes along the boundary is not submerged. sb 8/9/2024
-         I = 0                         
-         DO K = 1, NBOU  
-            SELECT CASE(LBCODEI(I+1))
-               CASE(4,24,5,25)
-                  I = I + NVELL(K)*2
-               CASE(64)
-                  DO J = 1,NVELL(K)
-                     I = I + 1
-                     NNBB1 = NBV(I)
-                     HTOT = ETA2(NNBB1) + IFNLFA*DP(NNBB1)
-                     IF(ISSUBMERGED64(I).NE.0.AND.
-     &                  NODECODE(NNBB1).NE.0.AND.
-     &                  HTOT.LT.4.D0*H0) THEN
-                        UNSUBMERGE = .FALSE.
-                        X1 = X(NNBB1)
-                        Y1 = Y(NNBB1)
-                        ET1 = ETA2(NNBB1)
-                        IF(J>1) THEN
-                           NNBBNEI = NBV(I-1)
-                           X2 = X(NNBBNEI)
-                           Y2 = Y(NNBBNEI)
-                           ET2 = ETA2(NNBBNEI)
-                           LEN = SQRT((X1-X2)**2+(Y1-Y2)**2)
-                           SLP = ABS(ET1-ET2)/LEN
-                           IF(SLP.GT.0.0001) THEN
-                              UNSUBMERGE = .TRUE.
-                           ENDIF
-                        ENDIF
-                        IF(J<NVELL(K)) THEN
-                           NNBBNEI = NBV(I+1)
-                           X2 = X(NNBBNEI)
-                           Y2 = Y(NNBBNEI)
-                           ET2 = ETA2(NNBBNEI)
-                           LEN = SQRT((X1-X2)**2+(Y1-Y2)**2)
-                           SLP = ABS(ET1-ET2)/LEN
-                           IF(SLP.GT.0.0001) THEN
-                              UNSUBMERGE = .TRUE.
-                           ENDIF
-                        ENDIF
-                        IF(.NOT.UNSUBMERGE) THEN
-                           NWETNEI = 0
-                           DO JJ = 2,NNeigh(NNBB1)
-                              II = NeiTab(NNBB1,JJ)
-                              IF(NODECODE(II).NE.0) THEN
-                                 NWETNEI = NWETNEI + 1
-                              ENDIF
-                           ENDDO
-                           IF(NWETNEI.LT.3) THEN
-                              UNSUBMERGE = .TRUE.
-                           ENDIF
-                        ENDIF
-                        IF(UNSUBMERGE) THEN
-                           ISSUBMERGED64(I) = 0
-                           NNBB2 = IBCONN(I)
-                           IF(NNBB2>0) THEN
-                              ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
-                           ENDIF
-                        ENDIF
-                     ENDIF
-                  ENDDO
-                  I = I + NVELL(K)
-               CASE DEFAULT
-                  I = I + NVELL(K)
-            END SELECT    
-         ENDDO 
       ENDIF
 
 C...  COMPUTE INWARD/OUTWARD NORMAL FLOW OVER SPECIFIED INTERNAL BARRIER

--- a/src/weir_boundary.F
+++ b/src/weir_boundary.F
@@ -46,9 +46,13 @@ C-----------------------------------------------------------------------
             REAL(8),ALLOCATABLE     :: BARINHT2(:)    !...Internal Barrier elevation at current timestep
             REAL(8),ALLOCATABLE     :: BARLANHT1(:)   !...External Barrier elevation at previous timestep
             REAL(8),ALLOCATABLE     :: BARLANHT2(:)   !...External Barrier elevation at current timestep
-            REAL(8), PARAMETER      :: BARMIN=0.04D0
-            REAL(8), PARAMETER      :: BARMIN64=0.04D0
-            REAL(8), PARAMETER      :: SUBMIN64=0.04D0
+            REAL(8), PARAMETER      :: BARMIN=0.04D0  !...Minimum water depth above weir to appply weir formula
+            REAL(8)                 :: BARMIN64=0.04D0         !...Minimum water depth above weir to appply weir formula along vertical element walls
+            REAL(8)                 :: BARMIN64_SUBM=0.04D0    !...Minimum water depth above weir to consider submerged at vertical element walls when the weir is already submerged
+            REAL(8)                 :: BARMIN64_NOSUBM=0.04D0  !...Minimum water depth above weir to consider submerged at vertical element walls when the weir is not submerged
+            REAL(8)                 :: BARMIN64_SLIM=0.5D0     !...Minimum water depth above weir to consider submerged at vertical element walls no matter the slope
+            REAL(8)                 :: BARSLIM64_ELEM=99999.D0 !...Water level elemental slope threhold for vertical element walls. A weir is considered not submerged if the water level slope is greater than this value
+            REAL(8)                 :: BARSLIM64_EDGE=99999.D0 !...Water level edge slope threhold for vertical element walls. A weir is considered not submerged if the water level slope is greater than this value
 
             !...Averaging information in time for boundaries. 
             !   This was previously zeroed out in the code, but the
@@ -245,6 +249,7 @@ C  THIS ROUTINE IS CALLED FROM adcirc.F TO ARRANGE THE WEIRS ONCE
 C  RESNODE HAS BEEN ESTABLISHED
 C-----------------------------------------------------------------------
             SUBROUTINE WEIR_SETUP()
+                USE GLOBAL,ONLY:H0
                 USE BOUNDARIES,ONLY:NFLUXIB,NFLUXIBP,NFLUXB
                 IMPLICIT NONE
                 
@@ -263,6 +268,12 @@ C-----------------------------------------------------------------------
                     ENDIF
 
                 ENDIF
+
+                !...Set the minimum water depth above weir to appply weir formula along vertical element walls
+                BARMIN64 = 1.2D0*H0 ! This is equivalent to HOFF in wetdry.F
+                BARMIN64_NOSUBM = 1.2D0*H0
+                BARMIN64_SUBM = 1.2D0*H0
+
 
 #if defined(TVW_TRACE) || defined(ALL_TRACE)
                 CALL allMessage(DEBUG,"Return")
@@ -2139,8 +2150,12 @@ C-----------------------------------------------------------------------
 
                 USE BOUNDARIES,ONLY:BARINCFSB,BARINCFSP,
      &              NVELL,IBCONN,BARINHT,ISSUBMERGED64,NBV
-                USE GLOBAL,ONLY:NIBNODECODE,TVW,USE_TVW,NODECODE,H0
-                USE MESH,ONLY:LBArray_Pointer,MNEI,NEITAB,NNEIGH,DP
+                USE GLOBAL,ONLY:NIBNODECODE,TVW,USE_TVW,NODECODE,H0,
+     &              IFSFM,NODES_LG,IFNLFA
+                USE MESH,ONLY:LBArray_Pointer,DP,AREAS,NM,
+     &              MNEI,NEITAB,NNEIGH,
+     &              NNEIGHELE,NEITABELE,
+     &              sfac,SFacEle,SFMYEle,SFMXEle,FDXE,FDYE,X,Y
                 IMPLICIT NONE
                 INTEGER,INTENT(IN),TARGET   :: BARRIER_INDEX
                 INTEGER,INTENT(IN),TARGET   :: BOUNDARY
@@ -2148,14 +2163,23 @@ C-----------------------------------------------------------------------
                 REAL(8),INTENT(IN)         :: TIMELOC
 
                 INTEGER                     :: NNBB1,NNBB2, NNBBL, NNBBH
-                INTEGER                     :: NNBB1WN,NNBB2WN
                 INTEGER                     :: FLOWDIR
                 INTEGER,POINTER             :: I,J,K
-                REAL(8)                    :: RBARWL1,RBARWL2,RBARWLL
+                REAL(8)                    :: RBARWL1,RBARWL2,RBARWLL,RBARWLH
                 REAL(8)                    :: RBARWL1F,RBARWL2F
                 LOGICAL                    :: CHECK
                 INTEGER                    :: ISSUBMP
+ 
+                real(8) :: sfdxfac, sfdyfac, sfacavg, SFmxAvg, SFmyAvg
+                real(8) :: fdx1, fdx2, fdx3, fdy1, fdy2, fdy3
+                real(8) :: etaN1, etaN2, etaN3
+                real(8) :: detadxa, detadya, etaslp
+                integer :: ineiele, jnei, nm1, nm2, nm3, nctot, wetcnt
 
+                INTEGER NNBBNEI, NWETNEI, II, JJ
+                LOGICAL UNSUBMERGE
+                REAL(8) X1, X2, Y1, Y2, ET1, ET2, LEN, SLP, HTOT
+       
                 CALL setMessageSource("SET_SUBMERGED64_AT")
 #if defined(WEIR_TRACE) || defined(ALL_TRACE) 
                 CALL allMessage(DEBUG,"Enter")
@@ -2168,8 +2192,6 @@ C...............SIMPLIFY VARIABLES
 
                 NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
                 NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
-                NNBB1WN = 0      ! COUNT NUMBER OF WET NEIGHBORS
-                NNBB2WN = 0      ! COUNT NUMBER OF WET NEIGHBORS
                 FLOWDIR = 0      ! DIRECTION OF FLOW
 
                 ! Check if the node ids on both sides of the barrier are valid
@@ -2189,111 +2211,171 @@ C...............SIMPLIFY VARIABLES
                     RETURN
                 ENDIF
 
-C...............CHECK TO SEE IF THERE IS A WET EDGE
-C                 This check is needed ocasionally but not always 
-C                 when the barrier is splitted for paralell computation
-                CHECK = .FALSE.
-                IF( (J.EQ.1).OR.(J.EQ.NVELL(K)+1) )THEN
-                    IF((NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
-                        NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
-                        NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
-                        CHECK = .TRUE.
+C...............CHECK TO SEE IF THE BARRIER ELEVATION NEEDS UPDATING
+                IF(INT_TVW)THEN
+                    IF(BAR_DEG(I))THEN
+                        CALL COMPUTE_BARRIER_HEIGHT(I,TIMELOC,BARINHT1(I)
+     &                   ,BARINHT2(I))
                     ENDIF
-                ELSE
-                    IF( J.EQ.NVELL(K).OR.(J.EQ.NVELL(K)*2) ) THEN
-                        IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0)) THEN
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
-                            CHECK = .TRUE.
-                        ENDIF
-                    ELSE
-                        IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0).AND.
-     &                     (NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
-                            CHECK = .TRUE.
-                        ENDIF
-                    ENDIF
-               ENDIF
+                    TVW(NNBB1) = BARINHT2(I)-BARINHT(I)
+                ENDIF
 
-               IF(.NOT.CHECK) THEN
-                   ISSUBMERGED64(I) = 0
-                   IF(LBArray_Pointer(NNBB2)>0) THEN
-                      ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
-                   ENDIF
-#if defined(WEIR_TRACE) || defined(ALL_TRACE) 
-                   CALL allMessage(DEBUG,"Return")
-#endif
-                   CALL unsetMessageSource()
-                   RETURN
-               ENDIF
-
-C..............CHECK TO SEE IF THE BARRIER ELEVATION NEEDS UPDATING
-               IF(INT_TVW)THEN
-                   IF(BAR_DEG(I))THEN
-                       CALL COMPUTE_BARRIER_HEIGHT(I,TIMELOC,BARINHT1(I)
-     &                  ,BARINHT2(I))
-                   ENDIF
-                   TVW(NNBB1) = BARINHT2(I)-BARINHT(I)
-               ENDIF
-
-C..............GET WATER LEVEL ABOVE WEIR ON EACH SIDE TO COMPUTE HEAD
-C              DEFINE COMPILER FLAG -DAVERAGEWEIRFLOW TO USE BARAVGWT,
-C              WHICH GENERALLY IS SET TO ZERO, AND IS HARD CODED
-C              TO ZERO HERE. READ_INPUT.F CONTAINS THE SPECIFICATION OF 
-C              BARAVGWT. WITH BARAVGWT SET TO ZERO, THERE IS NO NEED FOR
-C              IBSTART EITHER.
+C...............GET WATER LEVEL ABOVE WEIR ON EACH SIDE TO COMPUTE HEAD
+C               DEFINE COMPILER FLAG -DAVERAGEWEIRFLOW TO USE BARAVGWT,
+C               WHICH GENERALLY IS SET TO ZERO, AND IS HARD CODED
+C               TO ZERO HERE. READ_INPUT.F CONTAINS THE SPECIFICATION OF 
+C               BARAVGWT. WITH BARAVGWT SET TO ZERO, THERE IS NO NEED FOR
+C               IBSTART EITHER.
 #if AVERAGEWEIRFLOW
-               IF(IBSTART.EQ.0)THEN
-                  RBARWL1AVG(I)=ETA2(NNBB1)-BARINHT2(I)
-                  RBARWL2AVG(I)=ETA2(NNBB2)-BARINHT2(I)
-                  IBSTART=1
-               ELSE
-                  RBARWL1AVG(I)=(ETA2(NNBB1)-BARINHT2(I)+BARAVGWT
-     &                 *RBARWL1)/(1.D0+BARAVGWT)
-                  RBARWL2AVG(I)=(ETA2(NNBB2)-BARINHT2(I)+BARAVGWT
-     &                 *RBARWL2)/(1.D0+BARAVGWT)
-               ENDIF
-               RBARWL1=RBARWL1AVG(I)
-               RBARWL2=RBARWL2AVG(I)
+                IF(IBSTART.EQ.0)THEN
+                   RBARWL1AVG(I)=ETA2(NNBB1)-BARINHT2(I)
+                   RBARWL2AVG(I)=ETA2(NNBB2)-BARINHT2(I)
+                   IBSTART=1
+                ELSE
+                   RBARWL1AVG(I)=(ETA2(NNBB1)-BARINHT2(I)+BARAVGWT
+     &                  *RBARWL1)/(1.D0+BARAVGWT)
+                   RBARWL2AVG(I)=(ETA2(NNBB2)-BARINHT2(I)+BARAVGWT
+     &                  *RBARWL2)/(1.D0+BARAVGWT)
+                ENDIF
+                RBARWL1=RBARWL1AVG(I)
+                RBARWL2=RBARWL2AVG(I)
 #else               
-C..............ZC - STREAMLINE THE PROCESS SINCE BARAVGWT IS ZERO BY DEFAULT
-               RBARWL1=ETA2(NNBB1)-BARINHT2(I)
-               RBARWL2=ETA2(NNBB2)-BARINHT2(I)
+C...............ZC - STREAMLINE THE PROCESS SINCE BARAVGWT IS ZERO BY DEFAULT
+                RBARWL1=ETA2(NNBB1)-BARINHT2(I)
+                RBARWL2=ETA2(NNBB2)-BARINHT2(I)
 #endif               
-C..............RBARWL on the lower ground side SB
-               IF(DP(NNBB1).GE.DP(NNBB2)) THEN
+C...............RBARWL on the lower ground side SB
+                IF(DP(NNBB1).GE.DP(NNBB2)) THEN
                     RBARWLL = RBARWL1
+                    RBARWLH = RBARWL2
                     NNBBL = NNBB1
                     NNBBH = NNBB2
-               ELSE
+                ELSE
                     RBARWLL = RBARWL2
+                    RBARWLH = RBARWL1
                     NNBBL = NNBB2
                     NNBBH = NNBB1
-               ENDIF
+                ENDIF
 
-               RBARWL1F=2.D0*RBARWL1/3.D0
-               RBARWL2F=2.D0*RBARWL2/3.D0
-               ISSUBMP = ISSUBMERGED64(I)
-               ISSUBMERGED64(I) = 0
-               ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
+                RBARWL1F=2.D0*RBARWL1/3.D0
+                RBARWL2F=2.D0*RBARWL2/3.D0
+                ISSUBMP = ISSUBMERGED64(I)
+                ISSUBMERGED64(I) = 0
+                ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
 
-               IF(RBARWLL.GE.BARMIN64) THEN
-    !            IF(RBARWLL.GE.BARMIN64.AND.
-    !  &            (ISSUBMP.NE.0.OR.(ETA2(NNBBL).GT.(ETA2(NNBBH)+2.D0*H0)))) THEN
-C...............THIS IS THE MAJOR DIFFERENCE OF IBTYPE=64 FROM IBTYPE=24.
-C               WATER LEVEL ON BOTH SIDES OF BARRIER ABOVE BARRIER -> CASE 0
-                  ISSUBMERGED64(I) = 1
-                  ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 1
-               ENDIF
-               
+C...............Compute the water surface gradient of the higher ground side
+                ETASLP = 0.D0
+                IF(NODECODE(NNBBH).EQ.1.AND.RBARWLH.LT.BARMIN64_SLIM) THEN
+                    WETCNT = 0
+                    DO INEIELE = 1,NNEIGHELE(NNBBH)
+                        JNEI = NEITABELE(NNBBH,INEIELE)
+
+                        NM1 = NM(JNEI,1)
+                        NM2 = NM(JNEI,2)
+                        NM3 = NM(JNEI,3)
+
+                        NCTOT = NODECODE(NM1) + NODECODE(NM2) + NODECODE(NM3)
+                        IF(NCTOT.NE.3) CYCLE
+
+                        WETCNT = WETCNT + 1
+
+                        SFacAvg = SFacEle(JNEI)
+                        SFmxAvg = SFMXEle(JNEI)  
+                        SFmyAvg = SFMYEle(JNEI)  
+                        sfdxfac = (1 - IFSFM)*SFacAvg + IFSFM*SFmxAvg ;
+                        sfdyfac = (1 - IFSFM)*1.0D0 + IFSFM*SFmyAvg ;
+                 
+                        FDX1 = FDXE(1,JNEI)*sfdxfac  !b1
+                        FDX2 = FDXE(2,JNEI)*sfdxfac  !b2
+                        FDX3 = FDXE(3,JNEI)*sfdxfac  !b3
+                        FDY1 = FDYE(1,JNEI)*sfdyfac  !a1
+                        FDY2 = FDYE(2,JNEI)*sfdyfac  !a2
+                        FDY3 = FDYE(3,JNEI)*sfdyfac  !a3
+                 
+                        ETAN1 = ETA2(NM1)
+                        ETAN2 = ETA2(NM2)
+                        ETAN3 = ETA2(NM3)
+                    
+                        DETADXA = ETAN1*FDX1 + ETAN2*FDX2 + ETAN3*FDX3
+                        DETADYA = ETAN1*FDY1 + ETAN2*FDY2 + ETAN3*FDY3
+                        ETASLP = ETASLP + SQRT(DETADXA**2 + DETADYA**2)/AREAS(JNEI)
+                    END DO
+                    IF(WETCNT.NE.0) THEN
+                        ETASLP = ETASLP / DBLE(WETCNT)
+                    ELSE
+                        ETASLP = 99999.D0
+                    ENDIF
+                ENDIF
+
+                ! Consider submerged if the water depth over the weir is greater than a threshold 
+                ! and the averaged elemental water surface slope on the higher ground side is less 
+                ! than a threshold
+                IF(((ISSUBMP.EQ.0.AND.RBARWLL.GE.BARMIN64_NOSUBM).OR.
+     &              (ISSUBMP.EQ.1.AND.RBARWLL.GE.BARMIN64_SUBM)).AND.
+     &             (ETASLP.LE.BARSLIM64_ELEM)) THEN
+                    ISSUBMERGED64(I) = 1
+                    IF(NNBB2>0) THEN
+                        ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 1
+                    ENDIF
+                ENDIF
+
+C...............Check if the water suraface slope along the weir is greater than a threshold
+C...............If the slope is greater than a threshold, then the weir is not submerged
+                HTOT = ETA2(NNBB1) + IFNLFA*DP(NNBB1)
+                IF(ISSUBMERGED64(I).NE.0.AND.
+     &             NODECODE(NNBB1).NE.0.AND.
+     &             HTOT.LT.4.D0*H0) THEN
+                    UNSUBMERGE = .FALSE.
+                    X1 = X(NNBB1)
+                    Y1 = Y(NNBB1)
+                    ET1 = ETA2(NNBB1)
+                    IF(J>1) THEN
+                        NNBBNEI = NBV(I-1)
+                        X2 = X(NNBBNEI)
+                        Y2 = Y(NNBBNEI)
+                        ET2 = ETA2(NNBBNEI)
+                        LEN = SQRT((X1-X2)**2+(Y1-Y2)**2)
+                        SLP = ABS(ET1-ET2)/LEN
+                        IF(SLP.GT.BARSLIM64_EDGE) THEN
+                            UNSUBMERGE = .TRUE.
+                        ENDIF
+                    ENDIF
+                    IF(J<NVELL(K)) THEN
+                        NNBBNEI = NBV(I+1)
+                        X2 = X(NNBBNEI)
+                        Y2 = Y(NNBBNEI)
+                        ET2 = ETA2(NNBBNEI)
+                        LEN = SQRT((X1-X2)**2+(Y1-Y2)**2)
+                        SLP = ABS(ET1-ET2)/LEN
+                        IF(SLP.GT.BARSLIM64_EDGE) THEN
+                            UNSUBMERGE = .TRUE.
+                        ENDIF
+                    ENDIF
+                    IF(.NOT.UNSUBMERGE) THEN
+                        NWETNEI = 0
+                        DO JJ = 2,NNeigh(NNBB1)
+                            II = NeiTab(NNBB1,JJ)
+                            IF(NODECODE(II).NE.0) THEN
+                                NWETNEI = NWETNEI + 1
+                            ENDIF
+                        ENDDO
+                        IF(NWETNEI.LT.3) THEN
+                            UNSUBMERGE = .TRUE.
+                        ENDIF
+                    ENDIF
+                    IF(UNSUBMERGE) THEN
+                        ISSUBMERGED64(I) = 0
+                        IF(NNBB2>0) THEN
+                            ISSUBMERGED64(LBArray_Pointer(NNBB2)) = 0
+                        ENDIF
+                    ENDIF
+                ENDIF
+                
 #if defined(WEIR_TRACE) || defined(ALL_TRACE) 
-               CALL allMessage(DEBUG,"Return")
+                CALL allMessage(DEBUG,"Return")
 #endif
-               CALL unsetMessageSource()
-               RETURN
+                CALL unsetMessageSource()
+                RETURN
 C-----------------------------------------------------------------------
             END SUBROUTINE SET_SUBMERGED64_AT
 C-----------------------------------------------------------------------
@@ -2314,8 +2396,8 @@ C-----------------------------------------------------------------------
      &          ISFRONT)
 
                 USE BOUNDARIES,ONLY:BARINCFSB,BARINCFSP,
-     &              NVELL,IBCONN,BARINHT,ISSUBMERGED64,NBV
-                USE GLOBAL,ONLY:NIBNODECODE,TVW,USE_TVW,NODECODE,H0
+     &              NVELL,NBV,IBCONN,BARINHT,ISSUBMERGED64,BNDEDGE3RD
+                USE GLOBAL,ONLY:NIBNODECODE,TVW,USE_TVW,NODECODE,H0,NODES_LG
                 USE MESH,ONLY:LBArray_Pointer,MNEI,NEITAB,NNEIGH,DP
                 IMPLICIT NONE
                 INTEGER,INTENT(IN),TARGET   :: BARRIER_INDEX
@@ -2329,6 +2411,9 @@ C-----------------------------------------------------------------------
                 INTEGER                     :: NNBB1WN,NNBB2WN
                 INTEGER                     :: FLOWDIR
                 INTEGER,POINTER             :: I,J,K
+                INTEGER                     :: I1,I2
+                INTEGER                     :: N11,N12,N21,N22
+                INTEGER                     :: FORCEDWET
                 REAL(8)                    :: RBARWL1,RBARWL2,RBARWLL
                 REAL(8)                    :: RBARWL1F,RBARWL2F
                 LOGICAL                    :: CHECK
@@ -2343,6 +2428,8 @@ C...............SIMPLIFY VARIABLES
                 J => BOUNDARYNODE
                 K => BOUNDARY
 
+                I2 = LBArray_Pointer(IBCONN(I)) ! I2 is the pointer to the node on the opposite side of the barrier
+
                 NNBB1=NBV(I)     ! GLOBAL NODE NUMBER ON THIS SIDE OF BARRIER
                 NNBB2=IBCONN(I)  ! GLOBAL NODE NUMBER ON OPPOSITE SIDE OF BARRIER
                 NNBB1WN = 0      ! COUNT NUMBER OF WET NEIGHBORS
@@ -2352,7 +2439,7 @@ C...............SIMPLIFY VARIABLES
                 ! Check if the node ids on both sides of the barrier are valid
                 ! Either of them can be invalid ocasionally but not always 
                 ! when the barrier is splitted for paralell computation
-                IF((NNBB1<=0).OR.(NNBB2<=0)) THEN
+                IF((NNBB1<=0).OR.(NNBB2<=0).OR.(I2<=0)) THEN
                     FLUX = 0.D0
 #if defined(WEIR_TRACE) || defined(ALL_TRACE) 
                     CALL allMessage(DEBUG,"Return")
@@ -2365,30 +2452,97 @@ C...............CHECK TO SEE IF THERE IS A WET EDGE
 C                 This check is needed ocasionally but not always 
 C                 when the barrier is splitted for paralell computation
                 CHECK = .FALSE.
+    !             IF( (J.EQ.1).OR.(J.EQ.NVELL(K)+1) )THEN
+    !                 IF((NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
+    !                     NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
+    !                     NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
+    !                     CHECK = .TRUE.
+    !                 ENDIF
+    !             ELSE
+    !                 IF( J.EQ.NVELL(K).OR.(J.EQ.NVELL(K)*2) ) THEN
+    !                     IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0)) THEN
+    !                         NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
+    !                         NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
+    !                         CHECK = .TRUE.
+    !                     ENDIF
+    !                 ELSE
+    !                     IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0).AND.
+    !  &                     (NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
+    !                         NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
+    !                         NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
+    !                         NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
+    !                         NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
+    !                         CHECK = .TRUE.
+    !                     ENDIF
+    !                 ENDIF
+    !             ENDIF
+                
+                ! ------
                 IF( (J.EQ.1).OR.(J.EQ.NVELL(K)+1) )THEN
                     IF((NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
-                        NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
-                        NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
-                        CHECK = .TRUE.
+                        I1 = I + 1
+                        N11 = NBV(I1)
+                        N12 = BNDEDGE3RD(I1-1)
+                        N21 = NBV(I2-1)
+                        N22 = BNDEDGE3RD(I2-1)
+                    IF(N12.NE.0.AND.N22.NE.0) THEN
+                            IF(NODECODE(N11).NE.0.AND.NODECODE(N12).NE.0.AND.
+     &                         NODECODE(N21).NE.0.AND.NODECODE(N22).NE.0) THEN
+                                NNBB1WN = NNBB1WN + 1
+                                NNBB2WN = NNBB2WN + 1
+                                CHECK = .TRUE.
+                            ENDIF
+                        ENDIF
                     ENDIF
                 ELSE
                     IF( J.EQ.NVELL(K).OR.(J.EQ.NVELL(K)*2) ) THEN
                         IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0)) THEN
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
-                            CHECK = .TRUE.
+                            I1 = I-1
+                            N11 = NBV(I1)
+                            N12 = BNDEDGE3RD(I1)
+                            N21 = NBV(I2+1)
+                            N22 = BNDEDGE3RD(I2)
+                            IF(N12.NE.0.AND.N22.NE.0) THEN
+                                IF(NODECODE(N11).NE.0.AND.NODECODE(N12).NE.0.AND.
+     &                             NODECODE(N21).NE.0.AND.NODECODE(N22).NE.0) THEN
+                                    NNBB1WN = NNBB1WN + 1
+                                    NNBB2WN = NNBB2WN + 1
+                                    CHECK = .TRUE.
+                                ENDIF
+                            ENDIF
                         ENDIF
                     ELSE
                         IF((NBV(I-1)>0).AND.(IBCONN(I-1)>0).AND.
      &                     (NBV(I+1)>0).AND.(IBCONN(I+1)>0)) THEN
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I-1))
-                            NNBB1WN = NNBB1WN + NODECODE(NBV(I+1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I+1))
-                            NNBB2WN = NNBB2WN + NODECODE(IBCONN(I-1))
-                            CHECK = .TRUE.
+                            I1 = I-1
+                            N11 = NBV(I1)
+                            N12 = BNDEDGE3RD(I1)
+                            N21 = NBV(I2+1)
+                            N22 = BNDEDGE3RD(I2)
+                            IF(N12.NE.0.AND.N22.NE.0) THEN
+                                IF(NODECODE(N11).NE.0.AND.NODECODE(N12).NE.0.AND.
+     &                             NODECODE(N21).NE.0.AND.NODECODE(N22).NE.0) THEN
+                                    NNBB1WN = NNBB1WN + 1
+                                    NNBB2WN = NNBB2WN + 1
+                                    CHECK = .TRUE.
+                                ENDIF
+                            ENDIF
+                            I1 = I+1
+                            N11 = NBV(I1)
+                            N12 = BNDEDGE3RD(I1-1)
+                            N21 = NBV(I2-1)
+                            N22 = BNDEDGE3RD(I2-1)
+                            IF(N12.NE.0.AND.N22.NE.0) THEN
+                                IF(NODECODE(N11).NE.0.AND.NODECODE(N12).NE.0.AND.
+     &                             NODECODE(N21).NE.0.AND.NODECODE(N22).NE.0) THEN
+                                    NNBB1WN = NNBB1WN + 1
+                                    NNBB2WN = NNBB2WN + 1
+                                    CHECK = .TRUE.
+                                ENDIF
+                            ENDIF
                         ENDIF
                     ENDIF
-               ENDIF
+                ENDIF
 
                IF(.NOT.CHECK) THEN
                    FLUX = 0.D0
@@ -2467,15 +2621,17 @@ C................LEAST ONE WET EDGE. IF NOT, WE SHUT DOWN THE FLOW ACROSS
 C................THE BARRIER. shintaro v46.28.sb05.05 11/01/2006
                   IF(RBARWL2.GT.RBARWL1F) THEN
 C..................OUTWARD SUBCRITICAL FLOW -> CASE 3
-                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0) THEN
+                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0.OR.
+     &                  FORCEDWET.EQ.1) THEN
                         FLUX=0.0D0
                      ELSE
                         FLUX=-RampIntFlux*RBARWL2*BARINCFSB(I)*
      &                     (2.D0*G*(RBARWL1-RBARWL2))**0.5D0
-                    ENDIF
+                     ENDIF
                   ELSE
 C..................OUTWARD SUPERCRITICAL FLOW -> CASE 4
-                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0) THEN
+                     IF(NODECODE(NNBB1).EQ.0.OR.NNBB1WN.EQ.0.OR.
+     &                  FORCEDWET.EQ.1) THEN
                         FLUX=0.0D0
                      ELSE
                         FLUX=-RampIntFlux*BARINCFSP(I)*RBARWL1F*
@@ -2496,23 +2652,29 @@ C................LEAST ONE WET EDGE. IF NOT, WE SHUT DOWN THE FLOW ACROSS
 C................THE BARRIER. shintaro v46.28.sb05.05 11/01/2006
                   IF(RBARWL1.GT.RBARWL2F) THEN
 C..................INWARD SUBCRITICAL FLOW -> CASE 5
-                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0) THEN
+                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0.OR.
+     &                  FORCEDWET.EQ.1) THEN
                         FLUX=0.0D0
                      ELSE
                         FLUX=RampIntFlux*RBARWL1*BARINCFSB(I)*
      &                     (2.0D0*G*(RBARWL2-RBARWL1))**0.5D0
+                        ! WRITE(*,*) "Receiving flux, subcritical"
+                        ! NIBNODECODE(NNBB1)=1
                      ENDIF
                   ELSE
 C..................INWARD SUPERCRITICAL FLOW -> CASE 6
-                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0) THEN
+                     IF(NODECODE(NNBB2).EQ.0.OR.NNBB2WN.EQ.0.OR.
+     &                  FORCEDWET.EQ.1) THEN
                         FLUX=0.0D0
                      ELSE
                         FLUX=RampIntFlux*BARINCFSP(I)*RBARWL2F*
      &                     (RBARWL2F*G)**0.5D0
+                        ! WRITE(*,*) "Receiving flux, supercritical"
+                        ! NIBNODECODE(NNBB1)=1
                      ENDIF
                   ENDIF
                ELSE
-                  FLUX=0
+                  FLUX=0.D0
                ENDIF
                
 #if defined(WEIR_TRACE) || defined(ALL_TRACE) 

--- a/src/wetdry.F
+++ b/src/wetdry.F
@@ -159,7 +159,8 @@ CWET...
      &   loadCondensedNodes, NCondensedNodes,
      &   ListCondensedNodes, NListCondensedNodes,
      &   NNodesListCondensedNodes
-      USE BOUNDARIES, ONLY : IBCONN, ISSUBMERGED64, NFLUXIB64_GBL
+      USE BOUNDARIES, ONLY : IBCONN, ISSUBMERGED64, NFLUXIB64_GBL, BARINHT,
+     &   LBCODEI
       use global_3dvs, only : a, b, islip, kp, z0b, sigma, evtot, q
 !Casey 220207 from Rosemary
      &    , nfen, sal, temp
@@ -171,7 +172,7 @@ CWET...
       integer, intent(in) :: it ! time step number
       complex(8) :: duds 
       integer :: nc1, nc2, nc3
-      integer :: nm1, nm2, nm3
+      integer :: nm1, nm2, nm3, nmi
       integer :: nm123
       integer :: ncele
       integer :: nctot
@@ -186,6 +187,7 @@ CWET...
       real(8) :: htot
       real(8) :: h1
       real(8) :: tk_tmp(np),tmp1(np),tmp2(np),tmp3(np)
+      real(8) :: totArea1,totArea2,eta2Avg
       integer :: tk_cnt(np)
       integer :: nbnctot
       integer :: i,j,k,kk,l
@@ -292,17 +294,26 @@ C.....submerged. If it is the case, set the nnodecode to 1.   SB
 C.....
          IF (NFLUXIB64_GBL.GT.0) THEN
             DO I=1,NP
-               IF(LBArray_Pointer(I).GT.0) THEN
-                  J = LBArray_Pointer(I)
-                  IF((ISSUBMERGED64(J).GT.0).AND.(NODECODE(I).EQ.0)) THEN
-                     NNBB2=IBCONN(J)
-                     IF(NNBB2.GT.0) THEN ! This check is needed ocasionally but not always when the barrier is splitted for paralell computation
-                        ETA2(I) = ETA2(NNBB2)
-                        HTOT=DP(I)+ETA2(I)
-                        IF(HTOT.GT.HOFF) THEN
-                           NNODECODE(I)=1
-                           NODECODE(I)=1
-                           NCCHANGE=NCCHANGE+1 !NCCHANGE=0 set near beginning of GWCE
+               J = LBArray_Pointer(I)
+               IF(J.GT.0) THEN
+                  IF((LBCODEI(J)).EQ.64.AND.(NODECODE(I).EQ.0)) THEN
+                     IF((ISSUBMERGED64(J).GT.0)) THEN
+                        NNBB2=IBCONN(J)
+                        IF(NNBB2.GT.0) THEN ! This check is needed ocasionally but not always when the barrier is splitted for paralell computation
+                           ! ETA2(I) = ETA2(NNBB2)
+                           ! HTOT=DP(I)+ETA2(I)
+                           HTOT = DP(I) + MAX(ETA2(I), ETA2(NNBB2))
+                           IF(HTOT.GT.HOFF) THEN
+                              ! ETA2(I) = MAX(ETA2(I), ETA2(NNBB2))
+                              TotArea1 = computeTotAreaAtNode(I)
+                              TotArea2 = computeTotAreaAtNode(NNBB2)
+                              ETA2AVG = (ETA2(I)*TotArea1 + ETA2(NNBB2)*TotArea2)/(TotArea1 + TotArea2)
+                              ETA2(I) = ETA2AVG
+                              ETA2(NNBB2) = ETA2AVG
+                              NNODECODE(I)=1
+                              NODECODE(I)=1
+                              NCCHANGE=NCCHANGE+1 !NCCHANGE=0 set near beginning of GWCE
+                           ENDIF
                         ENDIF
                      ENDIF
                   ENDIF
@@ -354,6 +365,7 @@ CWET...
                   HTOTN2=DP(NM2)+ETA2(NM2)
                   HTOTN3=DP(NM3)+ETA2(NM3)
                ENDIF
+               NMI = 0
                IF((NODECODE(NM1).EQ.1).AND.(NODECODE(NM2).EQ.1)) THEN
                   IF((HTOTN1.GE.HOFF).AND.(HTOTN2.GE.HOFF)) THEN
                      NM123=NM1
@@ -428,6 +440,7 @@ C where:  Cd=kappa^2/(ln(z+zo)/z0)^2 is the depth integrated drag coefficient
                      IF(VEL.GT.VELMIN) THEN
 C    ....         third node met criteria and is also wet
                         NNODECODE(NM3)=1
+                        NMI = NM3
 c. RJW merged 08/26/20008 Casey 071219: Added the following logic to obtain the correct friction.
                         IF(C2DDI)THEN
 
@@ -574,6 +587,7 @@ C where:  Cd=kappa^2/(ln(z+zo)/z0)^2 is the depth integrated drag coefficient
 
                      IF(VEL.GT.VELMIN) THEN
                         NNODECODE(NM1)=1
+                        NMI = NM1
 c. RJW merged 08/26/2008 Casey 071219: Added the following logic to obtain the correct friction.
                         IF(C2DDI)THEN
                            TK_TMP(NM123) = MIN(
@@ -719,6 +733,7 @@ C where:  Cd=kappa^2/(ln(z+zo)/z0)^2 is the depth integrated drag coefficient
 
                      IF(VEL.GT.VELMIN) THEN
                         NNODECODE(NM2)=1
+                        NMI = NM2
 c. RJW merged 08/26/2008 Casey 071219: Added the following logic to obtain the correct friction.
                         IF(C2DDI)THEN                   
                         
@@ -1635,6 +1650,26 @@ c.....
 
 !-----------------------------------------------------------------------
       end subroutine computeAlpha
+!-----------------------------------------------------------------------
+
+!-----------------------------------------------------------------------
+      real(8) function computeTotAreaAtNode(INODE)
+!-----------------------------------------------------------------------
+      USE MESH,ONLY: NE,NNeighEle,NeiTabEle,Areas
+      IMPLICIT NONE
+      integer, intent(in) :: INODE
+      integer :: I,IE
+      real(8) :: TotArea
+
+      TotArea = 0.d0
+      DO I=1,NNeighEle(INODE)
+         IE = NeiTabEle(INODE,I)
+         TotArea = TotArea + Areas(IE)
+      enddo
+      computeTotAreaAtNode = 0.5d0*TotArea
+      return
+!-----------------------------------------------------------------------
+      end function computeTotAreaAtNode
 !-----------------------------------------------------------------------
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
# Description

Updates the VEW boundary implementation to correctly activate weir giving and receiving node pairs. This fixes occasional mass leakage when the weir formula is used in certain configurations. Additional namelist parameters are introduced to eliminate hard-coded parameters for VEW.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

Tested in the adcirc test suite and also with an operational storm surge model.

# Relevant Publications (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments

N/A