### PR TITLE
Temporal controls (phase 1 of 2)

### DIFF
--- a/prep/prep.F
+++ b/prep/prep.F
@@ -2278,6 +2278,10 @@ C
            write(15,*) '! -- Begin SWAN Output Control Namelist --'
            write(15,SWANOutputControl)
            write(15,*) '! -- End SWAN Output Control Namelist --'
+Casey 251212: Adding time control.
+           write(15,*) '! -- Begin SWAN Time Control Namelist --'
+           write(15,SWANTimeControl)
+           write(15,*) '! -- End SWAN Time Control Namelist --'
          endif
 
 ! tcm v50.79 Changed so that metControl namelist is only written if it was found in the

--- a/prep/presizes.F
+++ b/prep/presizes.F
@@ -146,6 +146,8 @@ Casey 121019: Added multiplication factor to be used before sending winds to cou
      &    SWAN_OutputHS,SWAN_OutputDIR,SWAN_OutputTM01,
      &    SWAN_OutputTPS,SWAN_OutputWIND,SWAN_OutputTM02,
      &    SWAN_OutputTMM10
+Casey 251212: Adding time control.
+     &   ,RunStartDateTime
 
       USE WIND, ONLY :  WindDragLimit,DragLawString,rhoAir,
      &                  initWindModule, 
@@ -270,6 +272,8 @@ C Logicals added for adcprep paths
       NAMELIST /SWANOutputControl/ SWAN_OutputHS, SWAN_OutputDIR,
      &    SWAN_OutputTM01, SWAN_OutputTPS, SWAN_OutputWIND,
      &    SWAN_OutputTM02, SWAN_OutputTMM10
+Casey 251212: Adding time control.
+      NAMELIST /SWANTimeControl/ RunStartDateTime
 
       NAMELIST /metControl/ WindDragLimit,DragLawString,outputWindDrag,rhoAir,
      &                       invertedBarometerOnElevationBoundary,nPowellSearchDomains
@@ -730,6 +734,15 @@ C.....REWIND THE FORT.15 FILE IN ORDER TO PROCESS THE REMAINING PIECES
          SWAN_OutputHS=.TRUE.
          SWAN_OutputTPS=.TRUE.
          SWAN_OutputDIR=.TRUE.
+      ENDIF
+      REWIND(15)
+
+Casey 251212: Adding time control.
+      IOS = 0
+      READ(UNIT=15,NML=SWANTimeControl,IOSTAT=IOS)
+      IF (IOS.ne.0) THEN
+         write(*,*)"INFO: The SWANTimeControl namelist was not found."
+         RunStartDateTime = "-99999"
       ENDIF
       REWIND(15)
 

--- a/src/couple2swan.F
+++ b/src/couple2swan.F
@@ -954,6 +954,8 @@ CTGA 110912:  Full SWAN ice implementation.  Use global variables
      &                    NCICE,
      &                    CICE1,
      &                    CICE2
+Casey 251212: Adding time control.
+     &                   ,RunStartDateTime
       USE WIND, ONLY :   WVNX1,
      &                    WVNX2,
      &                    WVNY1,
@@ -963,12 +965,16 @@ CTGA 111003:  Adding ability to read in ice info from fort.26 file
       USE SWCOMM3,  ONLY: SWAN_WBICETH => WBICETH,
      &                    SWAN_IICE => IICE
       USE TIMECOMM, ONLY: SWAN_DT => DT
+Casey 251212: Adding time control.
+     &                   ,SWAN_TINIC => TINIC
 
       IMPLICIT NONE
 
       INTRINSIC :: ALLOCATED
 
       INTEGER   :: IN  ! Node counter.
+Casey 251212: Adding time control.
+      REAL(8) :: AdcircStartTime
 
       LOG_SCOPE_TRACED("PADCSWAN_INIT", COUPLE2SWAN_TRACING)
 Casey 090302: Allocate memory for the ADCIRC values that may be
@@ -1079,6 +1085,18 @@ C      ENDDO
 Casey 090302: Compute the coupling interval as equivalent
 C             to the SWAN time step.
       CouplingInterval = SWAN_DT / DT
+Casey 251212: Adding time control. Determine how many SWAN time steps
+C             to skip before the start of its calculations.
+      IF( INDEX( RunStartDateTime, "-") .GT. 0 ) THEN
+         SwanTimeStep = 0
+      ELSE
+         ! I will mimic code from thirdparty/swan/swanpre1.ftn
+         ! Convert datetime to real time since reference.
+!Nicole 251218: fixed hardcoded date to datetime from namelist
+         CALL DTRETI( RunStartDateTime, 1, AdcircStartTime )
+         ! Initialize the starting time step.
+         SwanTimeStep = NINT( ( AdcircStartTime - SWAN_TINIC ) / SWAN_DT )
+      ENDIF
 
 C-----------------------------------------------------------------------
       END SUBROUTINE PADCSWAN_INIT
@@ -1104,10 +1122,21 @@ CTGA 110912:  Full SWAN ice implementation.  Use global variables
      &                    CICE2,
      &                    CICE_TIME1,
      &                    CICE_TIMINC
