### PR TITLE
Updating binary hotstart format for radiation stress information

### DIFF
--- a/src/hstart.F
+++ b/src/hstart.F
@@ -334,6 +334,24 @@ C        jgf46.34 Added support for IBTYPE=52.
          ! jgf52.08.01: subroutine timestep() uses nodecode. Set it here.
          nodecode(:) = nnodecode(:)
          CALL readAndMapEleToSubdomainInt2D(NOFF, IHOT, IHOTSTP, moderbin)
+
+         if(nrs.ne.0)then
+           CALL readAndMapToSubdomain2d(RSNX1, IHOT, IHOTSTP, moderbin)
+           CALL readAndMapToSubdomain2d(RSNY1, IHOT, IHOTSTP, moderbin)
+           CALL readAndMapToSubdomain2d(RSNX2, IHOT, IHOTSTP, moderbin)
+           CALL readAndMapToSubdomain2d(RSNY2, IHOT, IHOTSTP, moderbin)
+           if(nrs.eq.3)then
+              CALL readAndMapToSubdomain2d(SWAN_RSNX1, IHOT, IHOTSTP, moderbin)
+              CALL readAndMapToSubdomain2d(SWAN_RSNY1, IHOT, IHOTSTP, moderbin)
+              CALL readAndMapToSubdomain2d(SWAN_RSNX2, IHOT, IHOTSTP, moderbin)
+              CALL readAndMapToSubdomain2d(SWAN_RSNY2, IHOT, IHOTSTP, moderbin)
+           else
+              IHOTSTP=IHOTSTP+4*np_g
+           endif
+         else
+           IHOTSTP=IHOTSTP+8*np_g
+         endif
+
 C
          READ(IHOT,*) IDMY
          READ(IHOT,*) NSCOUE

--- a/src/mesh.F
+++ b/src/mesh.F
@@ -2150,7 +2150,7 @@
             WRITE(16,6532)
  6532       FORMAT(5X,'This segment uses a specified periodic normal ',
      &          'flux as a natural b.c. combined with outward ',
-     &          7X,'radiating boundary. The GWCE is forced with the ,'
+     &          7X,'radiating boundary. The GWCE is forced with the ,',
      &          'total normal flux computed by adding the',/,
      &          7X,'specified normal flux and the flux associated ',
      &          'with the outward radiating wave.',/,
@@ -3421,7 +3421,7 @@ Csb...
         write(scratchMessage,99312) I,J
         call allMessage(ERROR,scratchMessage)
 99312   FORMAT('!!!!!!!!!!  FATAL ERROR !!!!!!!!! ',
-     &       'NODES ',i0,' AND ',i0,' HAVE THE SAME COORDINATES.'
+     &       'NODES ',i0,' AND ',i0,' HAVE THE SAME COORDINATES.',
      &       '!!!!!! EXECUTION WILL NOW BE TERMINATED !!!!!!')
         call terminate()
       end subroutine neighb_terminateDuplicateNode

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -913,8 +913,8 @@ Corbitt 120321: Allow advection to be turned on locally instead of globally
      &   ((LoadAbsLayerSigma).and.(.not.FoundAbsLayerSigma)).or. 
      &   ((LoadTau0MinMax).and.(.not.FoundTau0MinMax))) THEN
          WRITE(scratchMessage,1111)
- 1111   FORMAT('Nodal Attributes file (unit 13) does '
-     &        'not contain all the attributes listed in the '
+ 1111   FORMAT('Nodal Attributes file (unit 13) does ',
+     &        'not contain all the attributes listed in the ',
      &        'model parameter file (unit 15).')
          call allMessage(ERROR, scratchMessage)
          call na_terminate()

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -6281,7 +6281,7 @@ C        is later than the start time for output.
             WRITE(scratchMessage,541) description, endTime
             CALL allMessage(WARNING,scratchMessage)
  541        FORMAT('End time for output of ',A,' data = ',E14.6,
-     &       ' which is before the start time for output of these data.'
+     &       ' which is before the start time for output of these data.',
      &       ' It has been reset to coincide with the start time.')
             endTime=startTime
             endTS=startTS

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -1401,7 +1401,7 @@ C     output the global node number to debug the local PE fort.14s
      &           5X,'TIME = ',E15.8,
      &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
      &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,/,
-     &           2X,'** ERROR: Elevation.gt.ErrorElev, '
+     &           2X,'** ERROR: Elevation.gt.ErrorElev, ',
      &           'ADCIRC stopping. **')
             CALL ADCIRC_Terminate()
          ENDIF

