### PR TITLE
Un-Rotate velocity vectors for output

### DIFF
--- a/src/global.F
+++ b/src/global.F
@@ -255,6 +255,12 @@ c.
       !jgf50.44: Added variable to record the time that the min or max
       ! has occurred
       REAL(8),ALLOCATABLE, TARGET ::  ETA1(:), ETA2(:), UU2(:), VV2(:), H1(:), H2(:) ! DMW202401 Added variables for tracking flow depths
+!     Rotated-frame support: velocities re-expressed in geographic
+!     east/north for analysis-facing output when the momentum equations
+!     are solved in a rotated spherical frame; allocated in initOutput2D
+!     only when IFSPROTS = 1 and filled by
+!     updateGeographicOutputVelocity() in write_output.F
+      REAL(8),ALLOCATABLE, TARGET ::  UU2_GEO(:), VV2_GEO(:)
       REAL(8),ALLOCATABLE, TARGET ::  ETAMAX(:) ! v46.50 sb 11/11/2006
       REAL(8),ALLOCATABLE, TARGET ::  UMAX(:) ! v46.50 sb 11/11/2006
       REAL(8),ALLOCATABLE, TARGET ::  ET00(:), UU00(:), VV00(:)

--- a/src/write_output.F
+++ b/src/write_output.F
@@ -350,11 +350,12 @@ C----------------------------------------------------------------------
       USE SIZES, ONLY : INPUTDIR, NBYTE, MNWPROC, MYPROC, MNPROC,
      &                  GLOBALDIR, OFF, ASCII, NETCDF3, NETCDF4, XDMF,
      &                  numFormats, write_local_files, localdir,
-     &                  controlFileName
+     &                  controlFileName, MNP
       use mod_logging, only: allMessage, INFO, logMessage
       USE GLOBAL, ONLY : imap_stae_lg, imap_stav_lg, et00, eta2,
      &   nscoue, nne, staie1, staie2, staie3, xel, yel,
      &   slel, sfel, uu00, vv00, uu2, vv2, nscouv, nnv,
+     &   uu2_geo, vv2_geo, ifsprots,
      &   staiv1, staiv2, staiv3, xev, yev, slev, sfev, nscouge,
      &   nodes_lg, labels_g, eta2_g, nscougt, nscougs,
      &   sponge, nscougv, uu2_g, vv2_g, imap_stam_lg, rmp00,
@@ -553,8 +554,23 @@ C
       VelStaDescript % array2               => VV00
       VelStaDescript % array_g              => UU00_g
       VelStaDescript % array2_g             => VV00_g
-      VelStaDescript % interped_array       => UU2
-      VelStaDescript % interped_array2      => VV2
+C     Rotated-frame: velocities are computed in the rotated spherical
+C     frame; analysis-facing output is written in geographic east/north
+C     (filled by updateGeographicOutputVelocity in writeOutput2D)
+      IF ( IFSPROTS.EQ.1 ) THEN
+C        ...The re-expressed arrays exist only when the rotated frame is
+C        in use; allocate them before the first pointer association
+         IF ( .NOT.ALLOCATED(UU2_GEO) ) THEN
+            ALLOCATE ( UU2_GEO(MNP),VV2_GEO(MNP) )
+            UU2_GEO(:) = -99999.d0
+            VV2_GEO(:) = -99999.d0
+         ENDIF
+         VelStaDescript % interped_array       => UU2_GEO
+         VelStaDescript % interped_array2      => VV2_GEO
+      ELSE
+         VelStaDescript % interped_array       => UU2
+         VelStaDescript % interped_array2      => VV2
+      ENDIF
       VelStaDescript % ConsiderWetDry       = .TRUE.
       VelStaDescript % field_name           = 'VelSta'
       VelStaDescript % isStation            = .true.
@@ -714,8 +730,14 @@ C
       VelDescript % outputTimeStepIncrement = NSPOOLGV
       VelDescript % spoolCounter            => NSCOUGV
       VelDescript % num_items_per_record = 2
