### PR TITLE
Fix 3D baroclinic hotstart, I/O, and scalar diffusivity handling

### DIFF
--- a/src/cstart.F
+++ b/src/cstart.F
@@ -957,8 +957,13 @@ C...  and baroclinic.
       END IF
 
 C kmd - River information for boundary conditions in baroclinic simulation
-      IF (BndBCRiver) THEN
-        OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
+!Seun 251227: Read fort.39 only for IDEN=2/3/4 (prognostic river T/S BCs)
+C     IF (BndBCRiver) THEN
+C       OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
+      IF (BndBCRiver .AND. (IDEN.EQ.2 .OR. IDEN.EQ.3 .OR.
+     &    IDEN.EQ.4)) THEN
+        OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39',
+     &       STATUS='OLD',ACTION='READ')
         READ(39,*) RIVBCTIMINC, RIVBCSTATIM
         RIVBCTIME1=RIVBCSTATIM*86400.d0
         RIVBCTIME2=RIVBCTIME1+RIVBCTIMINC

--- a/src/cstart.F
+++ b/src/cstart.F
@@ -958,8 +958,6 @@ C...  and baroclinic.
 
 C kmd - River information for boundary conditions in baroclinic simulation
 !Seun 251227: Read fort.39 only for IDEN=2/3/4 (prognostic river T/S BCs)
-C     IF (BndBCRiver) THEN
-C       OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
       IF (BndBCRiver .AND. (IDEN.EQ.2 .OR. IDEN.EQ.3 .OR.
      &    IDEN.EQ.4)) THEN
         OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39',

--- a/src/hstart.F
+++ b/src/hstart.F
@@ -716,7 +716,12 @@ C     ---------------------------------------------
       ! run (i.e, in the fort.15 file) ... if so, this affects any 
       ! calculation of time in seconds since cold start, and any 
       ! feature that counts time steps since cold start
-      DTDPHS=TimeLoc/ITHS  ! Set up time step information for hotstart file.
+Casey 140701: Protect for case when ITHS=0
+      IF(ITHS.NE.0)THEN
+         DTDPHS=TimeLoc/ITHS  ! Set up time step information for hotstart file.
+      ELSE
+         DTDPHS=DTDP
+      ENDIF
       dtChange = DTDPHS - DTDP
       ! we don't use .ne. for dtChange b/c of the limitations in machine precision
       IF ( (abs(dtChange).gt.1.0e-10).OR.
@@ -2060,6 +2065,8 @@ c******************************************************************************
 
       SUBROUTINE HOTSTART_3D(TimeLoc,ITHS)
       USE GLOBAL_3DVS
+Casey 140701: Added the following line.
+      USE SIZES, ONLY : WRITE_LOCAL_FILES, MNPROC, GLOBALDIR
       USE MESH, ONLY : NP, AGRID
       USE WRITE_OUTPUT, ONLY : initOutput3D
       USE BOUNDARIES, ONLY : NOPE, NETA, NBD, totalbcrivernodes, 
@@ -2255,7 +2262,8 @@ C  kmd48.33bc - restart boundary condtions for baroclinic simulations
                   IF(TIMEIT.GT.TTBCTIME2) THEN
                      TTBCTIME1=TTBCTIME2
                      TTBCTIME2=TTBCTIME1+TTBCTIMEINC
-                     DO NumofNodes=1,NH
+               !170109 Rosemary Changed NH to NP
+                     DO NumofNodes=1,NP
                        q_heat1(NumofNodes)=q_heat2(NumofNodes)
                        READ(38,*) NOD, q_heat2(NumofNodes)
                      END DO
@@ -2373,8 +2381,13 @@ C  kmd48.33bc - restart boundary condtions for baroclinic simulations
       END IF
 
 C kmd - River information for boundary conditions
-      IF (BndBCRiver) THEN
-        OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
+!Seun 251227: Read fort.39 only for IDEN=2/3/4 (prognostic river T/S BCs)
+C     IF (BndBCRiver) THEN
+C       OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
+      IF (BndBCRiver .AND. (IDEN.EQ.2 .OR. IDEN.EQ.3 .OR.
+     &    IDEN.EQ.4)) THEN
+        OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39',
+     &       STATUS='OLD',ACTION='READ')
         READ(39,*) RIVBCTIMINC, RIVBCSTATIM
         RIVBCTIME1=RIVBCSTATIM*86400.d0
         RIVBCTIME2=RIVBCTIME1+RIVBCTIMINC
@@ -2512,17 +2525,46 @@ C     jgf46.27 Replaced IRType with IDen
 !kmd48.33bc - added in the information to make a file with all the
 !             top temperature boundary condition information in
 
