### PR TITLE
Modernizing MPI import syntax

### DIFF
--- a/src/adcirc.F
+++ b/src/adcirc.F
@@ -95,7 +95,7 @@ C******************************************************************************
 C******************************************************************************
 C******************************************************************************
 #ifdef CMPI
-      USE mpi
+      use mpi_f08, only: MPI_Comm
 #endif
 
       IMPLICIT NONE
@@ -146,8 +146,13 @@ C******************************************************************************
       USE HSWRITER, ONLY : hswriter_init
 #endif
       IMPLICIT NONE
-C
+
+#ifdef CMPI
+      type(MPI_Comm), OPTIONAL :: COMM
+#else
       INTEGER, OPTIONAL :: COMM
+#endif
+
       CHARACTER(*), OPTIONAL :: ROOTD
       REAL(8) :: StaTimHS
       REAL(8) :: RefTimHS
@@ -646,7 +651,7 @@ C-----------------------------------------------------------------------
         USE MESSENGER
         USE GLOBAL,ONLY: terminate_localproc, screenUnit, comm
         USE SIZES,ONLY: MYPROC
-        USE MPI
+        USE MPI_F08, ONLY: MPI_ALLREDUCE, MPI_2INTEGER, MPI_MAXLOC
         IMPLICIT NONE
 
         INTEGER :: TERM_LOCAL(2)

--- a/src/gl2loc_mapping.F90
+++ b/src/gl2loc_mapping.F90
@@ -33,8 +33,8 @@ module GL2LOC_MAPPING
    use MESH, only: NP ! local number of nodes
    use GLOBAL, only: nodes_lg, np_g, COMM
 
-   use MPI, only: MPI_INTEGER, MPI_STATUS_SIZE, MPI_Bcast, MPI_GATHER, &
-                  MPI_GATHERV, MPI_SCATTERV, MPI_Comm_rank, MPI_Comm_size
+   use mpi_f08, only: MPI_INTEGER, MPI_Bcast, MPI_Gather, &
+                      MPI_Gatherv, MPI_Scatterv
 
    implicit none
 
@@ -56,7 +56,7 @@ contains
 
    !----------------------------------------------------------------------
    subroutine MAPTOLOCAL_REAL(GLOBALDATA, LOCALDATA)
-      use mpi, only: MPI_DOUBLE_PRECISION
+      use mpi_f08, only: MPI_DOUBLE_PRECISION
       implicit none
       real(8), intent(IN) :: GLOBALDATA(:)
       real(8), intent(OUT) :: LOCALDATA(:)
@@ -147,7 +147,7 @@ contains
 
    !----------------------------------------------------------------------
    subroutine BcastToLocal_2DRealArray(Val, NX, NY)
-      use mpi, only: MPI_REAL
+      use mpi_f08, only: MPI_REAL
       implicit none
       real(4), intent(INOUT) :: Val(:, :)
       integer, intent(IN) :: NX, NY

--- a/src/global.F
+++ b/src/global.F
@@ -42,6 +42,9 @@ C
 #ifdef DATETIME
       use datetime_module, only: datetime
 #endif
+#ifdef CMPI
+      use mpi_f08, only: MPI_Comm, MPI_Datatype
+#endif
       IMPLICIT NONE
       SAVE
 C     jgf46.21 Added support for IBTYPE=52.
@@ -107,16 +110,18 @@ C     Variables related to hotstarting.
       real(8),allocatable ::   mom_lv_y(:)
 
       !-----------------------------------------------------------------
-      !        F U L L   D O M A I N   V A R I A B L E S   
-      !                  O N L Y   U S E D   
+      !        F U L L   D O M A I N   V A R I A B L E S
+      !                  O N L Y   U S E D
       !        I N   P A R A L L E L   E X E C U T I O N
       !-----------------------------------------------------------------
       ! jgf51.21.25: The variables in this section are only used in
       ! parallel execution but they are declared here (rather than in
-      ! the messenger module) because they are used in many different 
+      ! the messenger module) because they are used in many different
       ! modules, including harm.F, write_output.F, globalio.F et al.
       !-----------------------------------------------------------------
