### PR TITLE
Fixing issue where certain compiler/mpi combinations hang within SWAN

### DIFF
--- a/thirdparty/swan/SwanPunCollect.ftn90
+++ b/thirdparty/swan/SwanPunCollect.ftn90
@@ -48,7 +48,7 @@ subroutine SwanPunCollect ( blkndc )
 !PUN!
 !PUN!   Modules used
 !PUN!
-!PUN    use mpi_f08, only: MPI_Gather, MPI_Gatherv, MPI_INTEGER, MPI_REAL, MPI_SUCCESS
+!PUN    use mpi_f08, only: MPI_Allgather, MPI_Gatherv, MPI_INTEGER, MPI_REAL, MPI_SUCCESS
 !PUN    use ocpcomm4
 !PUN    use swcomm2, only: XOFFS, YOFFS
 !PUN    use m_parall, only: IAMMASTER
@@ -110,32 +110,31 @@ subroutine SwanPunCollect ( blkndc )
 !PUN       endif
 !PUN    enddo
 !PUN    !
-!PUN    if ( IAMMASTER ) then
-!PUN       allocate(icount(0:MNPROC-1))
-!PUN       allocate(idsplc(0:MNPROC-1))
-!PUN    endif
+!PUN    ! allocate on all processes for allgather
 !PUN    !
-!PUN    ! gather the array sizes to the master
+!PUN    allocate(icount(0:MNPROC-1))
+!PUN    icount(:) = 0
 !PUN    !
-!PUN    call MPI_GATHER( nownv, 1, MPI_INTEGER, icount, 1, MPI_INTEGER, 0, COMM, ierr )
+!PUN    ! gather the array sizes to all processes
+!PUN    !
+!PUN    call MPI_ALLGATHER( nownv, 1, MPI_INTEGER, icount, 1, MPI_INTEGER, COMM, ierr )
 !PUN    if ( ierr /= MPI_SUCCESS ) then
 !PUN       write (msgstr, '(a,i6)') ' MPI produces some internal error - return code is ',ierr
 !PUN       call msgerr( 4, trim(msgstr) )
 !PUN       return
 !PUN    endif
 !PUN    !
-!PUN    ! check consistency with respect to size of gathered data
+!PUN    ! check consistency with respect to size of gathered data (all processes)
 !PUN    !
-!PUN    if ( IAMMASTER ) then
-!PUN       if ( sum(icount) /= nvertsg ) then
-!PUN          call msgerr(4, 'inconsistency found in SwanPunCollect: size of gathered data not correct ')
-!PUN          return
-!PUN       endif
+!PUN    if ( sum(icount) /= nvertsg ) then
+!PUN       call msgerr(4, 'inconsistency found in SwanPunCollect: size of gathered data not correct ')
+!PUN       return
 !PUN    endif
 !PUN    !
 !PUN    ! calculate starting address of each local array with respect to the global array
 !PUN    !
 !PUN    if ( IAMMASTER ) then
+!PUN       allocate(idsplc(0:MNPROC-1))
 !PUN       idsplc(0) = 0
 !PUN       do j = 1, MNPROC-1
 !PUN          idsplc(j) = icount(j-1) + idsplc(j-1)
@@ -193,6 +192,7 @@ subroutine SwanPunCollect ( blkndc )
 !PUN    !
 !PUN    deallocate(ivertp,blknd)
 !PUN    deallocate(xpl,ypl)
-!PUN    if ( IAMMASTER ) deallocate(icount,idsplc,iarr,arr)
+!PUN    deallocate(icount)
+!PUN    if ( IAMMASTER ) deallocate(idsplc,iarr,arr,xcugrdgl,ycugrdgl)
 !PUN    !
 end subroutine SwanPunCollect


### PR DESCRIPTION
# Description

SWAN issues an `MPI_GATHER` command in `SwanPunCollect.ftn90` which should collect data to process 0, however, if the mpi implementation makes assumptions about the receive buffer on non-root processes of the `MPI_GATHER` (ex. Intel-LLVM + OpenMPI 5), then the code could be working with uninitialized memory. Instead, we allocate the `icount` array on all processes and set to 0 to explicitly initialize it on all processors which resolves the issue.

This manifests itself as the coupled model hanging while final outputs (i.e. max files) are being written to disk. Processor 0 continues working in the SWAN code, but all other processors early return to ADCIRC and hang there. 

Aside from the potential issue with specific library combinations, this check is a possible desynchronization point anyway. It is updated to use `MPI_ALLGATHER`, so that all processes can exit if an error in the node count is found. This is important because if the check for did fail, only processor 0 would ever know about it introducing a second way for the code to stall.

Tagging @caseydietrich to pass upstream to the SWAN team.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`