-      CALL initOutput3D(44, I3DGD, NDSET3DGD, NP, NP_g,
-     &                        NSPO3DGD, IRType, I3DGDRec)
-      IF(I3DGD.EQ.-1) THEN         !start a new ASCII file
-        IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
-          IF (BCFLAG_TEMP.NE.0) THEN
-            OPEN(47,FILE=TRIM(LOCALDIR)//'/'//'fort.47')
-            WRITE(47,499) RUNDES,RUNID,AGRID
-            WRITE(47,498) NDSet3DGD,NP,DTDP*NSpo3DGD,NSpo3DGD,1
-            CLOSE(47)
-          END IF
-        END IF
+!      CALL initOutput3D(44, I3DGD, NDSET3DGD, NP, NP_g,
+!     &                        NSPO3DGD, IRType, I3DGDRec)
+
+! arash June 23 2016
+      CALL initOutput3D(44, I3DGD, NDSET3DGD, NP, NP_G,
+     &                        NSPO3DGD, IDen, I3DGDRec)
+
+Casey 140701: Replaced the following section with the lines below.
+C     IF(I3DGD.EQ.-1) THEN         !start a new ASCII file
+C       IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
+C         IF (BCFLAG_TEMP.NE.0) THEN
+C           OPEN(47,FILE=TRIM(LOCALDIR)//'/'//'fort.47')
+C           WRITE(47,499) RUNDES,RUNID,AGRID
+C           WRITE(47,498) NDSet3DGD,NP,DTDP*NSpo3DGD,NSpo3DGD,1
+C           CLOSE(47)
+C         END IF
+C       END IF
+C     ENDIF
+      IF (ABS(I3DGD).EQ.1) THEN
+         IF ((MNPROC.EQ.1.).OR.(WRITE_LOCAL_FILES.eqv..true.)) THEN
+            IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
+               IF (BCFLAG_TEMP.NE.0) THEN
+                  OPEN(47,FILE=TRIM(LOCALDIR)//'/'//'fort.47')
+                  WRITE(47,499) RUNDES,RUNID,AGRID
+                  WRITE(47,498) NDSet3DGD,NP,DTDP*NSpo3DGD,NSpo3DGD,1
+                  CLOSE(47)
+               END IF
+            END IF
+         ENDIF
+         IF ((MNPROC.GT.1.).AND.(WRITE_LOCAL_FILES.eqv..false.).and.
+     &       (myProc.eq.0)) THEN
+            IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
+               IF (BCFLAG_TEMP.NE.0) THEN
+                  OPEN(47,FILE=TRIM(GLOBALDIR)//'/'//'fort.47')
+                  WRITE(47,499) RUNDES,RUNID,AGRID
+                  WRITE(47,498) NDSet3DGD,NP,DTDP*NSpo3DGD,NSpo3DGD,1
+                  CLOSE(47)
+               END IF
+            END IF
+         ENDIF
       ENDIF
 
 c.... Initialize the global 3D velocity output file (Unit 45)

--- a/src/hstart.F
+++ b/src/hstart.F
@@ -2065,7 +2065,6 @@ c******************************************************************************
 
       SUBROUTINE HOTSTART_3D(TimeLoc,ITHS)
       USE GLOBAL_3DVS
-Casey 140701: Added the following line.
       USE SIZES, ONLY : WRITE_LOCAL_FILES, MNPROC, GLOBALDIR
       USE MESH, ONLY : NP, AGRID
       USE WRITE_OUTPUT, ONLY : initOutput3D
@@ -2382,8 +2381,6 @@ C  kmd48.33bc - restart boundary condtions for baroclinic simulations
 
 C kmd - River information for boundary conditions
 !Seun 251227: Read fort.39 only for IDEN=2/3/4 (prognostic river T/S BCs)
-C     IF (BndBCRiver) THEN
-C       OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39')
       IF (BndBCRiver .AND. (IDEN.EQ.2 .OR. IDEN.EQ.3 .OR.
      &    IDEN.EQ.4)) THEN
         OPEN(39,FILE=TRIM(INPUTDIR)//'/'//'fort.39',
@@ -2532,17 +2529,6 @@ C     jgf46.27 Replaced IRType with IDen
       CALL initOutput3D(44, I3DGD, NDSET3DGD, NP, NP_G,
      &                        NSPO3DGD, IDen, I3DGDRec)
 
-Casey 140701: Replaced the following section with the lines below.
-C     IF(I3DGD.EQ.-1) THEN         !start a new ASCII file
-C       IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
-C         IF (BCFLAG_TEMP.NE.0) THEN
-C           OPEN(47,FILE=TRIM(LOCALDIR)//'/'//'fort.47')
-C           WRITE(47,499) RUNDES,RUNID,AGRID
-C           WRITE(47,498) NDSet3DGD,NP,DTDP*NSpo3DGD,NSpo3DGD,1
-C           CLOSE(47)
-C         END IF
-C       END IF
-C     ENDIF
       IF (ABS(I3DGD).EQ.1) THEN
          IF ((MNPROC.EQ.1.).OR.(WRITE_LOCAL_FILES.eqv..true.)) THEN
             IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN

--- a/src/netcdfio.F90
+++ b/src/netcdfio.F90
@@ -675,12 +675,16 @@ contains
          iret = nf90_def_var(sta%ncid, 'sigmat', NF90_DOUBLE, &
                              sta%station_data_dims_3D, sta%u_station_data_id)
          call check_err(iret)
-         if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 2) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(sta%ncid, 'salinity', NF90_DOUBLE, &
                                 sta%station_data_dims_3D, sta%v_station_data_id)
             call check_err(iret)
          end if
-         if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 3) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(sta%ncid, 'temperature', NF90_DOUBLE, &
                                 sta%station_data_dims_3D, sta%w_station_data_id)
             call check_err(iret)
@@ -699,7 +703,9 @@ contains
          call putUnitsAttribute(sta%ncid, sta%u_station_data_id, &
                                 "kg/m^3", "n/a")
          ! salinity
-         if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 2) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             att_text = &
                'station water column vertically varying salinity'
             iret = nf90_put_att(sta%ncid, &
@@ -715,7 +721,9 @@ contains
                                    "PSU", "n/a")
          end if
          ! temperature
-         if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 3) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             att_text = &
                'station water column vertically varying temperature'
             iret = nf90_put_att(sta%ncid, &
@@ -1365,12 +1373,16 @@ contains
             iret = nf90_def_var_deflate(sta%ncid, sta%u_station_data_id, &
                                         1, 1, 2)
             call check_err(iret)
-            if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!           if ((IDEN == 2) .or. (IDEN == 4)) then
+            if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(sta%ncid, &
                                            sta%v_station_data_id, 1, 1, 2)
                call check_err(iret)
             end if
-            if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!           if ((IDEN == 3) .or. (IDEN == 4)) then
+            if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(sta%ncid, &
                                            sta%w_station_data_id, 1, 1, 2)
                call check_err(iret)
@@ -1547,12 +1559,16 @@ contains
          iret = nf90_def_var(dat%ncid, 'sigmat', NF90_DOUBLE, &
                              dat%nodal_data_dims_3D, dat%u_nodal_data_id)
          call check_err(iret)
-         if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 2) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(dat%ncid, 'salinity', NF90_DOUBLE, &
                                 dat%nodal_data_dims_3D, dat%v_nodal_data_id)
             call check_err(iret)
          end if
-         if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 3) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(dat%ncid, 'temperature', NF90_DOUBLE, &
                                 dat%nodal_data_dims_3D, dat%w_nodal_data_id)
             call check_err(iret)
@@ -1569,7 +1585,9 @@ contains
          call putUnitsAttribute(dat%ncid, dat%u_nodal_data_id, &
                                 "kg/m^3", "n/a")
          ! salinity
-         if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 2) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             att_text = "water column vertically varying salinity"
             iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id, &
                                 'long_name', trim(att_text))
