### PR TITLE
Fix for segmentation fault while initializing CondensedNodesDefVal

### DIFF
--- a/src/nodalattr.F
+++ b/src/nodalattr.F
@@ -429,7 +429,9 @@ Csb
       LoadCondensedNodes     = .False.
       FoundCondensedNodes    = .FALSE.
       CondensedNodesNoOfVals = 3
-      CondensedNodesDefVal   = 0
+      IF ( ALLOCATED(CondensedNodesDefVal) ) DEALLOCATE(CondensedNodesDefVal)
+      ALLOCATE(CondensedNodesDefVal(CondensedNodesNoOfVals))
+      CondensedNodesDefVal(:) = 0.D0
 C
       LoadTau0           = .False.
       LoadStartDry       = .False.
@@ -986,9 +988,8 @@ Casey 100210: Allow SWAN to handle wave refraction as a nodal attribute.
       ALLOCATE(SwanWaveRefrac(NumOfNodes))
 Corbitt 120321: Allow advection to be turned on locally instead of globally
       ALLOCATE(AdvectionState(NumOfNodes))
-      IF ( .not.ALLOCATED(CondensedNodesDefVal) ) THEN
-         ALLOCATE(CondensedNodesDefVal(CondensedNodesNoOfVals))
-      ENDIF
+      IF ( ALLOCATED(CondensedNodesDefVal) ) DEALLOCATE(CondensedNodesDefVal)
+      ALLOCATE(CondensedNodesDefVal(CondensedNodesNoOfVals))
       ALLOCATE(CondensedNodes(NumOfNodes,CondensedNodesNoOfVals))
       ALLOCATE(River_et_WSE(NumOfNodes))  ! tcm 20140502 v51.27
       ALLOCATE(OverlandReductionFactor(NumOfNodes))


### PR DESCRIPTION
Fixes a bug introduced in daae7d9, which changed CondensedNodesDefVal from a fixed length array to an allocatable array. Memory allocation is added before an initial value assignment. Also, memory allocation logic is updated for a better safeguard when reading actual number of values from a fort.13 file. This resolves a segmentation fault that occurs with specific compilers (e.g., gfortran).

# Description

Remove `CondensedNodesDefVal   = 0` in nodalattr.F.

## Type of change

<!--- Select the type of change, use [x] to select and [ ] to mark unselected -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix with breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing feature to add new functionality
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Issue Number

N/A

# How Has This Been Tested?

Ran the codes before and after this fix in models with both without and with VEWs and confirmed expected behavior.

# Relevant Publications (if applicable)

N/A

# Checklist:

<!--- Please fill out the checklist. Use [x] to mark selected and [ ] to mark unselected -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] My code is up-to-date and tested with changes from the latest version of `main`

## If any of the above are not checked, please explain why:

N/A

# Further comments

N/A