### PR TITLE
Print timestep info to stdout instead of stderr

### DIFF
--- a/src/read_input.F
+++ b/src/read_input.F
@@ -1023,6 +1023,7 @@ C
       READ(15,*) NSCREEN
       ScreenUnit=0
       IF(NSCREEN.GT.0.AND.MYPROC.EQ.0) THEN
+        ScreenUnit=6
          WRITE(16,3561) NSCREEN
  3561    FORMAT(5X,'NSCREEN = ',I6,
      &        /,9X,'SCREEN OUTPUT WILL BE PROVIDED TO UNIT 6',

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -1023,10 +1023,10 @@ C
       READ(15,*) NSCREEN
       ScreenUnit=0
       IF(NSCREEN.GT.0.AND.MYPROC.EQ.0) THEN
-        ScreenUnit=6
+        ScreenUnit=output_unit
          WRITE(16,3561) NSCREEN
  3561    FORMAT(5X,'NSCREEN = ',I6,
-     &        /,9X,'SCREEN OUTPUT WILL BE PROVIDED TO UNIT 6',
+     &        /,9X,'SCREEN OUTPUT WILL BE PROVIDED TO STDOUT',
      &        /,9X,'EVERY NSCREEN TIME STEPS.',/)
       ELSEIF((NSCREEN.LT.0).AND.(MYPROC.EQ.0)) THEN
          ScreenUnit=999


### PR DESCRIPTION
# Description

Previously timestep information is printed to stdout (unit 6) but was changed to stderr (unit 0) in commit 33e290b41c3be14711ab9691555280288e603af0 . Was there a particular reason for this? This commit sets `screenunit` back to 6.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

<!--- Please link to the issue this PR addresses -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Relevant Publications (if applicable)

<!--- Please list any relevant publications that should be cited when using this feature -->

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