+Casey 251212: Adding time controls.
+     &                   ,Swan_HSOut,
+     &                    Swan_DIROut,
+     &                    Swan_TM01Out,
+     &                    Swan_TPSOut,
+     &                    Swan_WindXOut,
+     &                    Swan_WindYOut,
+     &                    Swan_TM02Out,
+     &                    Swan_TMM10Out
 CTGA 111003:  Adding ability to read in ice info from fort.26 file
       USE MESH, ONLY : NP, DP
       USE SWCOMM3,  ONLY: SWAN_IICE => IICE,
      &                    SWAN_WBICETH => WBICETH
+Casey 251212: Adding time controls.
+     &                   ,SWAN_MTC => MTC
       USE TIMECOMM, ONLY: SWAN_DT => DT
 
       IMPLICIT NONE
@@ -1212,7 +1241,55 @@ Csb   251003: Remove IF(COUPFRIC) so that SWAN_Z0 is always initialized. COUPFRI
 Casey 090729: Average values over the time step.
       InterpoWeight = 0.5D0
       SwanTimeStep = SwanTimeStep + 1
-      CALL SWMAIN(ITIME,SwanTimeStep)
+Casey 251212: Adding time control.
+      IF((SwanTimeStep.GE.1).AND.(SwanTimeStep.LE.SWAN_MTC))THEN
+        CALL SWMAIN(ITIME,SwanTimeStep)
+      ENDIF
+
+Casey 251212: Adding time control. The call to 'SwanOutput' is made from
+C             the SWAN side. If we did not call SWAN, then we need to
+C             'compute' or at least initialize the output quantities.
+      IF((SwanTimeStep.LT.1).OR.(SwanTimeStep.GT.SWAN_MTC))THEN
+         Swan_HSOut(:) = -99999.D0
+         Swan_DIROut(:) = -99999.D0
+         Swan_TM01Out(:) = -99999.D0
+         Swan_TPSOut(:) = -99999.D0
+         Swan_WindXOut(:) = 0.D0
+         Swan_WindYOut(:) = 0.D0
+         Swan_TM02Out(:) = 0.D0
+         Swan_TMM10Out(:) = -99999.D0
+      ENDIF
+Casey 251212: End changes for output.
+
+Casey 251212: Adding time control. The call to 'ComputeRadiationStresses'
+C             is made from the SWAN side. If we did not call SWAN,
+C             then we need to 'compute' the radiation stresses here.
+      IF((SwanTimeStep.LT.1).OR.(SwanTimeStep.GT.SWAN_MTC))THEN
+!... (Re)allocate the arrays.
+         IF(.NOT.ALLOCATED(ADCIRC_SXX))THEN
+            ALLOCATE(ADCIRC_SXX(1:NP,1:2))
+            ADCIRC_SXX(:,:) = 0.D0
+         ENDIF
+         IF(.NOT.ALLOCATED(ADCIRC_SXY))THEN
+            ALLOCATE(ADCIRC_SXY(1:NP,1:2))
+            ADCIRC_SXY(:,:) = 0.D0
+         ENDIF
+         IF(.NOT.ALLOCATED(ADCIRC_SYY))THEN
+            ALLOCATE(ADCIRC_SYY(1:NP,1:2))
+            ADCIRC_SYY(:,:) = 0.D0
+         ENDIF
+         DO IN=1,NP
+!... Transfer the stresses from the new time level to the old time level.
+            ADCIRC_SXX(IN,1) = ADCIRC_SXX(IN,2)
+            ADCIRC_SXY(IN,1) = ADCIRC_SXY(IN,2)
+            ADCIRC_SYY(IN,1) = ADCIRC_SYY(IN,2)
+!... Initialize the radiation stresses as zero at all of the nodes.
+            ADCIRC_SXX(IN,2) = 0.0
+            ADCIRC_SXY(IN,2) = 0.0
+            ADCIRC_SYY(IN,2) = 0.0
+         ENDDO
+      ENDIF
+Casey 251212: End changes for radiation stresses.
 
 Casey 090302: Move the 'old' values into the first columns.
 C             We do this for the winds after the SWAN time steps

--- a/src/global.F
+++ b/src/global.F
@@ -316,6 +316,8 @@ Cobell 20120510: Added logicals for turning on/off swan output files
       LOGICAL                      :: SWAN_OutputTM02 = .FALSE.
       LOGICAL                      :: SWAN_OutputTMM10 = .FALSE.
       LOGICAL                      :: SWAN_OutputAgg(7)
+Casey 251212: Adding time control.
+      CHARACTER(LEN=15)            :: RunStartDateTime
 
 Cobell - Added for Time Varying Weirs, Set to default values
       LOGICAL                      :: USE_TVW = .FALSE.     !..From namelist, used time varying weirs

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -82,6 +82,12 @@ C      StartDry              "surface_submergence_state"
 C      Fric                  "quadratic_friction_coefficient_at_sea_floor"
 C      z0Land                "surface_directional_effective_roughness_length"
 C                            (z0Land has ValuesPerNode = 12)
+!Nicole 260220: Allow SWAN to be activated for selective regions of the 
+! ADCIRC mesh and identified using a nodal attribute. The nodal attribute 
+! controls which nodes are active vs inactive and which nodes should be 
+! used as internal source nodes to apply spectral 'boundary' conditions at. 
+C      SwanLocalControl      "swan_local_control"
+C                            (SwanLocalControl has ValuesPerNode = 2)
 C      VCanopy               "surface_canopy_coefficient"
 C      BK,BAlpha,BDelX,POAN  "bridge_pilings_friction_parameters"
 C                            (bridge_pilings... has ValuesPerNode=4)