--- a/src/write_output.F
+++ b/src/write_output.F
@@ -5010,6 +5010,67 @@ C        program to exit immediately after writing the hotstart file.
                WRITE(hss % lun,REC=IHOTSTP) NOFFDescript % iarray_g(I)
                IHOTSTP=IHOTSTP+1
             ENDDO
+            IF(NRS.ne.0)THEN
+              DO I=1, HotstartRS1Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS1Descript % array_g(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS1Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS1Descript % array2_g(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS2Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS2Descript % array_g(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS2Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS2Descript % array2_g(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ELSE
+              ! Fill with zeros to pad the format
+              DO I=1, Elev1Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ENDIF
+
+            IF(NRS.eq.3)THEN
+              DO I=1, HotstartSwanRS1Descript % num_fd_records
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS1Descript % array_g(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS1Descript % num_fd_records
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS1Descript % array2_g(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS2Descript % num_fd_records
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS2Descript % array_g(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS2Descript % num_fd_records
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS2Descript % array2_g(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+            ELSE
+              ! Fill with zeros to pad the format
+              DO I=1, Elev1Descript % num_fd_records
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ENDIF
          ENDIF
          IF ((MNPROC.eq.1).or.
      &      (WRITE_LOCAL_HOT_START_FILES.eqv..TRUE.)) THEN
@@ -5047,6 +5108,66 @@ C        program to exit immediately after writing the hotstart file.
                WRITE(hss % lun,REC=IHOTSTP) NOFFDescript % iarray(I)
                IHOTSTP=IHOTSTP+1
             ENDDO
+            IF(NRS.ne.0)THEN
+              DO I=1, HotstartRS1Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS1Descript % array(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS1Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS1Descript % array2(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS2Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS2Descript % array(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartRS2Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) HotstartRS2Descript % array2(I)
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ELSE
+              ! Fill with zeros to pad the format
+              DO I=1, Elev1Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ENDIF
+            IF(NRS.eq.3)THEN
+              DO I=1, HotstartSwanRS1Descript % num_records_this
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS1Descript % array(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS1Descript % num_records_this
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS1Descript % array2(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS2Descript % num_records_this
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS2Descript % array(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+              DO I=1, HotstartSwanRS2Descript % num_records_this
+                  WRITE(hss % lun,REC=IHOTSTP) HotstartSwanRS2Descript % array2(I)
+                  IHOTSTP=IHOTSTP+1
+              ENDDO
+            ELSE
+              ! Fill with zeros to pad the format
+              DO I=1, Elev1Descript % num_records_this
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+                 WRITE(hss % lun,REC=IHOTSTP) 0.0
+                 IHOTSTP=IHOTSTP+1
+              ENDDO
+            ENDIF
          ENDIF
 C
          IF ((MYPROC.eq.0).or.

--- a/src/writer.F
+++ b/src/writer.F
@@ -1515,7 +1515,7 @@ C...
       ELSE
          WRITE(16,24541) hss % lun,WRITER_ID,IT,TimeLoc
       ENDIF
-24541 FORMAT(1X,'HOT START OUTPUT WRITTEN TO UNIT ',I2,'  HSWriter:',i2
+24541 FORMAT(1X,'HOT START OUTPUT WRITTEN TO UNIT ',I2,'  HSWriter:',i2,
      &    ' AT TIME STEP = ',I9,' TIME = ',E15.8)
       IF(hss % lun.EQ.67) THEN
 C        jgf45.07 added option to stop ADCIRC after writing hot start file.


### PR DESCRIPTION
# Description

This updates the binary hotstart format to include radiation stress information which is necessary for appropriately hot starting with a wave model. The change had already been made for netCDF hotstart format and this PR brings the two formats into sync.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Test suite runs successfully and a number of bespoke tests were run as well

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