-      integer :: comm        ! MPI communicator.
+#ifdef CMPI
+      type(MPI_Comm) :: comm        ! MPI communicator.
+#endif
       integer :: np_g, ne_g  ! global (full domain) number of nodes, elements
 
 C     jgf48.03 Arrays for mapping subdomain nodes and elements to full
@@ -210,17 +215,14 @@ C     globalio and writer modules
       real(8) :: resultBuf(BUFSIZE_MAX)
       integer :: integerBuffer(BUFSIZE_MAX)
       integer :: integerResultBuffer(BUFSIZE_MAX)
-      integer                    :: float_type
-C
-C     jgf48.03 Variables shared between messenger and writer modules
-      integer ::  realtype, dbletype
-      !
+#ifdef CMPI
       ! there is a separate mpi communicator for each dedicated
-      ! writer processor; their communicator ids are stored in the 
+      ! writer processor; their communicator ids are stored in the
       ! following array
-      integer, allocatable ::  comm_writer(:)
+      type(MPI_Comm), allocatable ::  comm_writer(:)
       ! communicators for hotstart file writing !st3
-      integer, allocatable ::  comm_writeh(:), comm_hsleep(:)
+      type(MPI_Comm), allocatable ::  comm_writeh(:), comm_hsleep(:)
+#endif
       !
       ! = 0 if this is a compute proc; > 0 if this is a writer node
       integer :: writer_id

--- a/src/globalio.F
+++ b/src/globalio.F
@@ -30,7 +30,8 @@
       use GLOBAL
       use MESH, ONLY : NP, AGRID
 #ifdef CMPI
-      use mpi
+      use mpi_f08, only: MPI_Reduce, MPI_INTEGER, MPI_SUM,
+     &                   MPI_Status, MPI_Request, MPI_DOUBLE_PRECISION
 #endif
       contains
 
@@ -98,7 +99,9 @@ C--------------------------------------------------------------------
       external unpack_cmd
 #ifdef CMPI
       ! the subroutine used to write the file
-      integer      :: ierr, status(MPI_STATUS_SIZE), request
+      integer      :: ierr
+      type(MPI_Status) :: status
+      type(MPI_Request) :: request
       integer, save:: tagbase = 6000
       integer      :: iproc
       integer      :: bufsize
@@ -157,7 +160,7 @@ C        now send data to processor 0
            call mpi_reduce(integerBuffer, integerResultBuffer, bufsize,
      &                 MPI_INTEGER, MPI_SUM, 0, COMM, ierr)
          else
-           call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM,
+           call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM,
      &                     0, COMM, ierr)
          endif
          if (myproc == 0) then
@@ -632,9 +635,11 @@ C
       type (OutputDataDescript_t) :: descript
       real(8), intent(in) :: TimeLoc
       integer, intent(in) :: it
-      external write_cmd   
+      external write_cmd
 #ifdef CMPI
-      integer      :: ierr, status(MPI_STATUS_SIZE), request
+      integer      :: ierr
+      type(MPI_Status) :: status
+      type(MPI_Request) :: request
       integer      :: nGWetNodes
       integer      :: iglobal
 #endif
@@ -695,10 +700,10 @@ C
    
            call write_cmd(descript%lun, descript, istart, iend)
            if(descript%isInteger)then
-               call mpi_reduce(integerbuffer, integerresultBuffer, bufsize, mpi_int, MPI_SUM, 0,
+               call mpi_reduce(integerbuffer, integerresultBuffer, bufsize, mpi_integer, MPI_SUM, 0,
      &       COMM, ierr)
            else
-               call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM, 0,
+               call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM, 0,
      &       COMM, ierr)
            endif
            if (myproc == 0) then
@@ -751,9 +756,11 @@ C
       type (OutputDataDescript_t) :: descript
       real(8), intent(in) :: TimeLoc
       integer, intent(in) :: it
-      external write_cmd   
+      external write_cmd
 #ifdef CMPI
