### PR TITLE
Shinbunya/fix swan hstart

### DIFF
--- a/src/couple2swan.F
+++ b/src/couple2swan.F
@@ -982,7 +982,7 @@ C-----------------------------------------------------------------------
 
       !USE, INTRINSIC :: IEEE_ARITHMETIC !jgfdebug ieee_is_nan()
       USE GLOBAL,   ONLY: DT,
-     &                    ETA2,
+     &                    ETA2, UU2, VV2,
 Casey 120305: Merging ice changes from Taylor Asher.
 CTGA 110912:  Full SWAN ice implementation.  Use global variables
      &                    NCICE,
@@ -1032,10 +1032,10 @@ Casey 090302: Initialize the arrays.
       DO IN=1,NP
          SWAN_ETA2(IN,1) = ETA2(IN)
          SWAN_ETA2(IN,2) = ETA2(IN)
-         SWAN_UU2 (IN,1) = 0.D0
-         SWAN_UU2 (IN,2) = 0.D0
-         SWAN_VV2 (IN,1) = 0.D0
-         SWAN_VV2 (IN,2) = 0.D0
+         SWAN_UU2 (IN,1) = UU2(IN)  ! sb251003: Initialize velocity arrays
+         SWAN_UU2 (IN,2) = UU2(IN)  ! with current velocities, not zero.
+         SWAN_VV2 (IN,1) = VV2(IN)  ! This should improve transition at
+         SWAN_VV2 (IN,2) = VV2(IN)  ! hotstart.
       ENDDO
 
 Casey 090302: Need to pass correct first wind snaps to SWAN.


### PR DESCRIPTION
# Description

This contains the following changes to fix/improve hotstarting of the SWAN module. 
- Fix of z0 initialization issue: Without this fix, SWAN_Z0 was initialized when COUPFRIC was TRUE. However, COUPFRIC was not initialized yet when checked for SWAN_Z0 initialization. As a consequence, the occurrence of SWAN_Z0 initialization was not predictable and thus might cause noticeable changes immediately after a hotstart in SWAN outputs including significant wave heights. With this fix, SWAN_Z0 is always initialized.
- Fix of wind initialization issue: Without this fix, in PADCSWAN_INIT, the wind velocity variables for SWAN, i.e., SWAN_WX2 and SWAN_WY2, which hold wind velocities at two steps, were initialized first with wind velocities at the first two snaps at times T and T+1. However, at the end of PADCSWAN_INIT, SWAN_WX2(:,1) and SWAN_WY2(:,1), which are supposed to store wind velocities of a past snap, is overwritten with wind velocities at T+1. This fix avoid the overwriting.
- Fix of velocity initialization issue: Without this fix, in PADCSWAN_INIT, velocity variables for SWAN computations, SWAN_UU2 and SWAN_VV2, were initialized with 0.D0. With this fix, they are initialized with UU2 and VV2, which are loaded from the ADCIRC hotstart files.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

Tested in forecasting configurations.

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments

N/A