@@ -1582,7 +1600,9 @@ contains
                                    "PSU", "PSU")
          end if
          ! temperature
-         if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 3) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             att_text = "water column vertically varying temperature"
             iret = nf90_put_att(dat%ncid, dat%w_nodal_data_id, &
                                 'long_name', trim(att_text))
@@ -3610,12 +3630,16 @@ contains
             iret = nf90_def_var_deflate(dat%ncid, dat%u_nodal_data_id, &
                                         1, 1, 2)
             call check_err(iret)
-            if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!           if ((IDEN == 2) .or. (IDEN == 4)) then
+            if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(dat%ncid, dat%v_nodal_data_id, &
                                            1, 1, 2)
                call check_err(iret)
             end if
-            if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!           if ((IDEN == 3) .or. (IDEN == 4)) then
+            if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(dat%ncid, dat%w_nodal_data_id, &
                                            1, 1, 2)
                call check_err(iret)
@@ -4353,7 +4377,9 @@ contains
          end if
          call check_err(iret)
 
-         if ((iden == 2) .or. (iden == 4)) then
+!Casey 140701
+!        if ((iden == 2) .or. (iden == 4)) then
+         if ((abs(iden) == 2) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(sta%ncid, "salinity", &
                                   sta%v_station_data_id)
             call check_err(iret)
@@ -4367,7 +4393,9 @@ contains
 
             call check_err(iret)
          end if
-         if ((iden == 3) .or. (iden == 4)) then
+!Casey 140701
+!        if ((iden == 3) .or. (iden == 4)) then
+         if ((abs(iden) == 3) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(sta%ncid, "temperature", &
                                   sta%w_station_data_id)
             call check_err(iret)
@@ -4656,12 +4684,16 @@ contains
       case (44)
          iret = nf90_inq_varid(dat%ncid, "sigmat", dat%u_nodal_data_id)
          call check_err(iret)
-         if ((iden == 2) .or. (iden == 4)) then
+!Casey 140701
+!        if ((iden == 2) .or. (iden == 4)) then
+         if ((abs(iden) == 2) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(dat%ncid, "salinity", &
                                   dat%v_nodal_data_id)
             call check_err(iret)
          end if
-         if ((iden == 3) .or. (iden == 4)) then
+!Casey 140701
+!        if ((iden == 3) .or. (iden == 4)) then
+         if ((abs(iden) == 3) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(dat%ncid, "temperature", &
                                   dat%w_nodal_data_id)
             call check_err(iret)
@@ -4870,6 +4902,7 @@ contains
 
 !     Write the array values
       select case (lun)
+!Casey 140701: Added this section for lun=44.
       case (44)
          if (MNPROC == 1) then
             iret = nf90_put_var(dat%ncid, dat%u_nodal_data_id, &
@@ -4880,7 +4913,7 @@ contains
          end if
          call check_err(iret)
 
-         if ((iden == 2) .or. (iden == 4)) then
+         if ((abs(iden) == 2) .or. (abs(iden) == 4)) then
             if (MNPROC == 1) then
                iret = nf90_put_var(dat%ncid, dat%v_nodal_data_id, &
                                    descript2%array2D, start3D, kount3D)
@@ -4890,7 +4923,7 @@ contains
             end if
             call check_err(iret)
          end if
-         if ((iden == 3) .or. (iden == 4)) then
+         if ((abs(iden) == 3) .or. (abs(iden) == 4)) then
             if (MNPROC == 1) then
                iret = nf90_put_var(dat%ncid, dat%w_nodal_data_id, &
                                    descript3%array2D, start3D, kount3D)
@@ -6559,7 +6592,9 @@ contains
          hs%density3D%nodal_data_dims_3D(2) = hs%myMesh%num_v_nodes_dim_id
          hs%density3D%nodal_data_dims_3D(3) = hs%myTime%timenc_dim_id
       end if
-      if (IDEN == 1) then
+!Casey 140701
+!     if (IDEN == 1) then
+      if (abs(IDEN) == 1) then
          iret = nf90_def_var(hs%ncid, 'sigt', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, hs%density3D%u_nodal_data_id)
          call check_err(iret)
@@ -6571,7 +6606,9 @@ contains
                              '_FillValue', doubleval)
          call check_err(iret)
       end if
-      if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!     if ((IDEN == 2) .or. (IDEN == 4)) then
+      if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
          iret = nf90_def_var(hs%ncid, 'salinity', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, &
                              hs%density3D%v_nodal_data_id)
@@ -6584,12 +6621,16 @@ contains
                              '_FillValue', doubleval)
          call check_err(iret)
       end if
-      if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!     if ((IDEN == 3) .or. (IDEN == 4)) then
+      if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
          iret = nf90_def_var(hs%ncid, 'temperature', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, &
                              hs%density3D%w_nodal_data_id)
          call check_err(iret)
-         att_text = "salinity"
+!Casey 140701
+!        att_text = "salinity"
+         att_text = "temperature"
          iret = nf90_put_att(hs%ncid, hs%density3D%w_nodal_data_id, &
                              'long_name', trim(att_text))
          call check_err(iret)
@@ -6692,17 +6733,23 @@ contains
          iret = nf90_def_var_deflate(hs%ncid, hs%bsy%nodal_data_id, &
                                      1, 1, 2)
          call check_err(iret)
-         if (IDEN == 1) then
+!Casey 140701
+!        if (IDEN == 1) then
+         if (abs(IDEN) == 1) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%u_nodal_data_id, 1, 1, 2)
             call check_err(iret)
          end if
-         if ((IDEN == 2) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 2) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%v_nodal_data_id, 1, 1, 2)
             call check_err(iret)
          end if
-         if ((IDEN == 3) .or. (IDEN == 4)) then
+!Casey 140701
+!        if ((IDEN == 3) .or. (IDEN == 4)) then
+         if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%w_nodal_data_id, 1, 1, 2)
             call check_err(iret)