-      integer      :: ierr, status(MPI_STATUS_SIZE), request
+      integer      :: ierr
+      type(MPI_Status) :: status
+      type(MPI_Request) :: request
       integer      :: nGWetNodes
       integer      :: iglobal
 #endif
@@ -855,7 +862,7 @@ C
            tag     = tagbase + mod(ibucket, 8)
    
            call write_cmd(descript%lun, descript, istart, iend)
-           call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM, 0,
+           call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM, 0,
      &       COMM, ierr)
            if (myproc == 0) then
              do i = istart, iend

--- a/src/sizes.F
+++ b/src/sizes.F
@@ -118,7 +118,7 @@ C-----------------------------------------------------------------------
       SUBROUTINE MAKE_DIRNAME()
 !tcm v50.85 added for windows builds
 #ifdef CMPI
-      USE MPI, ONLY: mpi_abort, mpi_comm_world
+      use mpi_f08, only: MPI_Abort, MPI_COMM_WORLD
 #ifdef WINDOWS
       USE IFPORT
 #endif

--- a/src/wind.F
+++ b/src/wind.F
@@ -37,7 +37,6 @@ C
      &                      rhoWat0, Rearth, rhoAir, one2ten,
      &                      windReduction,omega
 #ifdef CMPI
-      use mpi
       use messenger, only : msg_fini, msg_Rscalar_Reduce
 #endif
 #ifdef DATETIME

--- a/src/writer.F
+++ b/src/writer.F
@@ -25,15 +25,15 @@ C                                                              05 Feb 2007, sb
 C******************************************************************************
 C
       module writer
+      use mpi_f08, only: MPI_DOUBLE_PRECISION, MPI_Comm
       use sizes, only : mnproc, mnwproc, OFF, ASCII, SPARSE_ASCII,
-     &     NETCDF3, NETCDF4, XDMF, iSplit, globalDir, meshType, 
+     &     NETCDF3, NETCDF4, XDMF, iSplit, globalDir, meshType,
      &     controlType, meshFileName_g, controlFileName_g
       use global, only: c3d, comm,
-     &    bufsize_max, buf, resultbuf, outputdatadescript_t, float_type,
+     &    bufsize_max, buf, resultbuf, outputdatadescript_t,
      &     debug, echo, info, warning, error, logmessage, allmessage,
      &     setmessagesource, unsetmessagesource, initLogging, nabout,
-     &     scratchMessage, dbletype, realtype, 
-     &     sig_val, sig_write, sig_ini, sig_pause, comm_writer, 
+     &     scratchMessage, sig_val, sig_write, sig_ini, sig_pause, comm_writer,
      &     sig_term, sig_mesh, writer_id
       use messenger, only: tag, msg_fini
       implicit none
@@ -133,14 +133,14 @@ C     correctly
 C-----------------------------------------------------------------------
       SUBROUTINE sendLabelInfoToWriters()
 C-----------------------------------------------------------------------
-          use mpi
+          use mpi_f08, only: MPI_Send, MPI_Recv, MPI_INTEGER, MPI_Status
           use sizes,only: myproc, mnwproc, mnproc
           use messenger,only: mpi_comm_adcirc
           use global,only: labels_g, np_g
           implicit none
           INTEGER :: ierr
           INTEGER :: I,N
-          INTEGER :: mpistat(mpi_status_size)
+          type(MPI_Status) :: mpistat
 
           IF(myproc.EQ.0)THEN
               DO I = 0,MNWPROC-1
@@ -176,11 +176,11 @@ C     then goes back to waiting for another signal.
 C-----------------------------------------------------------------------
       subroutine writer_main ()
       use global, only : ScreenUnit
-      use mpi
+      use mpi_f08, only: MPI_Recv, MPI_INTEGER, MPI_Status
       use messenger, only: msg_barrier, mpi_comm_adcirc
       IMPLICIT NONE
       integer :: sig, ierr, waittime, nextProc, prevProc, sig_dummy
-      integer :: mpistat(mpi_status_size)
+      type(MPI_Status) :: mpistat
       character(len=16) :: TimeIni
 C
       call setMessageSource("writer_main")
