### PR TITLE
Building metis as object library instead of static library

### DIFF
--- a/cmake/metis.cmake
+++ b/cmake/metis.cmake
@@ -66,7 +66,7 @@ set(METIS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/metis/Lib/kwayvolrefine.c
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/metis/Lib/kwayvolfm.c
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/metis/Lib/subdomains.c)
-add_library(metis STATIC ${METIS_SOURCES})
+add_library(metis OBJECT ${METIS_SOURCES})
 target_include_directories(metis PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/metis/Lib)
 set_target_properties(metis PROPERTIES EXCLUDE_FROM_ALL TRUE)
 


### PR DESCRIPTION
# Description

When building with LTO, we need to ensure that functions don't get eliminated during archival. This comes up with Metis and `adcprep`. The simplest way to do this is to build the Metis library as an object library instead of a static library

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