@@ -7806,7 +7853,9 @@ contains
          call check_err(iret)
       case ("Temperature")
          iret = nf90_inq_varid(hs%ncid, "temperature", &
-                               hs%density3D%nodal_data_id)
+!Casey 140702
+!                              hs%density3D%nodal_data_id)
+                               hs%density3D%w_nodal_data_id)
          call check_err(iret)
          if (MNPROC == 1) then
             iret = nf90_put_var(hs%ncid, &
@@ -9407,7 +9456,9 @@ contains
                                             nfen, hs%myMesh%num_nodes, hs%turbulence3D%u_nodal_data_id, &
                                             subdomain_reals=q20)
          call mapFullDomainToSubdomainNPByM(hs%ncid, &
-                                            nfen, hs%myMesh%num_nodes, hs%velocity3D%v_nodal_data_id, &
+!Casey 140704
+!                                           nfen, hs%myMesh%num_nodes, hs%velocity3D%v_nodal_data_id, &
+                                            nfen, hs%myMesh%num_nodes, hs%turbulence3D%v_nodal_data_id, &
                                             subdomain_reals=l)
       end if
 

--- a/src/netcdfio.F90
+++ b/src/netcdfio.F90
@@ -675,15 +675,11 @@ contains
          iret = nf90_def_var(sta%ncid, 'sigmat', NF90_DOUBLE, &
                              sta%station_data_dims_3D, sta%u_station_data_id)
          call check_err(iret)