-      VelDescript % array                => UU2
-      VelDescript % array2               => VV2
+C     Rotated-frame: see note on VelStaDescript above
+      IF ( IFSPROTS.EQ.1 ) THEN
+         VelDescript % array                => UU2_GEO
+         VelDescript % array2               => VV2_GEO
+      ELSE
+         VelDescript % array                => UU2
+         VelDescript % array2               => VV2
+      ENDIF
       VelDescript % array_g              => UU2_g
       VelDescript % array2_g             => VV2_g
       VelDescript % field_name           = 'Vel'
@@ -1770,6 +1792,30 @@ C     R.L. 8/22/05 Subroutine to write primary 2D model output not
 C     including hotstart and harmonic analysis.
 C
 C----------------------------------------------------------------------
+C-----------------------------------------------------------------------
+C     S U B R O U T I N E
+C     U P D A T E  G E O G R A P H I C  O U T P U T  V E L O C I T Y
+C-----------------------------------------------------------------------
+C     When the momentum equations are solved in a rotated spherical
+C     frame (IFSPROTS = 1), the state velocities UU2/VV2 hold components
+C     along the rotated coordinate axes. Analysis-facing output
+C     (fort.62/fort.64 and their max files) is written in geographic
+C     east/north for consistency with the meteorological output and the
+C     harmonic analysis (see updateHarmonicAnalysis), so the components
+C     are re-expressed here before each output pass. Hotstart output is
+C     intentionally left in the rotated frame: it is internal state that
+C     must round-trip through a restart unchanged.
+C-----------------------------------------------------------------------
+      SUBROUTINE updateGeographicOutputVelocity()
+      USE GLOBAL, ONLY : UU2, VV2, UU2_GEO, VV2_GEO, IFSPROTS
+      USE MESH, ONLY : NP, DRVMAP2DSPVEC
+      IMPLICIT NONE
+      IF ( IFSPROTS.NE.1 ) RETURN
+      CALL DRVMAP2DSPVEC( UU2_GEO, VV2_GEO, UU2, VV2, NP,
+     &                    FWD = .FALSE. )
+      END SUBROUTINE updateGeographicOutputVelocity
+C-----------------------------------------------------------------------
+
       SUBROUTINE writeOutput2D(IT,TimeLoc)
       USE SIZES, ONLY : INPUTDIR, NBYTE, MNWPROC, MYPROC, MNPROC,
      &                  GLOBALDIR, OFF
@@ -1790,8 +1836,11 @@ C----------------------------------------------------------------------
       INTEGER, intent(in) :: IT
       REAL(8), intent(in) :: TimeLoc
       INTEGER :: i,j
+      LOGICAL :: geoVelUpdated ! geographic output velocities refreshed
 
       LOG_SCOPE_TRACED("writeOutput2D", WRITE_OUTPUT_TRACING)
+
+      geoVelUpdated = .false.
 
       do i=1,numOutputDescript2D
          !
@@ -1821,6 +1870,16 @@ C----------------------------------------------------------------------
          if (ptr(i) % descript2D % spoolCounter.ne.
      &       ptr(i) % descript2D % outputTimeStepIncrement) then
             cycle
+         endif
+         !
+         ! Rotated-frame: a velocity output is due this time step, so
+         ! refresh the geographic east/north output velocities (at most
+         ! once per step); a no-op unless IFSPROTS = 1
+         if ( (.not.geoVelUpdated) .and.
+     &        ( (ptr(i) % descript2D % field_name.eq.'Vel') .or.
+     &          (ptr(i) % descript2D % field_name.eq.'VelSta') ) ) then
+            call updateGeographicOutputVelocity()
+            geoVelUpdated = .true.
          endif
          !
          ! if this is station data, compute the solution at the station


### PR DESCRIPTION
# Description

Write velocity output in the input frame on rotated-pole meshes

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

#510

# How Has This Been Tested

Running with rotated mesh now shows corrected velocity vectors 

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

<!--- Please explain why any of the above are not checked -->

# Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->