@@ -144,6 +150,8 @@ C     required for the run, according to the unit 15 control file
       LOGICAL LoadTau0
       LOGICAL LoadStartDry
       LOGICAL LoadDirEffRLen
+! Nicole 250327: Allow SWAN to use a different spatial domain and inputs
+      LOGICAL LoadSwanLocalControl
       LOGICAL LoadCanopyCoef
       LOGICAL LoadQuadraticFric
       LOGICAL LoadBridgePilings
@@ -164,7 +172,8 @@ C     The following flags are .true. if there are data with the
 C     corresponding label in the unit 13 file.
       LOGICAL FoundTau0
       LOGICAL FoundStartDry
-      LOGICAL FoundDirEffRLen
+      LOGICAL FoundDirEffRLen 
+      LOGICAL FoundSwanLocalControl
       LOGICAL FoundCanopyCoef
       LOGICAL FoundQuadraticFric
       LOGICAL FoundBridgePilings
@@ -187,6 +196,7 @@ C     v46.00.
       CHARACTER(len=80) Tau0Units
       CHARACTER(len=80) StartDryUnits
       CHARACTER(len=80) DirEffRLenUnits
+      CHARACTER(len=80) SwanLocalControlUnits
       CHARACTER(len=80) CanopyCoefUnits
       CHARACTER(len=80) QuadraticFricUnits
       CHARACTER(len=80) BridgePilingsUnits
@@ -208,6 +218,7 @@ C     attribute.
       INTEGER Tau0NoOfVals
       INTEGER StartDryNoOfVals
       INTEGER DirEffRLenNoOfVals
+      INTEGER SwanLocalControlNoOfVals
       INTEGER CanopyCoefNoOfVals
       INTEGER QuadraticFricNoOfVals
       INTEGER BridgePilingsNoOfVals
@@ -228,6 +239,7 @@ C     These variables hold the default values for each attribute.
       REAL(8) Tau0DefVal
       REAL(8) StartDryDefVal
       REAL(8) DirEffRLenDefVal(12)
+      REAL(8) SwanLocalControlDefVal(2)
       REAL(8) CanopyCoefDefVal
       REAL(8) QuadraticFricDefVal
       REAL(8) BridgePilingsDefVal(4)
@@ -294,6 +306,7 @@ C     jgf48.42: Added backloaded time averaged tau0
                                                                    ! exceeded, used for gradient warnings
 
       REAL(8), ALLOCATABLE :: z0land(:,:) ! directional wind speed red. fac.
+      REAL(8), ALLOCATABLE :: SwanLocalControl(:,:) !swan local control
       REAL(8), ALLOCATABLE :: vcanopy(:)  ! canopy coefficient
 C     The following attribute contains BK(I),BALPHA(I),BDELX(I), and POAN(I)
       REAL(8), ALLOCATABLE :: BridgePilings(:,:)
@@ -421,6 +434,7 @@ C
       LoadTau0           = .False.
       LoadStartDry       = .False.
       LoadDirEffRLen     = .False.
+      LoadSwanLocalControl = .False.
       LoadManningsN      = .False.
       LoadQuadraticFric  = .False.
       LoadChezy          = .False.
@@ -440,6 +454,7 @@ C
       FoundTau0           = .False.
       FoundStartDry       = .False.
       FoundDirEffRLen     = .False.
+      FoundSwanLocalControl = .False.
       FoundManningsN      = .False.
       FoundQuadraticFric  = .False.
       FoundChezy          = .False.
@@ -460,6 +475,7 @@ C
       Tau0NoOfVals          = 1
       StartDryNoOfVals      = 1
       DirEffRLenNoOfVals    = 12
+      SwanLocalControlNoOfVals = 2
       QuadraticFricNoOfVals = 1
       ChezyNoOfVals         = 1
       ManningsNNoOfVals     = 1
@@ -481,6 +497,9 @@ C
       DO j=1, DirEffRLenNoOfVals
          DirEffRLenDefVal(j) = 0.0
       END DO
+! Nicole 250327 set SwanOn default to 1 (on) and IntSource default to 0 
+      SwanLocalControlDefVal(1) = 1.0
+      SwanLocalControlDefVal(2) = 0.0
       CanopyCoefDefVal       = 1.0 ! jgf49.1001 default is now full wind stress
       QuadraticFricDefVal    = 0.0
       DO j=1, BridgePilingsNoOfVals
@@ -645,6 +664,8 @@ C
             FoundQuadraticFric = .True.
          CASE("surface_directional_effective_roughness_length")
             FoundDirEffRLen = .True.
+         CASE("swan_local_control")
+            FoundSwanLocalControl = .True.
          CASE("surface_canopy_coefficient")
             FoundCanopyCoef = .True.
          CASE("bridge_pilings_friction_parameters")
@@ -788,6 +809,10 @@ C     numOfNodes value
             IF (LoadDirEffRLen) THEN
                z0land  = na(i)%xdmfMatrix
             ENDIF