-!Casey 140701
-!        if ((IDEN == 2) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(sta%ncid, 'salinity', NF90_DOUBLE, &
                                 sta%station_data_dims_3D, sta%v_station_data_id)
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((IDEN == 3) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(sta%ncid, 'temperature', NF90_DOUBLE, &
                                 sta%station_data_dims_3D, sta%w_station_data_id)
@@ -703,8 +699,6 @@ contains
          call putUnitsAttribute(sta%ncid, sta%u_station_data_id, &
                                 "kg/m^3", "n/a")
          ! salinity
-!Casey 140701
-!        if ((IDEN == 2) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             att_text = &
                'station water column vertically varying salinity'
@@ -721,8 +715,6 @@ contains
                                    "PSU", "n/a")
          end if
          ! temperature
-!Casey 140701
-!        if ((IDEN == 3) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             att_text = &
                'station water column vertically varying temperature'
@@ -1373,15 +1365,11 @@ contains
             iret = nf90_def_var_deflate(sta%ncid, sta%u_station_data_id, &
                                         1, 1, 2)
             call check_err(iret)
-!Casey 140701
-!           if ((IDEN == 2) .or. (IDEN == 4)) then
             if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(sta%ncid, &
                                            sta%v_station_data_id, 1, 1, 2)
                call check_err(iret)
             end if
-!Casey 140701
-!           if ((IDEN == 3) .or. (IDEN == 4)) then
             if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(sta%ncid, &
                                            sta%w_station_data_id, 1, 1, 2)
@@ -1559,15 +1547,11 @@ contains
          iret = nf90_def_var(dat%ncid, 'sigmat', NF90_DOUBLE, &
                              dat%nodal_data_dims_3D, dat%u_nodal_data_id)
          call check_err(iret)
-!Casey 140701
-!        if ((IDEN == 2) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(dat%ncid, 'salinity', NF90_DOUBLE, &
                                 dat%nodal_data_dims_3D, dat%v_nodal_data_id)
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((IDEN == 3) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var(dat%ncid, 'temperature', NF90_DOUBLE, &
                                 dat%nodal_data_dims_3D, dat%w_nodal_data_id)
@@ -1585,8 +1569,6 @@ contains
          call putUnitsAttribute(dat%ncid, dat%u_nodal_data_id, &
                                 "kg/m^3", "n/a")
          ! salinity
-!Casey 140701
-!        if ((IDEN == 2) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             att_text = "water column vertically varying salinity"
             iret = nf90_put_att(dat%ncid, dat%v_nodal_data_id, &
@@ -1600,8 +1582,6 @@ contains
                                    "PSU", "PSU")
          end if
          ! temperature
-!Casey 140701
-!        if ((IDEN == 3) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             att_text = "water column vertically varying temperature"
             iret = nf90_put_att(dat%ncid, dat%w_nodal_data_id, &
@@ -3630,15 +3610,11 @@ contains
             iret = nf90_def_var_deflate(dat%ncid, dat%u_nodal_data_id, &
                                         1, 1, 2)
             call check_err(iret)
-!Casey 140701
-!           if ((IDEN == 2) .or. (IDEN == 4)) then
             if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(dat%ncid, dat%v_nodal_data_id, &
                                            1, 1, 2)
                call check_err(iret)
             end if
-!Casey 140701
-!           if ((IDEN == 3) .or. (IDEN == 4)) then
             if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
                iret = nf90_def_var_deflate(dat%ncid, dat%w_nodal_data_id, &
                                            1, 1, 2)
@@ -4377,8 +4353,6 @@ contains
          end if
          call check_err(iret)
 
-!Casey 140701
-!        if ((iden == 2) .or. (iden == 4)) then
          if ((abs(iden) == 2) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(sta%ncid, "salinity", &
                                   sta%v_station_data_id)
@@ -4393,8 +4367,6 @@ contains
 
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((iden == 3) .or. (iden == 4)) then
          if ((abs(iden) == 3) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(sta%ncid, "temperature", &
                                   sta%w_station_data_id)
@@ -4684,15 +4656,11 @@ contains
       case (44)
          iret = nf90_inq_varid(dat%ncid, "sigmat", dat%u_nodal_data_id)
          call check_err(iret)
-!Casey 140701
-!        if ((iden == 2) .or. (iden == 4)) then
          if ((abs(iden) == 2) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(dat%ncid, "salinity", &
                                   dat%v_nodal_data_id)
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((iden == 3) .or. (iden == 4)) then
          if ((abs(iden) == 3) .or. (abs(iden) == 4)) then
             iret = nf90_inq_varid(dat%ncid, "temperature", &
                                   dat%w_nodal_data_id)
@@ -4902,7 +4870,6 @@ contains
 
 !     Write the array values
       select case (lun)
-!Casey 140701: Added this section for lun=44.
       case (44)
          if (MNPROC == 1) then
             iret = nf90_put_var(dat%ncid, dat%u_nodal_data_id, &
@@ -6592,8 +6559,6 @@ contains
          hs%density3D%nodal_data_dims_3D(2) = hs%myMesh%num_v_nodes_dim_id
          hs%density3D%nodal_data_dims_3D(3) = hs%myTime%timenc_dim_id
       end if
-!Casey 140701
-!     if (IDEN == 1) then
       if (abs(IDEN) == 1) then
          iret = nf90_def_var(hs%ncid, 'sigt', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, hs%density3D%u_nodal_data_id)
@@ -6606,8 +6571,6 @@ contains
                              '_FillValue', doubleval)
          call check_err(iret)
       end if
-!Casey 140701
-!     if ((IDEN == 2) .or. (IDEN == 4)) then
       if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
          iret = nf90_def_var(hs%ncid, 'salinity', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, &
@@ -6621,15 +6584,11 @@ contains
                              '_FillValue', doubleval)
          call check_err(iret)
       end if
-!Casey 140701
-!     if ((IDEN == 3) .or. (IDEN == 4)) then
       if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
          iret = nf90_def_var(hs%ncid, 'temperature', NF90_DOUBLE, &
                              hs%density3D%nodal_data_dims_3D, &
                              hs%density3D%w_nodal_data_id)
          call check_err(iret)
-!Casey 140701
-!        att_text = "salinity"
          att_text = "temperature"
          iret = nf90_put_att(hs%ncid, hs%density3D%w_nodal_data_id, &
                              'long_name', trim(att_text))
@@ -6733,22 +6692,16 @@ contains
          iret = nf90_def_var_deflate(hs%ncid, hs%bsy%nodal_data_id, &
                                      1, 1, 2)
          call check_err(iret)
-!Casey 140701
-!        if (IDEN == 1) then
          if (abs(IDEN) == 1) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%u_nodal_data_id, 1, 1, 2)
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((IDEN == 2) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 2) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%v_nodal_data_id, 1, 1, 2)
             call check_err(iret)
          end if
-!Casey 140701
-!        if ((IDEN == 3) .or. (IDEN == 4)) then
          if ((abs(IDEN) == 3) .or. (abs(IDEN) == 4)) then
             iret = nf90_def_var_deflate(hs%ncid, &
                                         hs%density3D%w_nodal_data_id, 1, 1, 2)
@@ -7853,8 +7806,6 @@ contains
          call check_err(iret)
       case ("Temperature")
          iret = nf90_inq_varid(hs%ncid, "temperature", &
-!Casey 140702
-!                              hs%density3D%nodal_data_id)
                                hs%density3D%w_nodal_data_id)
          call check_err(iret)
          if (MNPROC == 1) then
@@ -9456,8 +9407,6 @@ contains
                                             nfen, hs%myMesh%num_nodes, hs%turbulence3D%u_nodal_data_id, &
                                             subdomain_reals=q20)
          call mapFullDomainToSubdomainNPByM(hs%ncid, &
-!Casey 140704
-!                                           nfen, hs%myMesh%num_nodes, hs%velocity3D%v_nodal_data_id, &
                                             nfen, hs%myMesh%num_nodes, hs%turbulence3D%v_nodal_data_id, &
                                             subdomain_reals=l)
       end if

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -2445,12 +2445,14 @@ C     time stepping loop.
 C     ----------------------------------------------------------------
 C     ----------------------------------------------------------------
       SUBROUTINE Apply3DBottomFriction(Q, SIGMA, DP, ETA2, G,
-     &     IFNLFA, NP, TK, NFEN, Z0B)
+     &     IFNLFA, NP, TK, NFEN, Z0B, KP)
 Casey 140701: Prevent the depths from becoming negative in the bottom roughness calculations.
       USE GLOBAL, ONLY: H0
       USE SIZES
 ! arash May 31 2016
-      USE GLOBAL_3DVS, ONLY : KP
+CSeun 260619: KP is passed from timestep.F to avoid requiring
+C             global_3dvs.mod when compiling nodalattr.F in legacy builds.
+C     USE GLOBAL_3DVS, ONLY : KP
       IMPLICIT NONE
       INTEGER, intent(in) :: NP, NFEN             ! number of nodes in grid Horizontal and Vertical
       COMPLEX(8), intent(in), dimension(NP,NFEN) :: Q  ! x-dir velocities
@@ -2461,6 +2463,7 @@ Casey 140701: Prevent the depths from becoming negative in the bottom roughness 
       INTEGER, intent(in) :: IFNLFA               ! nonlin. finite amp. flag
       REAL(8), intent(inout), dimension(NP) :: TK! depth avg. fric.
       REAL(8), intent(in) :: Z0B
+      REAL(8), intent(in) :: KP                  ! 3D bottom friction coefficient
 C
       INTEGER NH
       REAL(8) Z0B1  ! velocity magnitude (speed)

--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -2446,6 +2446,11 @@ C     ----------------------------------------------------------------
 C     ----------------------------------------------------------------
       SUBROUTINE Apply3DBottomFriction(Q, SIGMA, DP, ETA2, G,
      &     IFNLFA, NP, TK, NFEN, Z0B)
+Casey 140701: Prevent the depths from becoming negative in the bottom roughness calculations.
+      USE GLOBAL, ONLY: H0
+      USE SIZES
+! arash May 31 2016
+      USE GLOBAL_3DVS, ONLY : KP
       IMPLICIT NONE
       INTEGER, intent(in) :: NP, NFEN             ! number of nodes in grid Horizontal and Vertical
       COMPLEX(8), intent(in), dimension(NP,NFEN) :: Q  ! x-dir velocities
@@ -2474,6 +2479,9 @@ C or as read in from nodal attributes
          IF (LoadZ0B_var) THEN
             Z0B1 = Z0B_var(NH)
          ELSEIF (LoadManningsN) THEN
+Casey 140701: Prevent the depths from becoming negative.  Cannot raise
+C             a negative number to the 1/6 power.
+            IF(H1.LT.H0) H1=H0
             Z0B1 = ( H1 )* exp(-(1.0D0+
      &             ( (0.41D0*( H1 )**(1.0D0/6.0D0) )/
      &                            (ManningsN(NH)*sqrt(g)) ) ))
@@ -2496,6 +2504,9 @@ C or as read in from nodal attributes
      &           *(BALPHA+15.d0*BALPHA**4)
             TK(I)=TK(I)+FricBP*ABS(Q(NH,1))/H1
          ENDIF
+! arash May 31 2016 added this based on Rosemary's work
+         If ( TK(NH) > abs( Q(NH,1) ) ) TK(NH) = abs( Q(NH,1) )
+         If ( TK(NH) < KP * abs( Q(NH,1) ) ) TK(NH) = KP * abs( Q(NH,1) )
       ENDDO
 C
       RETURN

--- a/src/read_input.F
+++ b/src/read_input.F
@@ -5520,7 +5520,8 @@ C                 salinity and temperature forcings.
          !jgf51.52.35: Make sure the RES_BC_FLAG value matches the IDEN value.
          if (RES_BC_FLAG.ne.IDEN) then
             call terminate(exit_code=ADCIRC_EXIT_FAILURE,
-     &                     message="The value of RES_BC_FLAG must be the same as the value of IDEN.")
+     &                     message="The value of RES_BC_FLAG "//
+     &                     "must be the same as the value of IDEN.")
          endif
          !
          IF ((RES_BC_FLAG.LT.0)) THEN  ! Diagnostic
@@ -5550,47 +5551,70 @@ C                 salinity and temperature forcings.
      &                boundary conditions every', E9.2,
      &                'seconds')
                END IF
-            ELSE IF ((ABS(RES_BC_FLAG).EQ.3)) THEN
-               IF (NOPE.GT.0) THEN
-                  READ(15,*) RBCTIMEINC, TBCTIMEINC
-                  READ(15,*) BCSTATIM, TBCSTATIM
-                  WRITE(16,432) RBCTIMEINC, TBCTIMEINC
- 432              FORMAT(/,5X,'Read in elevation boundary conditions
+
+!Seun 260217: Rewrote RES_BC_FLAG=3/4 section to share parsing logic.
+            ELSE IF ((ABS(RES_BC_FLAG).EQ.3).OR.
+     &               (ABS(RES_BC_FLAG).EQ.4)) THEN
+
+               IF ((ABS(RES_BC_FLAG).EQ.3)) THEN
+                  IF (NOPE.GT.0) THEN
+                     READ(15,*) RBCTIMEINC, TBCTIMEINC
+                     READ(15,*) BCSTATIM, TBCSTATIM
+                     WRITE(16,432) RBCTIMEINC, TBCTIMEINC
+ 432                 FORMAT(/,5X,'Read in elevation boundary conditions
      &                every', E9.2 ,'seconds and temperature
      &                boundary conditions every', E9.2,
      &                'seconds')
-                  IF (BCFLAG_TEMP.NE.0) THEN
-                     READ(15,*) TTBCTIMEINC, TTBCSTATIM
-                     WRITE(16,434) TTBCTIMEINC
- 434                 FORMAT(/,5X,'Read in the top temperature
-     &                   boundary condition every', E9.2 ,'
-     &                   seconds.')
                   END IF
-               END IF
-            ELSE IF ((ABS(RES_BC_FLAG).EQ.4)) THEN
-               IF (NOPE.GT.0) THEN
-                  READ(15,*) RBCTIMEINC, SBCTIMEINC, TBCTIMEINC
-                  READ(15,*) BCSTATIM, SBCSTATIM, TBCSTATIM
-                  WRITE(16,433) RBCTIMEINC, SBCTIMEINC, TBCTIMEINC
- 433              FORMAT(/,5X,'Read in elevation boundary conditions
+               ELSE
+                  IF (NOPE.GT.0) THEN
+                     READ(15,*) RBCTIMEINC, SBCTIMEINC, TBCTIMEINC
+                     READ(15,*) BCSTATIM, SBCSTATIM, TBCSTATIM
+                     WRITE(16,433) RBCTIMEINC, SBCTIMEINC, TBCTIMEINC
+ 433                 FORMAT(/,5X,'Read in elevation boundary conditions
      &                every', E9.2 ,'seconds and salinity
      &                boundary conditions every', E9.2,
      &                'seconds and temperature boundary conditions
      &                every', E9.2, 'seconds')
-                  IF (BCFLAG_TEMP.NE.0) THEN
-                     READ(15,*) TTBCTIMEINC, TTBCSTATIM
-                     WRITE(16,434) TTBCTIMEINC
-                 END IF
+                  END IF
                END IF
+
+Casey 140701: Possible to use surface heat fluxes even without
+C             an open ocean boundary.
+!              IF (BCFLAG_TEMP.NE.0) THEN
+!                  READ(15,*) TTBCTIMEINC, TTBCSTATIM
+!                  WRITE(16,434) TTBCTIMEINC
+!434               FORMAT(/,5X,'Read in the top temperature
+!    &                    boundary condition every', E9.2 ,'
+!    &                    seconds.')
+!              END IF
+C              END IF
+
             ELSE
                WRITE(16,350)
                WRITE(16,*) 'RES_BC_FLAG = ',RES_BC_FLAG
                WRITE(16,9722)
- 9722         FORMAT(/,1X,'Your selection of RES_BC_FLAG (a UNIT 15 input ',
-     &        'parameter) is not an allowable value')
-               CALL terminate(exit_code=ADCIRC_EXIT_FAILURE, message="Invalid RES_BC_FLAG value read from fort.15 file.")
+ 9722         FORMAT(/,1X,'Your selection of RES_BC_FLAG (a UNIT 15 ',
+     &        'input parameter) is not an allowable value')
+               CALL terminate(exit_code=ADCIRC_EXIT_FAILURE,
+     &               message="Invalid RES_BC_FLAG value read from "//
+     &                       "fort.15 file.")
             END IF
          END IF
+
+Casey 140701: Possible to use surface heat fluxes even without
+C             an open ocean boundary.
+         IF ((ABS(RES_BC_FLAG).EQ.3).OR.
+     &       (ABS(RES_BC_FLAG).EQ.4)) THEN
+            IF (BCFLAG_TEMP.NE.0) THEN
+               READ(15,*) TTBCTIMEINC, TTBCSTATIM
+               WRITE(16,434) TTBCTIMEINC
+ 434           FORMAT(/,5X,'Read in the top temperature
+     &               boundary condition every', E9.2 ,'
+     &               seconds.')
+            END IF
+         END IF
+
       END IF
 
 C    kmd48.33bc - added distance information for the sponge layer.

--- a/src/timestep.F
+++ b/src/timestep.F
@@ -592,10 +592,14 @@ C     2DDI.Set up the 2D friction coefficient
       endif
 C..RJW Set up the 3D friction coefficient
       if (C3D) then
+CSeun 260619: Pass KP into Apply3DBottomFriction to avoid adding a
+C             direct GLOBAL_3DVS dependency inside nodalattr.F.
+C         CALL Apply3DBottomFriction(Q, SIGMA, DP, ETA2, G, IFNLFA, NP,
+C     &                              TK, NFEN, Z0B)
          CALL Apply3DBottomFriction(Q, SIGMA, DP, ETA2, G, IFNLFA, NP,
-     &                              TK, NFEN, Z0B)
+     &                              TK, NFEN, Z0B, KP)
       endif
-      
+
 C-------------------BOTTOM FRICTION-------------------------------------
 C
 C

--- a/src/vsmy.F
+++ b/src/vsmy.F
@@ -1479,8 +1479,10 @@ C              boundary conditions
       END IF
 
 !kmd - adding information for rivers - baroclinic
-
-      IF ((CBaroclinic).AND.(BndBCRiver)) THEN
+!Seun 251227: Read fort.39 only for IDEN=2/3/4 (prognostic river T/S BCs)
+C     IF ((CBaroclinic).AND.(BndBCRiver)) THEN
+      IF ((CBaroclinic).AND.(BndBCRiver) .AND.
+     &    (IDEN.EQ.2 .OR. IDEN.EQ.3 .OR. IDEN.EQ.4)) THEN
          IF (TIMELOC.GT.RIVBCTIME2) THEN
             RIVBCTIME1=RIVBCTIME2
             RIVBCTIME2=RIVBCTIME1+RIVBCTIMINC
@@ -4053,6 +4055,19 @@ Cjgfdebug      USE GLOBAL, ONLY : NP,RHOWAT0, ScreenUnit
      &                          + w(IIP1) * TEMP(NH,IIP(IIP1))
                 ENDIF
               ENDDO
+
+!Seun 260518:  Limit interpolated salinity and temperature to the valid
+!              range of the equation of state.
+              IF(ABS(IDEN).EQ.2.OR.ABS(IDEN).EQ.4)THEN
+                 IF(SALM(NH,GQI).LT.S_min) SALM(NH,GQI)=S_min
+                 IF(SALM(NH,GQI).GT.S_max) SALM(NH,GQI)=S_max
+              ENDIF
+
+              IF(ABS(IDEN).EQ.3.OR.ABS(IDEN).EQ.4)THEN
+                 IF(TEMPM(NH,GQI).LT.T_min) TEMPM(NH,GQI)=T_min
+                 IF(TEMPM(NH,GQI).GT.T_max) TEMPM(NH,GQI)=T_max
+              ENDIF
+
             ENDDO
           ENDDO
         ENDDO

--- a/src/vsmy.F
+++ b/src/vsmy.F
@@ -3074,16 +3074,21 @@ C              viscosity
       do n = 1,nfen
          EVTOT(n) = Sm(n)*sqrt(q2(n))*l(nh,n)
          NTVTOT(n) = Sh(n)*sqrt(q2(n))*l(nh,n)
+
 !Casey 220207 from Rosemary : But this could be moved outside the loops
-          NTVMIN = EVMIN
-!Casey 220302 : Let's comment this for now.
-!        if(H.LE.15.d0) THEN
-!          NTVMIN = 0.0
-!        else if ((H.GE.15.d0) .and. (H.LE.30.d0)) THEN
-!          NTVMIN = 0.0 + (0.001/15.d0)*(H-15.d0)
-!        else if (H.GE.30.d0) THEN
-!          NTVMIN = 0.001
-!        endif
+!         NTVMIN = EVMIN
+
+
+!Seun 260608: Restore the depth-dependent minimum vertical scalar
+!             diffusivity from the previous 3D temperature workflow.
+         if(H.LE.15.d0) THEN
+           NTVMIN = 0.0d0
+         else if ((H.GE.15.d0) .and. (H.LE.30.d0)) THEN
+           NTVMIN = 0.0d0 + (0.001d0/15.d0)*(H-15.d0)
+         else if (H.GE.30.d0) THEN
+           NTVMIN = 0.001d0
+         endif
+
          if(EVTOT(n).lt.EVMIN) EVTOT(n)=EVMIN
          if(EVTOT(n).gt.100.0d0) EVTOT(n)=100.0d0
 !Casey 220207 from Rosemary

--- a/src/write_output.F
+++ b/src/write_output.F
@@ -2970,7 +2970,8 @@ C
 C
 1099  FORMAT(2X,1pE20.10E3,5X,I10)
 1100  FORMAT(1X,E17.10,1X,I10,32000(2X,E13.6))
-1104  FORMAT(9X,I6,4X,32000(E13.6,2X))
+Casey 140701: Allow for meshes with more than 1M vertices.
+1104  FORMAT(9X,I12,4X,32000(E13.6,2X))
 1105  FORMAT(2X,I8,2X,1pE20.10E3)
 C
       IF (FirstCall.eqv..true.) THEN
@@ -3874,17 +3875,22 @@ C        Check to see if it is time to generate 3D fulldomain density output.
                      IF(BCFLAG_TEMP.NE.0) THEN
                         IF (myProc.eq.0) THEN
                            ALLOCATE(qsurfkp1_g(NP_G))
+Casey 140701: Added the following line?
+                           QSurfkp1Descript % array_g => qsurfkp1_g
                         ENDIF
                         CALL collectFullDomainArray(QSurfKp1Descript,
      &                     packOne, unpackOne)
-                        OPEN(47,FILE=TRIM(GLOBALDIR)//'/'//'fort.47',
-     &                     ACCESS='SEQUENTIAL',POSITION='APPEND')
-                        WRITE(47,1099) TimeLoc,IT
-                        DO NH=1,NP_G
-                           WRITE(47,1105) NH, qsurfkp1_g(NH)
-                        END DO
-                        DEALLOCATE(qsurfkp1_g)
-                        CLOSE(47)
+Casey 140701: Added the check for MYPROC.eq.0.
+                        IF (myProc.eq.0) THEN
+                           OPEN(47,FILE=TRIM(GLOBALDIR)//'/'//'fort.47',
+     &                         ACCESS='SEQUENTIAL',POSITION='APPEND')
+                           WRITE(47,1099) TimeLoc,IT
+                           DO NH=1,NP_G
+                              WRITE(47,1105) NH, qsurfkp1_g(NH)
+                           END DO
+                           DEALLOCATE(qsurfkp1_g)
+                           CLOSE(47)
+                        END IF
                      END IF
                   END IF
                   OPEN(44,FILE=TRIM(GLOBALDIR)//'/'//'fort.44',
@@ -3938,18 +3944,42 @@ C        Check to see if it is time to generate 3D fulldomain density output.
                   I3DGDRec=I3DGDRec+1 ! for the header line
                   CLOSE(44)
                ENDIF
+
 #ifdef ADCNETCDF
             CASE(3,5) ! netcdf
                IF (myProc.eq.0) THEN
                   CALL writeOutArrayNetCDF(44, TimeLoc,
      &               SigTDescript,SalDescript,TempDescript)
-                  IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
-                     IF(BCFLAG_TEMP.NE.0) THEN
-                       call writeOutArrayNetCDF(47, TimeLoc,
-     &                    QSurfKp1Descript)
-                     ENDIF
-                  ENDIF   
                ENDIF
+
+               IF((IDEN.EQ.3).OR.(IDEN.EQ.4)) THEN
+                  IF(BCFLAG_TEMP.NE.0) THEN
+
+! Seun 030426: In parallel netcdf, gather qsurfkp1 to rank 0 so
+!              QSurfKp1Descript%array_g is valid for writeNodalData.
+                     IF ((MNPROC.GT.1).AND.(WRITE_LOCAL_FILES.eqv..false.)) THEN
+                        IF (myProc.eq.0) THEN
+                           ALLOCATE(qsurfkp1_g(NP_G))
+                           QSurfKp1Descript % array_g => qsurfkp1_g
+                        ENDIF
+                        CALL collectFullDomainArray(QSurfKp1Descript,
+     &                     packOne, unpackOne)
+                     ENDIF
+
+                     IF (myProc.eq.0) THEN
+                        call writeOutArrayNetCDF(47, TimeLoc,
+     &                     QSurfKp1Descript)
+                     ENDIF
+
+                     IF ((MNPROC.GT.1).AND.(WRITE_LOCAL_FILES.eqv..false.)) THEN
+                        IF (myProc.eq.0) THEN
+                           DEALLOCATE(qsurfkp1_g)
+                        ENDIF
+                     ENDIF
+
+                  ENDIF
+               ENDIF
+
 #endif
             CASE DEFAULT
                CALL allMessage(ERROR,


### PR DESCRIPTION
# Description

This PR includes fixes for 3D baroclinic ADCIRC workflows, especially for temperature/salinity simulations, hotstart handling, and 3D NetCDF input/output consistency.

The main updates are to 3D baroclinic startup and boundary condition handling, 3D hotstart logic, 3D NetCDF input/output handling, 3D related input/output controls, bottom friction coefficient protection, and depth dependent minimum scalar diffusivity for 3D temperature/scalar transport.

Two changes intentionally affect 3D model behavior. The first is the 3D bottom-friction `TK` clamp in `nodalattr.F`, which bounds the bottom friction related coefficient relative to the bottom layer velocity magnitude. The second is the restored depth dependent minimum scalar diffusivity in `vsmy.F`, which restores the intended 3D scalar/temperature workflow behavior. These changes were isolated during testing and are expected parts of the corrected 3D workflow.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Update to existing feature to add new functionality
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

The branch was compiled and tested on NC State’s Hazel cluster using Intel oneAPI / Intel MPI with NetCDF/HDF5.

The current branch HEAD tested was `043ddd18` (`Restore depth-dependent scalar diffusivity for 3D temperature`). The upstream baseline used for comparison was `6037225c` (`Fix ice time index bug in wind.F for NWS14 forcing`).

Testing included the official 3D test case and a filtered non-3D/ADCIRC+SWAN test suite comparison. The official 3D test showed output differences relative to the existing control, but these differences were isolated to the intended 3D behavior changes in `nodalattr.F` and `vsmy.F`.

For non-3D testing, the official 3D test was removed and NWS14-family tests were excluded because both the upstream baseline and current branch builds rejected `NWS=±14` on Hazel. The remaining filtered suite included 52 non-3D/non-NWS14 tests. Of these, 45 passed and 7 failed by output comparison.

The same 7 failed tests were rerun with the upstream baseline executable. The baseline failed the same 7 tests, and the extracted maximum difference values matched the current branch exactly. Therefore, the remaining non-3D/ADCIRC+SWAN failures are pre-existing baseline/control mismatches and are not regressions introduced by this branch.

# Relevant Publications (if applicable)

N/A

# Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing tests pass locally with my changes
* [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments

N/A