@@ -249,8 +249,9 @@ C     to send metadata and then output data to a writer processor.
 C-----------------------------------------------------------------------
       subroutine sendDataToWriter(descript, TimeLoc, it, store_cmd)
       use sizes, only : myproc
-      use global      
-      use mpi
+      use global
+      use mpi_f08, only: MPI_Send, MPI_Reduce, MPI_INTEGER,
+     &                   MPI_CHARACTER, MPI_SUM
       implicit none
       type (OutputDataDescript_t), intent(in) :: descript
       real(8) :: TimeLoc  ! output time in seconds
@@ -302,7 +303,7 @@ Cobell - Allow writer processors to output netcdf data
          REBUF(1) = descript % alternate_value
          REBUF(2) = timeLoc
          ! send dry value and time in seconds
-         call mpi_send(rebuf, numRealMetaData, realtype, mnproc, tag, 
+         call mpi_send(rebuf, numRealMetaData, MPI_DOUBLE_PRECISION, mnproc, tag, 
      &      comm_writer(wcommID),ierr)
          ! send file name
          call mpi_send(descript % file_name, 1024, mpi_character, 
@@ -334,7 +335,7 @@ C...     The following mpi_reduce sends array values to rank MNPROC,
 C...     which is the writer proc in the group.
 C...     Note that ranks from 0 to (MNPROC-1) are compute procs, and
 C...     rank MNPROC of writer communicators is always the writer proc.
-         call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM,
+         call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM,
      &      MNPROC, comm_writer(wcommID), ierr)
          istart = iend + 1
          iend   = min(istart + num - 1, descript % num_fd_records)
@@ -361,13 +362,14 @@ C     before receiving the actual output data. The data are not actually
 C     written in this subroutine.
 C-----------------------------------------------------------------------
       subroutine writer_recv_values()
-      use mpi
+      use mpi_f08, only: MPI_Recv, MPI_Reduce, MPI_INTEGER,
+     &                   MPI_CHARACTER, MPI_SUM, MPI_Status
       implicit none
       integer :: num, i, j
       integer :: ierr
       integer :: bufsize
       integer :: istart, iend
-      integer :: mpistat(MPI_STATUS_SIZE)
+      type(MPI_Status) :: mpistat
       logical :: descriptFound ! true if we found the particular buffer we need
       character(len=8) :: cdigit  !st3 100708: split file
 
@@ -417,7 +419,7 @@ C-----------------------------------------------------------------------
       nabout = intbuf(7)
       !
       ! receive "dry" data value and current simulation time
-      call mpi_recv(rebuf, numRealMetaData, realtype, 0, tag, 
+      call mpi_recv(rebuf, numRealMetaData, MPI_DOUBLE_PRECISION, 0, tag, 
      &   comm_writer(writer_id), mpistat, ierr)
       writer_descripts(bufid) % alternate_value = rebuf(1)
       writer_descripts(bufid) % wMD % myTime = rebuf(2)
@@ -472,7 +474,7 @@ C...     The following mpi_reduce sends array values to rank MNPROC,
 C...     which is a writer proc.
 C...     Note that ranks from 0 to (MNPROC-1) are compute procs, and
 C...     rank MNPROC of writer communicators is always a writer proc.
-         call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM,
+         call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM,
      &     MNPROC, comm_writer(writer_id), ierr)
 
          j = 1
@@ -515,7 +517,7 @@ C-----------------------------------------------------------------------
       SUBROUTINE FLUSH_WRITERS()
       use sizes, only : myproc
       use global
-      use mpi
+      use mpi_f08, only: MPI_Send, MPI_INTEGER
       implicit none
       INTEGER I,IERR
 
@@ -817,8 +819,8 @@ C     and use it during the writing of XDMF output.
 C-----------------------------------------------------------------------
       subroutine sendInitWriterXDMF(descript)
       use sizes, only : myproc
-      use global      
-      use mpi
+      use global
+      use mpi_f08, only: MPI_Send, MPI_INTEGER, MPI_CHARACTER
       implicit none
       type (OutputDataDescript_t), intent(in) :: descript
       character(len=80) :: fileKeyword
@@ -905,14 +907,14 @@ C-----------------------------------------------------------------------
       use global
       use mesh, only : readMesh, x, y, slam, sfea
       use sizes, only: MESHFILENAME,CONTROLFILENAME
-      use mpi
+      use mpi_f08, only: MPI_Recv, MPI_INTEGER, MPI_CHARACTER, MPI_Status
 #ifdef ADCXDMF
       use xdmfio, only : meshInitialized
       use control, only : readControlFile
 #endif
       implicit none
       integer      :: ierr
-      integer      :: mpistat(mpi_status_size)
+      type(MPI_Status) :: mpistat
       character(len=8) :: cdigit              !st3 100708: split file
 
       call setMessageSource("writerReadMesh")
@@ -977,7 +979,7 @@ C-----------------------------------------------------------------------
       subroutine writer_pause()
       use global
       use messenger, only: tag, writers_active
-      use mpi
+      use mpi_f08, only: MPI_Send, MPI_INTEGER
       implicit none
       integer i
       integer ierr
@@ -1024,10 +1026,14 @@ C
       MODULE HSWRITER
         USE SIZES
         USE GLOBAL
-        USE MESSENGER, ONLY: TAG, MSG_FINI
-        use mpi
+        USE MESSENGER, ONLY: TAG
+        use mpi_f08, only: MPI_Recv, MPI_Send, MPI_Barrier, MPI_Reduce,
+     &                     MPI_INTEGER, MPI_DOUBLE_PRECISION, MPI_LOGICAL,
+     &                     MPI_CHARACTER, MPI_SUM, MPI_Status, MPI_Request,
+     &                     MPI_Comm
       IMPLICIT NONE
-      INTEGER :: WCOMMID, WCOMM
+      INTEGER :: WCOMMID
+      type(MPI_Comm) :: WCOMM
       CONTAINS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!?
 
 !------------------------------------------------------------
@@ -1041,7 +1047,7 @@ C
         USE GLOBAL,ONLY : ScreenUnit
         IMPLICIT NONE
         INTEGER :: SIG,IERR
-        INTEGER :: STAT(MPI_STATUS_SIZE)
+        type(MPI_Status) :: STAT
 
         call setMessageSource("HSWRITER_MAIN")
 !
@@ -1084,7 +1090,6 @@ C...  Main loop
       subroutine HSWRITER_PAUSE()
       use global
       use messenger, only: tag, hs_writers_active
-      use mpi
       implicit none
       integer i
       integer ierr
@@ -1116,11 +1121,11 @@ C-----------------------------------------------------------------------
       USE SIZES
       USE GLOBAL
       USE MESH, ONLY : NE, NP
-      USE GLOBAL_IO, ONLY: packOne, unpackOne, 
+      USE GLOBAL_IO, ONLY: packOne, unpackOne,
      &    packTwo, unpackTwo, HEADER_MAX
 !
       IMPLICIT NONE
-      INTEGER :: STAT(MPI_STATUS_SIZE)
+      type(MPI_Status) :: STAT
       integer :: i
       integer :: ierr
 
@@ -1562,7 +1567,7 @@ C        jgf45.07 added option to stop ADCIRC after writing hot start file.
       END SUBROUTINE writeHotstart_through_HSwriter
 !
       SUBROUTINE GET_NEXT_HSWRITER_COMM(NEXT_WCOMM)
-      INTEGER,intent(inout) :: NEXT_WCOMM
+      type(MPI_Comm), intent(inout) :: NEXT_WCOMM
       INTEGER :: NEXT_WCOMMID
 
         IF(WCOMMID >= MNWPROH) THEN
@@ -1584,7 +1589,9 @@ C        jgf45.07 added option to stop ADCIRC after writing hot start file.
       external unpack_cmd
 #ifdef CMPI
 !     ! the subroutine used to write the file
-      integer      :: ierr, status(MPI_STATUS_SIZE), request
+      integer      :: ierr
+      type(MPI_Status) :: status
+      type(MPI_Request) :: request
       integer, save:: tagbase = 6000
       integer      :: iproc
       integer      :: bufsize
@@ -1619,7 +1626,7 @@ C        jgf45.07 added option to stop ADCIRC after writing hot start file.
          tag     = tagbase + mod(ibucket, 8)
 
          call pack_cmd(descript, istart, iend)
-         call mpi_reduce(buf, resultBuf, bufsize, float_type, MPI_SUM,
+         call mpi_reduce(buf, resultBuf, bufsize, MPI_DOUBLE_PRECISION, MPI_SUM,
      &                   MNPROC, WCOMM, ierr)
 
          if (WRITER_ID /= 0) then
@@ -1644,7 +1651,9 @@ C        jgf45.07 added option to stop ADCIRC after writing hot start file.
       external unpack_cmd
 #ifdef CMPI
 !     ! the subroutine used to write the file
-      integer      :: ierr, status(MPI_STATUS_SIZE), request
+      integer      :: ierr
+      type(MPI_Status) :: status
+      type(MPI_Request) :: request
       integer, save:: tagbase = 6000
       integer      :: iproc
       integer      :: bufsize

--- a/thirdparty/swan/SwanMaxOverNodes.ftn90
+++ b/thirdparty/swan/SwanMaxOverNodes.ftn90
@@ -44,7 +44,7 @@ subroutine SwanMaxOverNodes ( rval )
     use ocpcomm4
 !PUN    use SIZES, only: MNPROC
 !PUN    use GLOBAL, only: COMM
-!PUN    use mpi
+!PUN    use mpi_f08, only: MPI_ALLREDUCE, MPI_REAL4, MPI_MAX
 !
     implicit none
 !

--- a/thirdparty/swan/SwanMinOverNodes.ftn90
+++ b/thirdparty/swan/SwanMinOverNodes.ftn90
@@ -44,7 +44,7 @@ subroutine SwanMinOverNodes ( rval )
     use ocpcomm4
 !PUN    use SIZES, only: MNPROC
 !PUN    use GLOBAL, only: COMM
-!PUN    use mpi
+!PUN    use mpi_f08, only: MPI_ALLREDUCE, MPI_REAL4, MPI_MIN
 !
     implicit none
 !

--- a/thirdparty/swan/SwanPunCollect.ftn90
+++ b/thirdparty/swan/SwanPunCollect.ftn90
@@ -48,7 +48,7 @@ subroutine SwanPunCollect ( blkndc )
 !PUN!
 !PUN!   Modules used
 !PUN!
-!PUN    use mpi
+!PUN    use mpi_f08, only: MPI_Gather, MPI_Gatherv, MPI_INTEGER, MPI_REAL, MPI_SUCCESS
 !PUN    use ocpcomm4
 !PUN    use swcomm2, only: XOFFS, YOFFS
 !PUN    use m_parall, only: IAMMASTER

--- a/thirdparty/swan/SwanSumOverNodes.ftn90
+++ b/thirdparty/swan/SwanSumOverNodes.ftn90
@@ -44,7 +44,7 @@ subroutine SwanSumOverNodes ( rval )
     use ocpcomm4
 !PUN    use SIZES, only: MNPROC
 !PUN    use GLOBAL, only: COMM
-!PUN    use mpi
+!PUN    use mpi_f08, only: MPI_ALLREDUCE, MPI_REAL4, MPI_SUM
 !
     implicit none
 !


### PR DESCRIPTION
# Description

Using the modern MPI import syntax and `mpi_f08` module.

This allows for type-safe MPI handles and is better supported versus the legacy `mpi` module and is the recommended module to use for non-legacy code.

The `mpi_f08` module has been fully supported since approximately 2014 by most major MPI distributions:
* OpenMPI v1.0.8 (2014)
* MPICH 3.1 (2014)
* Intel MPI 5.0 (2014)
* MVAPICH2 2.0 (2013)

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`