+         CASE("swan_local_control")
+            IF (LoadSwanLocalControl) THEN
+               SwanLocalControl = na(i)%xdmfMatrix
+            ENDIF
          CASE("surface_canopy_coefficient")
             IF (LoadCanopyCoef) THEN
                vcanopy = na(i)%xdmfArray
@@ -892,6 +917,8 @@ C     that are not in the nodal attributes file.
      &    (.not.FoundQuadraticFric)).or.
      &   ((LoadDirEffRLen).and.
      &    (.not.FoundDirEffRLen)).or.
+     &   ((LoadSwanLocalControl) .and.
+     &    (.not.FoundSwanLocalControl)).or. 
      &   ((LoadCanopyCoef).and.
      &    (.not.FoundCanopyCoef)).or.
      &   ((LoadBridgePilings).and.
@@ -942,6 +969,7 @@ C     Allocate memory to hold our data.
       ALLOCATE(STARTDRY(NumOfNodes))
       ALLOCATE(FRIC(NumOfNodes))
       ALLOCATE(z0land(NumOfNodes,DirEffRLenNoOfVals))
+      ALLOCATE(SwanLocalControl(NumOfNodes,SwanLocalControlNoOfVals))
       ALLOCATE(vcanopy(NumOfNodes))
       ALLOCATE(BridgePilings(NumOfNodes,BridgePilingsNoOfVals))
       ALLOCATE(GeoidOffset(NumOfNodes))
@@ -1062,6 +1090,8 @@ C     loaded from nodal attributes file.
             LoadQuadraticFric = .True.
          CASE("surface_directional_effective_roughness_length")
             LoadDirEffRLen = .True.
+         CASE("swan_local_control")
+            LoadSwanLocalControl = .True.
          CASE("surface_canopy_coefficient")
             LoadCanopyCoef = .True.
          CASE("bridge_pilings_friction_parameters")
@@ -1201,6 +1231,12 @@ C
             READ(13,*) DirEffRLenNoOfVals
             READ(13,*)
      &      (DirEffRLenDefVal(j),j=1,DirEffRLenNoOfVals)
+         CASE("swan_local_control")
+            FoundSwanLocalControl = .True.
+            READ(13,'(A80)') SwanLocalControlUnits
+            READ(13,*) SwanLocalControlNoOfVals
+            READ(13,*) 
+     &      (SwanLocalControlDefVal(j),j=1,SwanLocalControlNoOfVals)
          CASE("surface_canopy_coefficient")
             FoundCanopyCoef = .True.
             READ(13,'(A80)') CanopyCoefUnits
@@ -1360,6 +1396,15 @@ C     (unit 15) file and skip past the others.
                CALL LoadAttrMat(z0land, DirEffRLenNoOfVals,
      &              DirEffRLenDefVal, NumNodesNotDefault,
      &              NScreen, MyProc, NAbOut)
+            ELSE
+               SkipDataSet = .True.
+            ENDIF
+         CASE("swan_local_control")
+            IF (LoadSwanLocalControl) THEN
+               CALL LoadAttrMat(SwanLocalControl,
+     &             SwanLocalControlNoOfVals,
+     &             SwanLocalControlDefVal, NumNodesNotDefault,
+     &             NScreen, MyProc, NAbOut)   
             ELSE
                SkipDataSet = .True.
             ENDIF
@@ -1992,6 +2037,17 @@ C     I N I T   B O T T O M   F R I C T I O N
          IFHYBF=1
       ENDIF
 C
+! Nicole 20260211 Initialize SwanLocalControl if not loaded 13
+      IF(.not.LoadSwanLocalControl) THEN
+         IF(.not.ALLOCATED(SwanLocalControl)) THEN
+           ALLOCATE(SwanLocalControl(NP,SwanLocalControlNoOfVals))
+         ENDIF
+         DO I=1,NP
+            DO J=1, SwanLocalControlNoOfVals
+               SwanLocalControl(I,J)=SwanLocalControlDefVal(J)
+            ENDDO
+         ENDDO
+      ENDIF
 C     Initialize bottom friction if it was not loaded from unit 13.
       IF(C2DDI) THEN
          IF((.not.LoadQuadraticFric).and.(.not.LoadManningsN).and.

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -91,6 +91,8 @@ C-----------------------------------------------------------------------
      &   , SWAN_OutputHS, SWAN_OutputDIR,
      &    SWAN_OutputTM01, SWAN_OutputTPS, SWAN_OutputWIND,
      &    SWAN_OutputTM02, SWAN_OutputTMM10
+Casey 251212: Adding time control.
+     &   , RunStartDateTime
 #endif
 #ifdef DATETIME
      &   ,basedatetime
@@ -234,6 +236,8 @@ C
       NAMELIST /SWANOutputControl/ SWAN_OutputHS, SWAN_OutputDIR,
      &    SWAN_OutputTM01, SWAN_OutputTPS, SWAN_OutputWIND,
      &    SWAN_OutputTM02, SWAN_OutputTMM10
+Casey 251212: Adding time control.
+      NAMELIST /SWANTimeControl/ RunStartDateTime
 #endif
       NAMELIST /metControl/ WindDragLimit,DragLawString,outputWindDrag,
      &  rhoAir, invertedBarometerOnElevationBoundary,
@@ -466,6 +470,16 @@ c     a non-default value we can determine this was the case.
      &    " SWAN_OutputWIND=",SWAN_OutputWIND,
      &    " SWAN_OutputTM02=",SWAN_OutputTM02,
      &    " SWAN_OutputTMM10=",SWAN_OutputTMM10
+      call logMessage(ECHO,trim(scratchMessage))
+      rewind(15)
+Casey 251212: Adding time control.
+      namelistSpecifier = 'SWANTImeControl'
+      RunStartDateTime = "-99999"
+      read(unit=15,nml=SWANTimeControl,iostat=ios,iomsg=ios_nml_error_msg)
+      call logNamelistReadStatus(namelistSpecifier, ios, ios_nml_error_msg)
+      call logMessage(ECHO,
+     &    "The values of SWANTImeControl are as follows:")
+      write(scratchMessage,*) "RunStartDateTime = ",RunStartDateTime
       call logMessage(ECHO,trim(scratchMessage))
       rewind(15)
 #endif

--- a/thirdparty/swan/SwanBpntlist.ftn90
+++ b/thirdparty/swan/SwanBpntlist.ftn90
@@ -63,10 +63,16 @@ subroutine SwanBpntlist
     use SwanGridobjects
     use SwanCompdata
     use OUTP_DATA                  ! 41.14
+!Nicole 250327: Allow for use of SwanLocalControl
+!ADC    use NodalAttributes, ONLY: SwanLocalControl
 !
     implicit none
 !
 !   Local variables
+!
+! Nicole 250317
+    integer                            :: kvert 
+    integer                            :: kk
 !
     integer                            :: icell      ! cell index
     integer, parameter                 :: idebug=0   ! level of debug output:
@@ -109,7 +115,7 @@ subroutine SwanBpntlist
     real                               :: xp, yp     ! coordinates of a boundary point                  41.14
     !
     character(80)                      :: msgstr     ! string to pass message
-    character (len=8)                  :: PSNAME     ! name of output curve                             41.14
+    character (len=16)                 :: PSNAME     ! name of output curve                             41.14
     !
     logical                            :: firstvert  ! indicate whether considered vertex is first vertex of boundary polygon
     logical                            :: found      ! indicates whether a new boundary part was found  41.14
@@ -323,8 +329,9 @@ subroutine SwanBpntlist
              !
           endif
           !
-          if ( k == nbptot ) exit faceloop
-          !
+!NADC     if ( k == nbptot ) exit faceloop
+!Nicole 241206: Change criteria to exit faceloop accounting for internal sources
+!ADC      if ( k == nbptot - num_int_src ) exit faceloop          !
        endif
        !
  10    continue
@@ -347,11 +354,22 @@ subroutine SwanBpntlist
              write(PRTEST,*) 'error in SwanBpntlist: nbptot =  ', nbptot
              write(PRTEST,*) 'error in SwanBpntlist: blistot = ', blistot
           endif
-          return
+ !Nicole 241009:  Changed return to exit
+          exit
           !
        endif
        !
     enddo faceloop
+    !
+! Nicole 250317: Add number of internal sources to variable count
+!ADC nbpol = nbpol + num_int_src
+! Nicole 250317: Add internal sources  
+!ADC nbpt(nbpol) = num_int_src
+!ADC do kk = 1,nbpt(nbpol)
+!ADC    vn = int_src_nd(kk)
+!ADC    blistot(k+kk) = vn
+!ADC    vert(vn)%atti(BPOL) = nbpol
+!ADC enddo
     !
     ! store number of boundary vertices for last polygon
     !

--- a/thirdparty/swan/SwanCompUnstruc.ftn90
+++ b/thirdparty/swan/SwanCompUnstruc.ftn90
@@ -99,7 +99,8 @@ subroutine SwanCompUnstruc ( ac2, ac1, compda, spcsig, spcdir, xytst, cross, it 
 !PUN    use SIZES, only: MNPROC
 !PUN    use MESSENGER
 !ADC    use couple2adcirc, only: MakeBoundariesReflective
-!ADC    use NodalAttributes, only: FoundSwanWaveRefrac, LoadSwanWaveRefrac, SwanWaveRefrac
+! Nicole 250327: add SwanLocalControl
+!ADC    use NodalAttributes, only: FoundSwanWaveRefrac, LoadSwanWaveRefrac, SwanWaveRefrac, SwanLocalControl
 !
     implicit none
 !
@@ -639,11 +640,19 @@ subroutine SwanCompUnstruc ( ac2, ac1, compda, spcsig, spcdir, xytst, cross, it 
     ! marks vertices active and non-active
     !
     !$omp single
+!Nicole 250315: If statement to deactivate SwanLocalControl 0 nodes 
     nwetp = 0.
     do kvert = 1, nverts
-       if ( compda(kvert,JDP2) > DEPMIN ) then
-          vert(kvert)%active = .true.
-          nwetp = nwetp +1.
+!NADC  if ( compda(kvert,JDP2) > DEPMIN ) then
+!NADC     vert(kvert)%active = .true.
+!NADC     nwetp = nwetp +1.
+!ADC   if ( NINT(SwanLocalControl(kvert, 1)) ==1 ) then
+!ADC      if ( compda(kvert,JDP2) > DEPMIN ) then
+!ADC         vert(kvert)%active = .true.
+!ADC         nwetp = nwetp +1.
+!ADC      else
+!ADC         vert(kvert)%active = .false.
+!ADC      endif
        else
           vert(kvert)%active = .false.
        endif
@@ -846,8 +855,9 @@ subroutine SwanCompUnstruc ( ac2, ac1, compda, spcsig, spcdir, xytst, cross, it 
 !ADC                IREFR = nint(SwanWaveRefrac(ivert))
 !ADC             endif
              !
-             if ( vert(ivert)%active ) then   ! this active vertex needs to be updated
-                !
+!NADC        if ( vert(ivert)%active ) then   ! this active vertex needs to be updated
+!250316 Nicole: fix to not update internal sources              
+!ADC         if ( vert(ivert)%active .and. NINT(SwanLocalControl(ivert, 2))==0 ) then   ! this active vertex needs to be updated
                 ! determine whether the present vertex is a test point
                 !
                 IPTST  = 0

--- a/thirdparty/swan/SwanGriddata.ftn90
+++ b/thirdparty/swan/SwanGriddata.ftn90
@@ -69,6 +69,9 @@ module SwanGriddata
     integer, dimension(:,:), save, allocatable :: kvertf         !
     !
     integer, dimension(:), save, allocatable   :: ivertg         ! vertex index in global grid
+! Nicole 250327: Variables for Swan Local Control 
+    integer, dimension(:), save, allocatable   :: int_src_nd     ! internal source node
+    integer                                    :: num_int_src    ! number of internal sources 
     integer, dimension(:), save, allocatable   :: vmark          ! boundary marker for vertices
     !
     integer                                    :: nsweep         ! fixed number of sweeps through grid

--- a/thirdparty/swan/SwanReadADCGrid.ftn90
+++ b/thirdparty/swan/SwanReadADCGrid.ftn90
@@ -56,6 +56,8 @@ subroutine SwanReadADCGrid
     use ocpcomm4
     use m_genarr
     use SwanGriddata
+!Nicole 250517: Allow for use of SwanLocalControl
+!ADC    use NodalAttributes, ONLY: SwanLocalControl 
 !PUN    use SIZES
 !PUN    use MESSENGER
 !Casey 231217: Carrying forward changes from earlier version.
@@ -78,6 +80,9 @@ subroutine SwanReadADCGrid
     integer                 :: k        ! loop counter
     integer                 :: n1       ! auxiliary integer
     integer                 :: n2       ! another auxiliary integer
+! Nicole 250318: Adding variable counters 
+    integer                 :: kk, vn
+    integer                 :: kvert    ! vert
 !Casey 231217: Carrying forward changes from earlier version.
 !ADC    integer                 :: n3       ! yet another auxiliary integer
     integer                 :: ndsd     ! unit reference number of file
@@ -181,6 +186,32 @@ subroutine SwanReadADCGrid
        enddo
     enddo
     !
+! Nicole 250314: Count internal sources  
+!ADC num_int_src = 0
+! Nicole 250410 initial counting of internal sources 
+!ADC do kvert = 1, nverts
+!ADC     if ( NINT(SwanLocalControl(kvert, 2)) > 0) then
+!ADC         num_int_src = num_int_src + 1
+!ADC     endif
+!ADC end do    
+! Nicole 250410: allocate the array for internal source nodes based on the number of internal sources 
+!ADC if (allocated(int_src_nd)) then
+!ADC     deallocate(int_src_nd)
+!ADC endif
+!ADC allocate(int_src_nd(num_int_src))
+! Nicole 250410: Store the node indices for internal source nodes
+!ADC kk = 0
+!ADC do kvert = 1, nverts
+!ADC     if ( NINT(SwanLocalControl(kvert, 2)) > 0) then
+!ADC         kk = kk + 1
+!ADC         int_src_nd(kk) = kvert
+!ADC     endif
+!ADC enddo
+! Nicole 250410: Setting internal sources as unique sides based on SLC value 
+!ADC do kk = 1, num_int_src 
+!ADC    vn = int_src_nd(kk)
+!ADC    vmark(vn) = NINT(SwanLocalControl(vn, 2))
+!ADC enddo
     read(ndsd, *, end=950, err=910) n1
     read(ndsd, *, end=950, err=910) idum
     do j = 1, n1

--- a/thirdparty/swan/SwanVTKPDataSets.ftn90
+++ b/thirdparty/swan/SwanVTKPDataSets.ftn90
@@ -66,7 +66,7 @@ subroutine SwanVTKPDataSets ( upvt, pstype, nvar, ivtyp, mxk, myk, vtkfile, upvd
     integer, dimension(4,0:NPROC-1), intent(in) :: iarr    ! array with collecting grid indices
     integer, dimension(nvar), intent(in)        :: ivtyp   ! types of output variable
     !
-    character(len=8), intent(in)                :: psname  ! name of output frame
+    character(len=16), intent(in)               :: psname  ! name of output frame
     character(len=1), intent(in)                :: pstype  ! type of output point set
     character(len=lenfnm), intent(in)           :: vtkfile ! a VTK file
 !

--- a/thirdparty/swan/swanout2.ftn
+++ b/thirdparty/swan/swanout2.ftn
@@ -97,7 +97,7 @@
 !       RTYPE   ch*4   input    type of output request:
 !                               'BLKP' for output on paper,
 !                               'BLKD' and 'BLKV' for output to datafile
-!       PSNAME  ch*8   input    name of output frame
+!       PSNAME  ch*16  input    name of output frame
 !       MXK     int    input    number of grid points in x-direction
 !       MYK     int    input    number of grid points in y-direction
 !       VOQR
@@ -483,7 +483,7 @@
       CHARACTER (LEN=21) :: WFORM2 = '(1X,I4,1X, 151(F6.0))'              41.41 40.13
       CHARACTER (LEN=20) :: WFORM3 = '(5X, 151(F6.0))'                    40.13
 
-      CHARACTER PSNAME*8, STRING*(*), QUNIT*(*)                           40.00
+      CHARACTER PSNAME*16, STRING*(*), QUNIT*(*)                          40.00
       REAL      DFAC, OQVALS(*)
       INTEGER   NREF, MXK, MYK, IPD
       LOGICAL   BPRN
@@ -798,7 +798,7 @@
                                               ! time step)
       REAL   , DIMENSION(MXK*MYK,*) :: VOQ    ! output variables
 
-      CHARACTER (LEN=8)             :: PSNAME ! name of output frame
+      CHARACTER (LEN=16)            :: PSNAME ! name of output frame
       CHARACTER (LEN=1)             :: PSTYPE ! type of output point set
 !
 !  6. Local variables
@@ -1292,7 +1292,7 @@
 !             ='TABT';
 !NCF!             ='TABC'; NETCDF output
 !
-      CHARACTER RTYPE*4, PSNAME*8
+      CHARACTER RTYPE*4, PSNAME*16
 !
 !     MIP
 !     VOQR

--- a/thirdparty/swan/swanparll.ftn
+++ b/thirdparty/swan/swanparll.ftn
@@ -5129,7 +5129,7 @@
       REAL      BLKND(MXCGL,MYCGL), XC(MXK*MYK), YC(MXK*MYK)              40.51
       REAL*8    OQR(2)                                                    41.40
       REAL      FAC(OQI(3))                                               41.40
-      CHARACTER RTYPE*4, PSNAME*8
+      CHARACTER RTYPE*4, PSNAME*16
 !
 !  6. Local variables
 !

--- a/thirdparty/swan/swanpre1.ftn
+++ b/thirdparty/swan/swanpre1.ftn
@@ -445,7 +445,7 @@
 !
       LOGICAL, SAVE :: LOGCOM(1:6) = .FALSE.                              40.03
       INTEGER   TIMARR(6)                                                 40.31 30.00
-      CHARACTER PSNAME *8, PNAME *8, COMPUT *(*), PTYPE *1, DTTIWR *18    40.00
+      CHARACTER PSNAME *16, PNAME *16, COMPUT *(*), PTYPE *1, DTTIWR *18  40.00
       INTEGER, SAVE :: IENT = 0       ! number of entries to this subr
       INTEGER, SAVE :: LWINDR = 0     ! if non-zero, there is wind
       INTEGER, SAVE :: LWINDM = 5     ! type of wind growth formulation   42.00

--- a/thirdparty/swan/swanpre2.ftn
+++ b/thirdparty/swan/swanpre2.ftn
@@ -330,7 +330,7 @@
 !         ver 30.20: names of input variables changed, order of data changed
           ALLOCATE(OPSTMP)                                                40.31
           CALL INCSTR ('SNAME',PSNAME,'REQ',' ')
-          IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+          IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
           OPSTMP%PSNAME = PSNAME                                          40.31
           CALL READXY ('XPFR', 'YPFR', XPFR, YPFR, 'REQ', 0., 0.)         40.31 30.20
           OPSTMP%OPR(1) = XPFR                                            40.31
@@ -384,7 +384,7 @@
 !         an option SUBG within the Frame command
           ALLOCATE(OPSTMP)                                                40.31
           CALL INCSTR ('SNAME',PSNAME,'REQ',' ')
-          IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+          IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
           OPSTMP%PSNAME = PSNAME                                          40.31
           CALL INKEYW ('STA', ' ')
           CALL IGNORE ('SUBG')                                            970221
@@ -462,7 +462,7 @@
       IF (KEYWIS ('CURV')) THEN
         ALLOCATE(OPSTMP)                                                  40.31
         CALL INCSTR('SNAME',PSNAME,'REQ',' ')
-        IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+        IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
         OPSTMP%PSNAME = PSNAME                                            40.31
         OPSTMP%PSTYPE = 'C'                                               40.31
         MIP  = 0
@@ -536,7 +536,7 @@
       IF (KEYWIS ('POIN')) THEN
         ALLOCATE(OPSTMP)                                                  40.31
         CALL INCSTR('SNAME',PSNAME,'REQ',' ')
-        IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+        IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
         OPSTMP%PSNAME = PSNAME                                            40.31
         OPSTMP%PSTYPE = 'P'                                               40.31
         MIP  = 0
@@ -700,7 +700,7 @@
         ELSE                                                              32.02
           ALLOCATE(OPSTMP)                                                40.31
           CALL INCSTR ('SNAME',PSNAME,'REQ',' ')
-          IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+          IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
           OPSTMP%PSNAME = PSNAME                                          40.31
           CALL INCSTR ('RNAME', PRNAME, 'REQ', ' ')
           IF (LENCST.GT.8) CALL MSGERR (2, 'RNAME is too long')
@@ -801,7 +801,7 @@
 !         ver 30.20: names changed, order changed
           ALLOCATE(OPSTMP)                                                40.31
           CALL INCSTR('SNAME',PSNAME,'REQ',' ')
-          IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+          IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
           OPSTMP%PSNAME = PSNAME                                          40.31
           OPSTMP%PSTYPE = 'N'                                             40.31
           CALL INKEYW ('STA', ' ')
@@ -2323,7 +2323,7 @@
 !
       IERR = 0
       CALL INCSTR ('SNAME', PSNAME, 'STA', 'BOTTGRID')
-      IF (LENCST.GT.8) CALL MSGERR (2, 'SNAME is too long')
+      IF (LENCST.GT.16) CALL MSGERR (2, 'SNAME is too long')
       CUOPS => FOPS                                                       40.31
       DO                                                                  40.31
         IF (CUOPS%PSNAME.EQ.PSNAME) EXIT                                  40.31

--- a/thirdparty/swan/swmod1.ftn
+++ b/thirdparty/swan/swmod1.ftn
@@ -948,7 +948,7 @@
       CHARACTER*40 OVLNAM(NMOVAR)
       CHARACTER*6  OVSNAM(NMOVAR)
       CHARACTER*16 OVUNIT(NMOVAR)
-      CHARACTER*8  SNAME
+      CHARACTER*16 SNAME
       CHARACTER*6  UAP,           UD,          UDI,         UDL
       CHARACTER*6  UET,           UF,          UH,          UL
       CHARACTER*6  UP,            UST,         UT,          UV

--- a/thirdparty/swan/swmod2.ftn
+++ b/thirdparty/swan/swmod2.ftn
@@ -202,7 +202,7 @@
 !
 !  7. Local variables
 
-      INTEGER, PARAMETER :: MAX_OUTP_REQ = 250 ! max. number of output requests
+      INTEGER, PARAMETER :: MAX_OUTP_REQ = 5000 ! max. number of output requests
 
       CHARACTER (LEN=1)  :: OUT_COMMENT = '%' ! comment sign for heading lines
 
@@ -254,7 +254,7 @@
 
       TYPE OPSDAT
          CHARACTER (LEN=1)     :: PSTYPE                     ! type (F, C, P, ...)
-         CHARACTER (LEN=8)     :: PSNAME                     ! name of point set
+         CHARACTER (LEN=16)    :: PSNAME                     ! name of point set
          INTEGER               :: OPI(2)                     ! integer coefficients
          REAL                  :: OPR(5)                     ! real coefficients
          INTEGER               :: MIP                        ! number of points
@@ -268,7 +268,7 @@
 
       TYPE ORQDAT
          CHARACTER (LEN=4)      :: RQTYPE   ! type (BLK, TAB, SPC ...)
-         CHARACTER (LEN=8)      :: PSNAME   ! name of point set
+         CHARACTER (LEN=16)     :: PSNAME   ! name of point set
          INTEGER                :: OQI(4)   ! integer coefficients
          REAL*8                 :: OQR(2)   ! real coefficients
          INTEGER, POINTER       :: IVTYP(:) ! type of output variable


### PR DESCRIPTION
# Description

This set of changes includes the source code changes for the SWAN temporal controls (the spatial control changes will follow shortly in a second phase of changes). With these controls, the user can specify exactly when and where SWAN will perform its computations during a coupled ADCIRC+SWAN simulation. Instead of having to run SWAN on the full mesh and for the entire timeframe, the user can limit SWAN to a spatial region near landfall and a temporal duration at the height of the storm. These controls have the potential to speed-up the overall simulation, without much sacrifice in accuracy.

For the temporal controls, a new name list is used to control the timing. From a user standpoint, two changes need to be made to utilize these controls: 

On the ADCIRC input side - the namelist SWANTimeControl must be used and the RunStartDateTime must be set with the start of the current ADCIRC simulation at the end of the fort.15:
&SWANTimeControl RunStartDateTime='YYYYMMDD.HHMMSS' /

On the SWAN input side - the COMPUTE' time in the SWAN input file (fort.26) can be altered to the desired time range.
COMPUTE YYYYMMDD.HHMMSS 1200 SEC YYYYMMDD.HHMMSS

These changes should not impact ADCIRC+SWAN simulations run with the previous default settings and should only apply when using the name list. 

Documentation for the spatial and temporal controls (along with supplementary scripts and examples) can be found on the CCHT-NCSU Organization GitHub (https://github.com/ccht-ncsu/Spatial-Temporal-Controls). 
 

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

These changes have been tested by comparing simulations using executables compiled from the latest ADCIRC source code to ensure that for simulations using the default identical time frame for SWAN and ADCIRC, no differences occurred due to the code changes. The changes have been tested with varying SWAN time frames (with the name list identified in the fort.15 and the SWAN time defined in fort.26) to examine the impacts of simulating SWAN when a storm is making landfall and these tests have yielded faster run times and similar accuracies. 


# Relevant Publications (if applicable)

N/A

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments


