### PR TITLE
Fix out-of-bounds memory access caused by zeros in NeiTabEle

### DIFF
--- a/src/mesh.F
+++ b/src/mesh.F
@@ -5670,7 +5670,8 @@ C
       ! Search through elements containing node1
       do i = 1, NNeighEle(node1)
           neighbor_elem = NeiTabEle(node1, i)
-          
+          if (neighbor_elem.le.0) cycle ! sb251003: Added this check to avoid out-of-bounds access.
+
           ! Get the three nodes of this element
           elem_node1 = nm(neighbor_elem, 1)
           elem_node2 = nm(neighbor_elem, 2) 

--- a/src/vew1d.F
+++ b/src/vew1d.F
@@ -398,6 +398,7 @@ C
 
       do i=1,nneighele(n1)
          ie = neitabele(n1,i)
+         if (ie.le.0) cycle ! sb251003: Added this check to avoid out-of-bounds access.
          nnm1 = nm(ie,1)
          nnm2 = nm(ie,2)
          nnm3 = nm(ie,3)
@@ -414,7 +415,7 @@ C
             nnm3 = nnm2
             nnm2 = tmp
          else
-            STOP('Error')
+            STOP('Error in FIND_IB2: node not found in neighbor element')
          end if
          if ((nnm2.eq.n2.and.nnm3.eq.n3).or.
      &       (nnm2.eq.n3.and.nnm3.eq.n2)) cycle


### PR DESCRIPTION
# Description

The neighbor element table (NeiTabEle) is built in NEIGHB() and may contain zeros even for entries where k <= NNeighEle(i). This commit prevents out-of-bounds memory access by updating two loops to account for the possibility that NeiTabEle(i,k) can be zero. The affected loops were recently introduced to handle vertical element wall (VEW) boundaries. VEW boundaries involve duplicated nodes sharing the same coordinates, which is a new condition for NEIGHB() that apparently breaks its logic.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

Tested locally in practical simulations.
 
# Relevant Publications (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments

N/A